### PR TITLE
Make sessions table columns configurable

### DIFF
--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -1725,7 +1725,7 @@ app.get('/sessions.json', function(req, res) {
       res.send(r);
       return;
     }
-    query._source = ["pr", "ro", "db", "fp", "lp", "a1", "p1", "a2", "p2", "pa", "by", "no", "us", "g1", "g2", "esub", "esrc", "edst", "efn", "dnsho", "tls", "ircch"];
+    query._source = ["pr", "ro", "db", "db1", "db2", "fp", "lp", "a1", "p1", "a2", "p2", "pa", "pa1", "pa2", "by", "by1", "by2", "no", "us", "g1", "g2", "esub", "esrc", "edst", "efn", "dnsho", "tls", "ircch"];
 
     if (query.aggregations && query.aggregations.dbHisto) {
       graph.interval = query.aggregations.dbHisto.histogram.interval;

--- a/viewer/views/index.jade
+++ b/viewer/views/index.jade
@@ -161,27 +161,27 @@ block content
       };
 
       var pinnedColWidths = {
-        plusminus:30,
-        start:105,
-        stop:105,
-        srcip:160,
-        srcport:40,
-        dstip:160,
-        dstport:40,
-        packets:80,
-        srcpackets:80,
-        dstpackets:80,
-        bytes:150,
-        srcbytes:80,
-        dstbytes:80,
-        srcdatabytes:80,
-        dstdatabytes:80,
-        node:150
+        "plusminus":30,
+        "fp":105,
+        "lp":105,
+        "a1":160,
+        "p1":40,
+        "a2":160,
+        "p2":40,
+        "pa":80,
+        "pa1":80,
+        "pa2":80,
+        "bytes":150,
+        "by1":80,
+        "by2":80,
+        "db1":80,
+        "db2":80,
+        "no":150
       };
 
-      var visibleColumns = ["plusminus", "start", "stop", "srcip", "srcport", "dstip", "dstport", "packets", "bytes", "node", "info"];
+      var visibleColumns = ["plusminus", "fp", "lp", "a1", "p1", "a2", "p2", "pa", "bytes", "no", "info"];
       if(molochSettings.visibleColumns){
-        visibleColumns = ["plusminus", "start", "stop"].concat(molochSettings.visibleColumns);
+        visibleColumns = ["plusminus", "fp", "lp"].concat(molochSettings.visibleColumns);
       }
 
       function visibleColumn(name) {
@@ -253,7 +253,7 @@ block content
             }
           },
           { "mDataProp" : "a1",
-            "bVisible": visibleColumn("srcip"),
+            "bVisible": visibleColumn("a1"),
             "sWidth": "100",
             "bUseRendered": false,
             "fnRender" : function(oObj) {
@@ -265,12 +265,12 @@ block content
             }
           },
           { "mDataProp" : "p1",
-            "bVisible": visibleColumn("srcport"),
+            "bVisible": visibleColumn("p1"),
             "sClass": "context-menu-one",
             "sWidth": "55px"
           },
           { "mDataProp" : "a2",
-            "bVisible": visibleColumn("dstip"),
+            "bVisible": visibleColumn("a2"),
             "sWidth": "100",
             "bUseRendered": false,
             "fnRender" : function(oObj) {
@@ -282,20 +282,20 @@ block content
             }
           },
           { "mDataProp" : "p2",
-            "bVisible": visibleColumn("dstport"),
+            "bVisible": visibleColumn("p2"),
             "sClass": "context-menu-one",
             "sWidth": "55px"
           },
           { "mDataProp" : "pa",
-            "bVisible": visibleColumn("packets"),
+            "bVisible": visibleColumn("pa"),
             "sWidth": "55px"
             },
           { "mDataProp" : "pa1",
-            "bVisible": visibleColumn("srcpackets"),
+            "bVisible": visibleColumn("pa1"),
             "sWidth": "55px"
             },
           { "mDataProp" : "pa2",
-            "bVisible": visibleColumn("dstpackets"),
+            "bVisible": visibleColumn("pa2"),
             "sWidth": "55px"
             },
           { "mDataProp" : "by",
@@ -307,23 +307,23 @@ block content
             }
           },
           { "mDataProp" : "by1",
-            "bVisible": visibleColumn("srcbytes"),
+            "bVisible": visibleColumn("by1"),
             "sWidth": "80px",
           },
           { "mDataProp" : "by2",
-            "bVisible": visibleColumn("dstbytes"),
+            "bVisible": visibleColumn("by2"),
             "sWidth": "80px",
           },
           { "mDataProp" : "db1",
-            "bVisible": visibleColumn("srcdatabytes"),
+            "bVisible": visibleColumn("db1"),
             "sWidth": "80px",
           },
           { "mDataProp" : "db2",
-            "bVisible": visibleColumn("dstdatabytes"),
+            "bVisible": visibleColumn("db2"),
             "sWidth": "80px",
           },
           { "mDataProp" : "no",
-            "bVisible": visibleColumn("node"),
+            "bVisible": visibleColumn("no"),
             "sWidth": "100px",
             bUseRendered: false,
             "fnRender" : function(oObj) {

--- a/viewer/views/index.jade
+++ b/viewer/views/index.jade
@@ -148,6 +148,16 @@ block content
         node: 10
       };
 
+      function visibleColumn(name) {
+        if(molochSettings.visibleColumns){
+          if (Array.isArray(molochSettings.visibleColumns)) {
+            return molochSettings.visibleColumns.indexOf(name)>=0;
+          } else return molochSettings.visibleColumns == name;
+        } else {
+          return ["start", "stop", "srcip", "srcport", "dstip", "dstport", "packets", "bytes", "node", "info"].indexOf(name)>=0;
+        }
+      }
+
       sessionsTable = $('#sessions').dataTable( {
         "oLanguage": {
           "sProcessing": "<img src=\"watching.gif\"><div class='blink'>I'm Hootin' :D</div>",
@@ -213,6 +223,7 @@ block content
             }
           },
           { "mDataProp" : "a1",
+            "bVisible": visibleColumn("srcip"),
             "sWidth": "100",
             "bUseRendered": false,
             "fnRender" : function(oObj) {
@@ -224,10 +235,12 @@ block content
             }
           },
           { "mDataProp" : "p1",
+            "bVisible": visibleColumn("srcport"),
             "sClass": "context-menu-one",
             "sWidth": "55px"
           },
           { "mDataProp" : "a2",
+            "bVisible": visibleColumn("dstip"),
             "sWidth": "100",
             "bUseRendered": false,
             "fnRender" : function(oObj) {
@@ -239,13 +252,16 @@ block content
             }
           },
           { "mDataProp" : "p2",
+            "bVisible": visibleColumn("dstport"),
             "sClass": "context-menu-one",
             "sWidth": "55px"
           },
           { "mDataProp" : "pa",
+            "bVisible": visibleColumn("packets"),
             "sWidth": "55px"
             },
           { "mDataProp" : "by",
+            "bVisible": visibleColumn("bytes"),
             "sWidth": "80px",
             "bUseRendered": false,
             "fnRender" : function(oObj) {
@@ -253,6 +269,7 @@ block content
             }
           },
           { "mDataProp" : "no",
+            "bVisible": visibleColumn("node"),
             "sWidth": "100px",
             bUseRendered: false,
             "fnRender" : function(oObj) {
@@ -261,6 +278,7 @@ block content
           },
           { "bSortable": false,
             "mDataProp" : null,
+            "bVisible": visibleColumn("info"),
             "sDefaultContent": "",
             "sClass": "infoColumn",
             "bUseRendered": false,

--- a/viewer/views/index.jade
+++ b/viewer/views/index.jade
@@ -31,7 +31,13 @@ block content
         th#a2.context-menu-one Dst IP
         th Dst Port
         th Packets
+        th Src Packets
+        th Dst Packets
         th Bytes
+        th Src Bytes
+        th Dst Bytes
+        th Src Databytes
+        th Dst Databytes
         th Node
         th#info.context-menu-one
           div.infoColumn Info
@@ -144,8 +150,14 @@ block content
         dstip: 6,
         dstport: 7,
         packets: 8,
-        bytes: 9,
-        node: 10
+        srcpackets: 9,
+        dstpackets: 10,
+        bytes: 11,
+        srcbytes: 12,
+        dstbytes: 13,
+        srcdatabytes: 14,
+        dstdatabytes: 15,
+        node: 16
       };
 
       function visibleColumn(name) {
@@ -260,6 +272,14 @@ block content
             "bVisible": visibleColumn("packets"),
             "sWidth": "55px"
             },
+          { "mDataProp" : "pa1",
+            "bVisible": visibleColumn("srcpackets"),
+            "sWidth": "55px"
+            },
+          { "mDataProp" : "pa2",
+            "bVisible": visibleColumn("dstpackets"),
+            "sWidth": "55px"
+            },
           { "mDataProp" : "by",
             "bVisible": visibleColumn("bytes"),
             "sWidth": "80px",
@@ -267,6 +287,22 @@ block content
             "fnRender" : function(oObj) {
               return "" + numberWithCommas(oObj.aData.db) + " /<br>" + numberWithCommas(oObj.aData.by);
             }
+          },
+          { "mDataProp" : "by1",
+            "bVisible": visibleColumn("srcbytes"),
+            "sWidth": "80px",
+          },
+          { "mDataProp" : "by2",
+            "bVisible": visibleColumn("dstbytes"),
+            "sWidth": "80px",
+          },
+          { "mDataProp" : "db1",
+            "bVisible": visibleColumn("srcdatabytes"),
+            "sWidth": "80px",
+          },
+          { "mDataProp" : "db2",
+            "bVisible": visibleColumn("dstdatabytes"),
+            "sWidth": "80px",
           },
           { "mDataProp" : "no",
             "bVisible": visibleColumn("node"),

--- a/viewer/views/index.jade
+++ b/viewer/views/index.jade
@@ -160,14 +160,32 @@ block content
         node: 16
       };
 
+      var pinnedColWidths = {
+        plusminus:30,
+        start:105,
+        stop:105,
+        srcip:160,
+        srcport:40,
+        dstip:160,
+        dstport:40,
+        packets:80,
+        srcpackets:80,
+        dstpackets:80,
+        bytes:150,
+        srcbytes:80,
+        dstbytes:80,
+        srcdatabytes:80,
+        dstdatabytes:80,
+        node:150
+      };
+
+      var visibleColumns = ["plusminus", "start", "stop", "srcip", "srcport", "dstip", "dstport", "packets", "bytes", "node", "info"];
+      if(molochSettings.visibleColumns){
+        visibleColumns = ["plusminus", "start", "stop"].concat(molochSettings.visibleColumns);
+      }
+
       function visibleColumn(name) {
-        if(molochSettings.visibleColumns){
-          if (Array.isArray(molochSettings.visibleColumns)) {
-            return molochSettings.visibleColumns.indexOf(name)>=0;
-          } else return molochSettings.visibleColumns == name;
-        } else {
-          return ["start", "stop", "srcip", "srcport", "dstip", "dstport", "packets", "bytes", "node", "info"].indexOf(name)>=0;
-        }
+        return visibleColumns.indexOf(name)>=0;
       }
 
       sessionsTable = $('#sessions').dataTable( {
@@ -582,18 +600,9 @@ block content
               var td = $(nTr).children("td");
               $(td).each(function(i, e) {
                 $(e).html($(e).html().replace("<br>", "&nbsp;"));
+                $(e).width(pinnedColWidths[visibleColumns[i]]);
               });
-              $(td[0]).width(50); // +-
-              $(td[1]).width(105); // Start
-              $(td[2]).width(105); // Stop
-              $(td[3]).width(160); // Src
-              $(td[4]).width(40);  // SPort
-              $(td[5]).width(160); // Dst
-              $(td[6]).width(40);  // DPort
-              $(td[7]).width(80);  // Packets
-              $(td[8]).width(150); // Bytes
-              $(td[9]).width(150); // Node
-              $(td[10]).hide();
+              $($(nTr).find(".infoColumn")).hide();
               $($(nTr).find(".protocolText")).hide();
             }
           } else {
@@ -636,6 +645,7 @@ block content
     }); // document ready
 
     function unPinRow(nTr, updateRows) {
+      $($(nTr).find(".infoColumn")).show();
       $($(nTr).find(".protocolText")).show();
       $($(nTr).children("td")[10]).show();
       $(nTr).removeClass('fixedrow');

--- a/viewer/views/settings.jade
+++ b/viewer/views/settings.jade
@@ -44,6 +44,17 @@ block content
     select#sortDirection.setting(name="sortDirection")
       option(value="asc") Ascending
       option(value="desc") Descending
+    br
+    label(for='visibleColumns') Sessions Visible Columns:
+    select#visibleColumns.setting(name="visibleColumns",multiple="multiple",size="6")
+      option(value="srcip") Src IP
+      option(value="srcport") Src Port
+      option(value="dstip") Dst IP
+      option(value="dstport") Dst Port
+      option(value="packets") Packets
+      option(value="bytes") Bytes
+      option(value="node") Node
+      option(value="info") Info
     h3 SPI Graph Tab
     label(for='spiGraph') Default Graph:
     +fieldsSelect("spiGraph", "setting", false)
@@ -185,14 +196,27 @@ block content
       var defaults = {
         spiGraph: "no",
         connSrcField: "a1",
-        connDstField: "ip.dst:port"
+        connDstField: "ip.dst:port",
+        visibleColumns: ["start", "stop", "srcip", "srcport", "dstip", "dstport", "packets", "bytes", "node", "info"]
       };
 
-      ["timezone", "detailFormat", "showTimestamps", "sortColumn", "sortDirection", "spiGraph", "connSrcField", "connDstField"].forEach(function(field) {
+      ["timezone", "detailFormat", "showTimestamps", "sortColumn", "sortDirection", "visibleColumns", "spiGraph", "connSrcField", "connDstField"].forEach(function(field) {
         if (settings[field]) {
-          $("#" + field + " option[value='" + settings[field] + "']").attr('selected', 'selected');
+          if (Array.isArray(settings[field])) {
+            for (key in settings[field]) {
+              $("#" + field + " option[value='" + settings[field][key] + "']").attr('selected', 'selected');
+            }
+          } else {
+            $("#" + field + " option[value='" + settings[field] + "']").attr('selected', 'selected');
+          }
         } else if (defaults[field]) {
-          $("#" + field + " option[value='" + defaults[field] + "']").attr('selected', 'selected');
+          if (Array.isArray(defaults[field])) {
+            for (key in defaults[field]) {
+              $("#" + field + " option[value='" + defaults[field][key] + "']").attr('selected', 'selected');
+            }
+          } else {
+            $("#" + field + " option[value='" + defaults[field] + "']").attr('selected', 'selected');
+          }
         }
       });
 

--- a/viewer/views/settings.jade
+++ b/viewer/views/settings.jade
@@ -53,19 +53,19 @@ block content
     br
     label(for='visibleColumns') Sessions Visible Columns:
     select#visibleColumns.setting(name="visibleColumns",multiple="multiple",size="6")
-      option(value="srcip") Src IP
-      option(value="srcport") Src Port
-      option(value="dstip") Dst IP
-      option(value="dstport") Dst Port
-      option(value="packets") Packets
-      option(value="srcpackets") Src Packets
-      option(value="dstpackets") Dst Packets
+      option(value="a1") Src IP
+      option(value="p1") Src Port
+      option(value="a2") Dst IP
+      option(value="p2") Dst Port
+      option(value="pa") Packets
+      option(value="pa1") Src Packets
+      option(value="pa2") Dst Packets
       option(value="bytes") Bytes
-      option(value="srcbytes") Src Bytes
-      option(value="dstbytes") Dst Bytes
-      option(value="srcdatabytes") Src Databytes
-      option(value="dstdatabytes") Dst Databytes
-      option(value="node") Node
+      option(value="by1") Src Bytes
+      option(value="by2") Dst Bytes
+      option(value="db1") Src Databytes
+      option(value="db2") Dst Databytes
+      option(value="no") Node
       option(value="info") Info
     h3 SPI Graph Tab
     label(for='spiGraph') Default Graph:
@@ -209,7 +209,7 @@ block content
         spiGraph: "no",
         connSrcField: "a1",
         connDstField: "ip.dst:port",
-        visibleColumns: ["start", "stop", "srcip", "srcport", "dstip", "dstport", "packets", "bytes", "node", "info"]
+        visibleColumns: ["a1", "p1", "a2", "p2", "pa", "bytes", "no", "info"]
       };
 
       ["timezone", "detailFormat", "showTimestamps", "sortColumn", "sortDirection", "visibleColumns", "spiGraph", "connSrcField", "connDstField"].forEach(function(field) {

--- a/viewer/views/settings.jade
+++ b/viewer/views/settings.jade
@@ -39,7 +39,13 @@ block content
       option(value="dstip") Dst IP
       option(value="dstport") Dst Port
       option(value="packets") Packets
+      option(value="srcpackets") Src Packets
+      option(value="dstpackets") Dst Packets
       option(value="bytes") Bytes
+      option(value="srcbytes") Src Bytes
+      option(value="dstbytes") Dst Bytes
+      option(value="srcdatabytes") Src Databytes
+      option(value="dstdatabytes") Dst Databytes
       option(value="node") Node
     select#sortDirection.setting(name="sortDirection")
       option(value="asc") Ascending
@@ -52,7 +58,13 @@ block content
       option(value="dstip") Dst IP
       option(value="dstport") Dst Port
       option(value="packets") Packets
+      option(value="srcpackets") Src Packets
+      option(value="dstpackets") Dst Packets
       option(value="bytes") Bytes
+      option(value="srcbytes") Src Bytes
+      option(value="dstbytes") Dst Bytes
+      option(value="srcdatabytes") Src Databytes
+      option(value="dstdatabytes") Dst Databytes
       option(value="node") Node
       option(value="info") Info
     h3 SPI Graph Tab


### PR DESCRIPTION
Resolves issue #257.
Made columns configurable from settings tab.
Added six new columns ("Src Bytes", "Dst Bytes", "Src data bytes", "Dst data bytes", "Src Packets", "Dst Packets").