### PR TITLE
--with-yara= and --with-libnids= not finding installed dependencies

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -81,6 +81,14 @@ AC_ARG_WITH(libnids,
       fi
       NIDS_CFLAGS="-I$withval/src"
       NIDS_LIBS="$withval/src/libnids.a"
+    elif test -f $withval/include/nids.h -a -f $withval/lib/libnids.a; then
+      owd=`pwd`
+      if cd $withval; then
+        withval=`pwd`;
+        cd $owd;
+      fi
+      NIDS_CFLAGS="-I$withval/include"
+      NIDS_LIBS="$withval/lib/libnids.a"
     else
       AC_ERROR(nids.h or libnids.a not found in $withval)
     fi
@@ -125,6 +133,14 @@ AC_ARG_WITH(yara,
       fi
       YARA_CFLAGS="-I$withval/libyara"
       YARA_LIBS="$withval/libyara/.libs/libyara.a"
+    elif test -f $withval/include/yara.h -a -f $withval/lib/libyara.a; then
+      owd=`pwd`
+      if cd $withval; then
+        withval=`pwd`;
+        cd $owd;
+      fi
+      YARA_CFLAGS="-I$withval/include"
+      YARA_LIBS="$withval/lib/libyara.a"
     else
       AC_ERROR(yara.h or yara.a not found in $withval)
     fi


### PR DESCRIPTION
If libnids or yara are installed already, "make install" for those tools has put the header and libraries in $prefix/include and $prefix/lib respectively.  Find the required pieces there if specified with --with-XXX=$prefix

We have libNIDS and yara installed to be shared with other tools, but moloch's configure wasn't finding them properly.

Note: I basically copy&pasted the detection code, changing the paths.  If there's a better/more standard autotools way to look in the --with-feature=/path/ option, we should use it instead, but I couldn't find one.
