### PR TITLE
Add caTrustFile config option

### DIFF
--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -2880,26 +2880,28 @@ function addAuth(info, user, node, secret) {
                                                     }, secret);
 }
 
-var caTrustCerts = [];
-function addCaTrust(info) {
-	if (!Config.isHTTPS()) {
-		return
+var caTrustCerts = {};
+function addCaTrust(info, node) {
+	if (!Config.isHTTPS(node)) {
+		return;
 	}
 	
-	if (caTrustCerts.length > 0) {
-		info.ca = caTrustCerts
-		return
+	if ((caTrustCerts[node] !== undefined) && (caTrustCerts[node].length > 0)) {
+		info.ca = caTrustCerts[node];
+		return;
 	} 
 	
-	var caTrustFile = Config.get("caTrustFile")
+	var caTrustFile = Config.getFull(node, "caTrustFile");
 	
 	if (caTrustFile && caTrustFile.length > 0) {
 		var caTrustFileLines = fs.readFileSync(caTrustFile, 'utf8');
 		caTrustFileLines = caTrustFileLines.split("\n");
 		
 		var foundCert = [],
-			line;
+			  line;
 		
+    caTrustCerts[node] = [];
+
 		for (var i = 0; i < caTrustFileLines.length; i++) {
 			line = caTrustFileLines[i];
 			if (line.length === 0) {
@@ -2907,13 +2909,14 @@ function addCaTrust(info) {
 			}
 			foundCert.push(line);
 			if (line.match(/-END CERTIFICATE-/)) {
-				caTrustCerts.push(foundCert.join("\n"));
+				caTrustCerts[node].push(foundCert.join("\n"));
 				foundCert = [];
 			}
 		}
 		
-		if (caTrustCerts.length > 0) {
-			info.ca = caTrustCerts
+		if (caTrustCerts[node].length > 0) {
+			info.ca = caTrustCerts[node];
+      return;
 		}
 	}
 }
@@ -2931,7 +2934,8 @@ function proxyRequest (req, res) {
     info.agent = (agent === httpAgent?foreverAgent:foreverAgentSSL);
     info.rejectUnauthorized = true;
     addAuth(info, req.user, req.params.nodeName);
-	addCaTrust(info);
+	  addCaTrust(info, req.params.nodeName);
+
     var preq = agent.request(info, function(pres) {
       pres.on('data', function (chunk) {
         res.write(chunk);
@@ -3271,7 +3275,8 @@ function sessionsPcapList(req, res, list, pcapWriter, extension) {
         info.agent = (agent === httpAgent?foreverAgent:foreverAgentSSL);
 
         addAuth(info, req.user, item.fields.no);
-		addCaTrust(info);
+		    addCaTrust(info, item.fields.no);
+
         var preq = agent.request(info, function(pres) {
           pres.on('data', function (chunk) {
             if (bufpos + chunk.length > buffer.length) {
@@ -3885,7 +3890,8 @@ function scrubList(req, res, entire, list) {
         info.path = Config.basePath(item.fields.no) + item.fields.no + (entire?"/delete/":"/scrub/") + item._id;
         info.agent = (agent === httpAgent?foreverAgent:foreverAgentSSL);
         addAuth(info, req.user, item.fields.no);
-		addCaTrust(info);
+		    addCaTrust(info, item.fields.no);
+
         var preq = agent.request(info, function(pres) {
           pres.on('end', function () {
             async.setImmediate(nextCb);
@@ -3989,7 +3995,7 @@ function sendSession(req, res, id, nextCb) {
 
     var info = url.parse(sobj.url + "/receiveSession?saveId=" + req.query.saveId);
     addAuth(info, req.user, req.params.nodeName, sobj.passwordSecret);
-	addCaTrust(info);
+	  addCaTrust(info, req.params.nodeName);
     info.method = "POST";
 
     var result = "";
@@ -4059,7 +4065,8 @@ function sendSessionsList(req, res, list) {
           info.path += "&tags=" + req.query.tags;
         }
         addAuth(info, req.user, item.fields.no);
-		addCaTrust(info);
+		    addCaTrust(info, item.fields.no);
+
         var preq = agent.request(info, function(pres) {
           pres.on('data', function (chunk) {
           });


### PR DESCRIPTION
Add caTrustFile config option that specifies a file containing certificate authority certificates in PEM format that the Moloch viewer should trust when connecting to other hosts via HTTPS.
