### PR TITLE
fix viewer crash on file download

### DIFF
--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -3203,7 +3203,7 @@ function reqGetRawBody(req, cb) {
       if (err) {
         return cb(err);
       }
-      if (typeof(items) === "undefined" || items.length === 0) {
+      if (items === undefined || items.length === 0) {
         return cb("No match");
       }
       cb(err, items[0].data);

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -3203,7 +3203,7 @@ function reqGetRawBody(req, cb) {
       if (err) {
         return cb(err);
       }
-      if (items.length === 0) {
+      if (typeof(items) === "undefined" || items.length === 0) {
         return cb("No match");
       }
       cb(err, items[0].data);


### PR DESCRIPTION
this PR fixes viewer crash on file download where `items` remains undefined