### PR TITLE
psl field mapping fix

### DIFF
--- a/db/db.pl
+++ b/db/db.pl
@@ -1016,7 +1016,7 @@ sub sessionsUpdate
         index: "no"
       },
       psl: {
-        type: "short",
+        type: "integer",
         index: "no"
       },
       fs: {


### PR DESCRIPTION
packets longer than 32k bits create errors