### PR TITLE
Fixed TCP flags offset

### DIFF
--- a/capture/nids.c
+++ b/capture/nids.c
@@ -382,7 +382,7 @@ void moloch_nids_cb_ip(struct ip *packet, int len)
                  session->addr2 == packet->ip_dst.s_addr &&
                  session->port1 == ntohs(tcphdr->th_sport) &&
                  session->port2 == ntohs(tcphdr->th_dport))?0:1;
-        session->tcp_flags |= *((char*)packet + 4 * packet->ip_hl+12);
+        session->tcp_flags |= *((char*)packet + (4 * packet->ip_hl) + 13);
         break;
     case IPPROTO_ICMP:
         which = (session->addr1 == packet->ip_src.s_addr &&


### PR DESCRIPTION
Hello, 

I've been a long time Moloch user, and have recently experimented with integrating the netflow plugin with Logstash.  

I noticed the TCP flags seemed strange, and in doing some digging found that the offset within the TCP header was incorrect.  It's a minor fix, but one that I'm using to get accustomed to using GitHub.

I did a fork/pull-request on this, but if there are better ways to do minor fixes please let me know.  Thanks!

Dave