### PR TITLE
Pfring autodetection

### DIFF
--- a/configure
+++ b/configure
@@ -1299,7 +1299,7 @@ Optional Features:
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
-  --with-pfring=DIR use pfring build directory
+  --with-pfring=DIR use libpfring directory
   --with-libpcap=DIR use libpcap build directory
   --with-libnids=DIR use libnids build directory
   --with-yara=DIR use yara build directory
@@ -3792,49 +3792,26 @@ fi
 
 
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for pfring" >&5
-$as_echo_n "checking for pfring... " >&6; }
-
 # Check whether --with-pfring was given.
 if test "${with_pfring+set}" = set; then :
   withval=$with_pfring;  case "$withval" in
   yes|no)
-     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-     ;;
-  *)
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $withval" >&5
-$as_echo "$withval" >&6; }
-    if test -f $withval/userland/libpcap/pcap.h -a -f $withval/userland/libpcap/libpcap.a; then
-      owd=`pwd`
-      if cd $withval; then
-        withval=`pwd`;
-        cd $owd;
-      fi
-
-      PCAP_CFLAGS="-I$withval"
-      PCAP_LIBS="$withval/userland/libpcap/libpcap.a $withval/userland/lib/libpfring.a"
-    elif test -f $withval/userland/libpcap/include/pcap.h -a -f $withval/userland/libpcap/lib/libpcap.a; then
-      owd=`pwd`
-      if cd $withval; then
-        withval=`pwd`;
-        cd $owd;
-      fi
-
-      PCAP_CFLAGS="-I$withval/userland/libpcap/include"
-      PCAP_LIBS="$withval/userland/libpcap/lib/libpcap.a $withval/userland/lib/libpfring.a"
-    else
-      as_fn_error $? "pcap.h or libpcap.a not found in $withval" "$LINENO" 5
-    fi
+    BLAHBLAH=1
     ;;
+  *)
+    if test -f $withval/libpfring.a; then
+      PCAP_LIBS="$withval/libpfring.a"
+    elif test -f $withval/lib/libpfring.a; then
+      PCAP_LIBS="$withval/lib/libpfring.a"
+    elif test -f $withval/userland/lib/libpfring.a; then
+      PCAP_LIBS="$withval/userland/lib/libpfring.a"
+    else
+      as_fn_error $? "libpfring.a not found" "$LINENO" 5
+    fi
+  ;;
 esac
-else
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
 fi
-
-
 
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for libpcap" >&5
@@ -3848,8 +3825,6 @@ if test "${with_libpcap+set}" = set; then :
 $as_echo "no" >&6; }
      ;;
   *)
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $withval" >&5
-$as_echo "$withval" >&6; }
     if test -f $withval/pcap.h -a -f $withval/libpcap.a; then
       owd=`pwd`
       if cd $withval; then
@@ -3858,7 +3833,10 @@ $as_echo "$withval" >&6; }
       fi
 
       PCAP_CFLAGS="-I$withval"
-      PCAP_LIBS="$withval/libpcap.a"
+      PCAP_LIBS="$withval/libpcap.a $PCAP_LIBS"
+      PCAP_DIR="$withval"
+      { $as_echo "$as_me:${as_lineno-$LINENO}: result: $withval" >&5
+$as_echo "$withval" >&6; }
     elif test -f $withval/include/pcap.h -a -f $withval/lib/libpcap.a; then
       owd=`pwd`
       if cd $withval; then
@@ -3867,10 +3845,73 @@ $as_echo "$withval" >&6; }
       fi
 
       PCAP_CFLAGS="-I$withval/include"
-      PCAP_LIBS="$withval/lib/libpcap.a"
+      PCAP_LIBS="$withval/lib/libpcap.a $PCAP_LIBS"
+      PCAP_DIR="$withval/lib"
+      { $as_echo "$as_me:${as_lineno-$LINENO}: result: $withval/lib" >&5
+$as_echo "$withval/lib" >&6; }
     else
       as_fn_error $? "pcap.h or libpcap.a not found in $withval" "$LINENO" 5
     fi
