### PR TITLE
Handle extra semicolons in pcapDir

### DIFF
--- a/viewer/public/common.js
+++ b/viewer/public/common.js
@@ -980,12 +980,19 @@ $(document).ready(function() {
         // in a substitution
         var urlParams = parseUrlParams();
         var dateparams;
+        var isostart;
+        var isostop;
         if (urlParams.startTime && urlParams.stopTime) {
           dateparams = "startTime=" + urlParams.startTime +
-                "&stopTime=" + urlParams.stopTime
+                "&stopTime=" + urlParams.stopTime;
+          isostart = new Date(parseInt(urlParams.startTime) * 1000);
+          isostop  = new Date(parseInt(urlParams.stopTime) * 1000);
         }
         else {
           dateparams = "date=" + urlParams.date;
+          isostart = new Date();
+          isostart.setHours(isostart.getHours() - parseInt(urlParams.date));
+          isostop  = new Date();
         }
 
         for (var key in molochRightClick) {
@@ -998,8 +1005,11 @@ $(document).ready(function() {
           var result = molochRightClick[key].url
                                             .replace("%EXPRESSION%", encodeURIComponent(urlParams.expression))
                                             .replace("%DATE%", dateparams)
+                                            .replace("%ISOSTART%", isostart.toISOString())
+                                            .replace("%ISOSTOP%", isostop.toISOString())
                                             .replace("%FIELD%", info.field)
                                             .replace("%TEXT%", text)
+                                            .replace("%UCTEXT%", text.toUpperCase())
                                             .replace("%HOST%", host)
                                             .replace("%URL%", encodeURIComponent("http:" + url));
 

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -938,6 +938,9 @@ function expireCheckAll () {
       }
       // Create a mapping from device id to stat information and all directories on that device
       pcapDirs.split(";").forEach(function (pcapDir) {
+        if (!pcapDir) {
+          return; // Skip empty elements.  Prevents errors when pcapDir has a trailing or double ;
+        }
         pcapDir = pcapDir.trim();
         var fileStat = fs.statSync(pcapDir);
         var vfsStat = fs.statVFS(pcapDir);


### PR DESCRIPTION
This skips empty elements in the pcapDir list to gracefully handle the case
where pcapDir has extraneous semicolons.  E.g.:

pcapDir=/dir1;/dir2;