### PR TITLE
Fix segment parameter in pcap export query string

### DIFF
--- a/viewer/public/common.js
+++ b/viewer/public/common.js
@@ -347,7 +347,7 @@ $(document).ready(function() {
     }
 
     if ($("#actions-linked").val() !== "false") {
-      qs.push({name: "segments", value: $("#addTags-linked").val()});
+      qs.push({name: "segments", value: $("#actions-linked").val()});
     }
 
     // Prevent normal form submission


### PR DESCRIPTION
Updated the segment parameter in the export pcap query string to assign the value of #actions-linked instead of #addTags-linked.  ( fixes #243 )