+
+        { $as_echo "$as_me:${as_lineno-$LINENO}: checking for libpcap dependancy" >&5
+$as_echo_n "checking for libpcap dependancy... " >&6; }
+    LIBS=$PCAP_LIBS
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char pcap_open_offline ();
+int
+main ()
+{
+return pcap_open_offline ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
+$as_echo "ok" >&6; }
+else
+  LIBS="$LIBS $PCAP_DIR/libpfring.a"
+        cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char pcap_open_offline ();
+int
+main ()
+{
+return pcap_open_offline ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  PCAP_LIBS=$LIBS
+           { $as_echo "$as_me:${as_lineno-$LINENO}: result: pfring required" >&5
+$as_echo "pfring required" >&6; }
+else
+  as_fn_error $? "no working libpcap found" "$LINENO" 5
+
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+
+
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
     ;;
 esac
 else

--- a/configure.ac
+++ b/configure.ac
@@ -17,43 +17,26 @@ AC_CHECK_LIB(pcre, main,,AC_MSG_ERROR(please install PCRE library))
 AC_CHECK_LIB(uuid, main,,AC_MSG_ERROR(please install uuid library))
 AC_CHECK_LIB(magic, main,,AC_MSG_ERROR(please install magic library))
 
-
-dnl Checks for pfring
-AC_MSG_CHECKING(for pfring)
 AC_ARG_WITH(pfring,
-[  --with-pfring=DIR use pfring build directory],
+[  --with-pfring=DIR use libpfring directory],
 [ case "$withval" in
   yes|no)
-     AC_MSG_RESULT(no)
-     ;;
+    BLAHBLAH=1
+    ;; dnl We'll find pfring when we look for libpcap
+
   *)
-  AC_MSG_RESULT($withval)
-    if test -f $withval/userland/libpcap/pcap.h -a -f $withval/userland/libpcap/libpcap.a; then
-      owd=`pwd`
-      if cd $withval; then
-        withval=`pwd`;
-        cd $owd;
-      fi
-
-      PCAP_CFLAGS="-I$withval"
-      PCAP_LIBS="$withval/userland/libpcap/libpcap.a $withval/userland/lib/libpfring.a"
-    elif test -f $withval/userland/libpcap/include/pcap.h -a -f $withval/userland/libpcap/lib/libpcap.a; then
-      owd=`pwd`
-      if cd $withval; then
-        withval=`pwd`;
-        cd $owd;
-      fi
-
-      PCAP_CFLAGS="-I$withval/userland/libpcap/include"
-      PCAP_LIBS="$withval/userland/libpcap/lib/libpcap.a $withval/userland/lib/libpfring.a"
+    if test -f $withval/libpfring.a; then
+      PCAP_LIBS="$withval/libpfring.a"
+    elif test -f $withval/lib/libpfring.a; then
+      PCAP_LIBS="$withval/lib/libpfring.a"
+    elif test -f $withval/userland/lib/libpfring.a; then
+      PCAP_LIBS="$withval/userland/lib/libpfring.a"
     else
-      AC_ERROR(pcap.h or libpcap.a not found in $withval)
+      AC_ERROR(libpfring.a not found)
     fi
-    ;;
-esac ], [
-AC_MSG_RESULT(no) ])
-AC_SUBST(PCAP_CFLAGS)
-AC_SUBST(PCAP_LIBS)
+  ;;
+esac ]
+)
 
 dnl Checks for libpcap
 AC_MSG_CHECKING(for libpcap)
@@ -64,7 +47,6 @@ AC_ARG_WITH(libpcap,
      AC_MSG_RESULT(no)
      ;;
   *)
-  AC_MSG_RESULT($withval)
     if test -f $withval/pcap.h -a -f $withval/libpcap.a; then
       owd=`pwd`
       if cd $withval; then
@@ -73,7 +55,9 @@ AC_ARG_WITH(libpcap,
       fi
 
       PCAP_CFLAGS="-I$withval"
-      PCAP_LIBS="$withval/libpcap.a"
+      PCAP_LIBS="$withval/libpcap.a $PCAP_LIBS"
+      PCAP_DIR="$withval"
+      AC_MSG_RESULT($withval)
     elif test -f $withval/include/pcap.h -a -f $withval/lib/libpcap.a; then
       owd=`pwd`
       if cd $withval; then
@@ -82,10 +66,26 @@ AC_ARG_WITH(libpcap,
       fi
 
       PCAP_CFLAGS="-I$withval/include"
-      PCAP_LIBS="$withval/lib/libpcap.a"
+      PCAP_LIBS="$withval/lib/libpcap.a $PCAP_LIBS"
+      PCAP_DIR="$withval/lib"
+      AC_MSG_RESULT($withval/lib)
     else
       AC_ERROR(pcap.h or libpcap.a not found in $withval)
     fi
+
+    dnl Check that it works and add libpfring if needed
+    AC_MSG_CHECKING(for libpcap dependancy)
+    LIBS=$PCAP_LIBS
+    AC_TRY_LINK_FUNC(pcap_open_offline,
+       AC_MSG_RESULT(ok),
+       [LIBS="$LIBS $PCAP_DIR/libpfring.a"
+        AC_TRY_LINK_FUNC(pcap_open_offline,
+          [PCAP_LIBS=$LIBS
+           AC_MSG_RESULT(pfring required)],
+          AC_ERROR(no working libpcap found)
+        )
+       ]
+    )
     ;;
 esac ], [
   if test "x$PCAP_LIBS" != "x"; then


### PR DESCRIPTION
A much-simplified pcap+pfring detection patch.

Basically, in the "old days" (v0.9.0) if your libpcap.a isn't complete-- i.e. it requires libpfring.a to function, you either had to add the path to libpfring.a to capture/Makefile manually, or otherwise hack around it.

Andy introduced the --with-pfring option to configure, and this patch cleans it up a bit, and more or less makes the --with-pfring= option unneeded except in very strange circumstances(1)

configure will try to link a sample executable (calling `pcap_open_offline`) against the libpcap.a found by the --with-libpcap=/path/ option, and if it does not result in a successful link, try again with adding $withval/libpfring.a.

So if linking with any of these combinations of libraries works, moloch-capture will be built using that combination:

```
$with_libpcap/{,lib/}libpcap.a
$with_libpcap/{,lib/}libpcap.a + $with_libpcap/{,lib/}libpfring.a
$with_libpcap/{,lib/}libpcap.a + $with_pfring/{,lib/,userland/lib}/libpfring.a
```

Note that if --with-libpcap= is not given, the default search for libpcap will often result in a dynamically linked -lpcap.  And in that case, the runtime linker should find and load the libpfring.so dependencies.

--Joe
(1) Strange circumstances = where the pfring userland libraries have been separated and libpfring.a is not in the same directory as the pfring-aware libpcap.a
