### PR TITLE
Do not expand seqence index to all nodes

### DIFF
--- a/db/db.pl
+++ b/db/db.pl
@@ -237,7 +237,7 @@ sub sequenceCreate
   settings: {
     number_of_shards: 1,
     number_of_replicas: 0,
-    auto_expand_replicas: "0-all"
+    auto_expand_replicas: "0-5"
   }
 }';
 


### PR DESCRIPTION
5 should be more than enough.
"All" makes removing nodes on the fly more difficult. Or some additional guidelines are required in the FAQ, as the current process breaks the "sequence" index :).