### PR TITLE
fix crash when sessionID is not found

### DIFF
--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -3217,7 +3217,7 @@ app.get('/:nodeName/:id/body/:bodyType/:bodyNum/:bodyName', checkProxyRequest, f
   reqGetRawBody(req, function (err, data) {
     if (err) {
       console.trace(err);
-      return res.send("Error");
+      return res.end("Error");
     }
 
     if (req.params.bodyType === "file") {


### PR DESCRIPTION
This fixes viewer crash when session ID is not found. with `res.send` it will resend headers, but `res.end` will close the response

relevant crash dump is :
`Trace: error
    at /data/moloch/viewer/viewer.js:3219:15
    at /data/moloch/viewer/viewer.js:3167:14
    at /data/moloch/viewer/viewer.js:2872:14
    at /data/moloch/viewer/viewer.js:2795:18
    at /data/moloch/viewer/viewer.js:2680:9
    at /data/moloch/viewer/pcap.js:157:16
    at Object.wrapper [as oncomplete] (fs.js:466:17)
Trace: error
    at /data/moloch/viewer/viewer.js:3219:15
    at /data/moloch/viewer/viewer.js:3167:14
    at /data/moloch/viewer/viewer.js:2872:14
    at /data/moloch/viewer/viewer.js:2795:18
    at /data/moloch/viewer/viewer.js:2680:9
    at /data/moloch/viewer/pcap.js:157:16
    at Object.wrapper [as oncomplete] (fs.js:466:17)

http.js:690
    throw new Error('Can\'t set headers after they are sent.');
          ^
Error: Can't set headers after they are sent.
    at ServerResponse.OutgoingMessage.setHeader (http.js:690:11)
    at ServerResponse.header (/data/moloch/viewer/node_modules/express/lib/response.js:718:10)
    at ServerResponse.send (/data/moloch/viewer/node_modules/express/lib/response.js:163:12)
    at /data/moloch/viewer/viewer.js:3220:18
    at /data/moloch/viewer/viewer.js:3167:14
    at /data/moloch/viewer/viewer.js:2872:14
    at /data/moloch/viewer/viewer.js:2795:18
    at /data/moloch/viewer/viewer.js:2680:9
    at /data/moloch/viewer/pcap.js:157:16
    at Object.wrapper [as oncomplete] (fs.js:466:17)`