### PR TITLE
Enable batch build in scripts

### DIFF
--- a/easybutton-config.sh
+++ b/easybutton-config.sh
@@ -9,11 +9,11 @@ fi
 
 clear
 
-if [ -z $USERNAME ]; then
+if [ -z $MOLOCHUSER ]; then
 	echo -n "Moloch service userid: [daemon] "
-	read USERNAME
+	read MOLOCHUSER
 fi
-if [ -z $USERNAME ]; then USERNAME="daemon"; fi
+if [ -z $MOLOCHUSER ]; then MOLOCHUSER="daemon"; fi
 
 if [ -z $GROUPNAME ]; then
 	echo -n "Moloch service groupid: [daemon] "
@@ -40,7 +40,7 @@ if [ -z $BATCHRUN ]; then
 	read OK
 fi
 
-cat ${TDIR}/etc/config.ini.template | sed -e 's/_PASSWORD_/'${PASSWORD}'/g' -e 's/_USERNAME_/'${USERNAME}'/g' -e 's/_GROUPNAME_/'${GROUPNAME}'/g' -e 's/_INTERFACE_/'${INTERFACE}'/g'  -e "s,_TDIR_,${TDIR},g" > ${TDIR}/etc/config.ini
+cat ${TDIR}/etc/config.ini.template | sed -e 's/_PASSWORD_/'${PASSWORD}'/g' -e 's/_USERNAME_/'${MOLOCHUSER}'/g' -e 's/_GROUPNAME_/'${GROUPNAME}'/g' -e 's/_INTERFACE_/'${INTERFACE}'/g'  -e "s,_TDIR_,${TDIR},g" > ${TDIR}/etc/config.ini
 
 cd ${TDIR}/etc/
 echo "MOLOCH: creating self signed certificate"

--- a/easybutton-config.sh
+++ b/easybutton-config.sh
@@ -9,26 +9,36 @@ fi
 
 clear
 
-echo -n "Moloch service userid: [daemon] "
-read USERNAME
+if [ -z $USERNAME ]; then
+	echo -n "Moloch service userid: [daemon] "
+	read USERNAME
+fi
 if [ -z $USERNAME ]; then USERNAME="daemon"; fi
 
-echo -n "Moloch service groupid: [daemon] "
-read GROUPNAME
+if [ -z $GROUPNAME ]; then
+	echo -n "Moloch service groupid: [daemon] "
+	read GROUPNAME
+fi
 if [ -z $GROUPNAME ]; then GROUPNAME="daemon"; fi
 
-echo -n "Moloch INTERNAL encryption phrase: [0mgMolochRules1] "
-read PASSWORD
+if [ -z $PASSWORD ]; then
+	echo -n "Moloch INTERNAL encryption phrase: [0mgMolochRules1] "
+	read PASSWORD
+fi
 if [ -z $PASSWORD ]; then PASSWORD="0mgMolochRules1"; fi
 
-echo -n "Moloch interface to listen on: [eth0] "
-read INTERFACE
+if [ -z $INTERFACE ]; then
+	echo -n "Moloch interface to listen on: [eth0] "
+	read INTERFACE
+fi
 if [ -z $INTERFACE ]; then INTERFACE="eth0"; fi
 
-echo "You are about to attempt a Moloch build (Proceed?)"
-echo
-echo "Hit Ctrl-C *now* to stop!   Hit enter to proceed"
-read OK
+if [ -z $BATCHRUN ]; then 
+	echo "You are about to attempt a Moloch build (Proceed?)"
+	echo
+	echo "Hit Ctrl-C *now* to stop!   Hit enter to proceed"
+	read OK
+fi
 
 cat ${TDIR}/etc/config.ini.template | sed -e 's/_PASSWORD_/'${PASSWORD}'/g' -e 's/_USERNAME_/'${USERNAME}'/g' -e 's/_GROUPNAME_/'${GROUPNAME}'/g' -e 's/_INTERFACE_/'${INTERFACE}'/g'  -e "s,_TDIR_,${TDIR},g" > ${TDIR}/etc/config.ini
 

--- a/easybutton-singlehost.sh
+++ b/easybutton-singlehost.sh
@@ -106,8 +106,10 @@ if [ "x$https_proxy" != "x" ]; then
     sleep 1
 fi
 
-echo -n "Use pfring? ('yes' enables) [no] "
-read USEPFRING
+if [ -z $USEPFRING ]; then
+	echo -n "Use pfring? ('yes' enables) [no] "
+	read USEPFRING
+fi
 PFRING=""
 if [ -n "$USEPFRING" -a "x$USEPFRING" = "xyes" ]; then 
     echo "MOLOCH - Using pfring - Make sure to install the kernel modules"
@@ -223,8 +225,10 @@ fi
 
 
 
-echo -n "Memory to give to elasticsearch, box MUST have more then this available: [512M] "
-read ESMEM
+if [ -z $ESMEM ]; then
+	echo -n "Memory to give to elasticsearch, box MUST have more then this available: [512M] "
+	read ESMEM
+fi
 if [ -z $ESMEM ]; then ESMEM="512M"; fi
 
 echo "MOLOCH: Copying single-host config files"
@@ -273,11 +277,12 @@ echo "MOLOCH: Adding user admin/admin"
 cd ${TDIR}/viewer
 ../bin/node addUser.js -c ../etc/config.ini admin "Admin" admin -admin
 
-echo "MOLOCH: Starting viewer and capture"
-cd ${TDIR}/bin
-nohup ./run_viewer.sh &
-nohup ./run_capture.sh &
-
+if [ -z $DONOTSTART ]; then
+	echo "MOLOCH: Starting viewer and capture"
+	cd ${TDIR}/bin
+	nohup ./run_viewer.sh &
+	nohup ./run_capture.sh &
+fi
 
 HOSTNAME=`hostname`
 echo "MOLOCH: Complete use https://$HOSTNAME:8005 to access.  You should also make the run_* scripts in ${TDIR}/bin run on start up and look at the config files in ${TDIR}/etc"


### PR DESCRIPTION
The code still supports old interactive mode of scripts, but also this patch enables that moloch can be built automatically, something like:

USEPFRING=no ESMEM="512M" DONOTSTART=yes USERNAME=daemon GROUPNAME=daemon PASSWORD=0mgMolochRules1 INTERFACE=eth0 BATCHRUN=yes ./easybutton-singlehost.sh

Something like this helps in automatically building lxc/docker/vm images.