### PR TITLE
Fix viewer crash when node stats aren't provided from ES

### DIFF
--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -1419,10 +1419,10 @@ app.get('/esstats.json', function(req, res) {
         searchesTime: node.indices.search.query_time_in_millis,
         heapSize: node.jvm.mem.heap_used_in_bytes,
         nonHeapSize: node.jvm.mem.non_heap_used_in_bytes,
-        cpu: node.process.cpu.percent,
+        cpu: (typeof node.process.cpu !== 'undefined') ? node.process.cpu.percent : 0,
         read: 0,
         write: 0,
-        load: node.os.load_average
+        load: (typeof node.os.load_average !== 'undefined') ? node.os.load_average : [0, 0, 0]
       });
 
       var oldnode = internals.previousNodeStats[0][nodes[n]];
@@ -1435,8 +1435,13 @@ app.get('/esstats.json', function(req, res) {
           newdisk[1] += node.fs.data[i].disk_write_size_in_bytes;
         }
 
-        stats[stats.length-1].read  = Math.ceil((newdisk[0] - olddisk[0])/(node.timestamp - oldnode.timestamp));
-        stats[stats.length-1].write = Math.ceil((newdisk[1] - olddisk[1])/(node.timestamp - oldnode.timestamp));
+        var read = Math.ceil((newdisk[0] - olddisk[0])/(node.timestamp - oldnode.timestamp));
+        var write = Math.ceil((newdisk[1] - olddisk[1])/(node.timestamp - oldnode.timestamp));
+
+        if (!(isNaN(read) && isNaN(write))) {
+            stats[stats.length-1].read = read;
+            stats[stats.length-1].write = write;
+        }
       }
     }
 


### PR DESCRIPTION
I found that the viewer would crash when looking at the stats page if ES doesn't provide OS node stats (which will happen if libsigar isn't present). This change will handle situations where OS node stats are unavailable. If this happens, the numbers will all show up as 0 in the stats interface.