### PR TITLE
Handle extra semicolons in pcapDir

### DIFF
--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -938,6 +938,9 @@ function expireCheckAll () {
       }
       // Create a mapping from device id to stat information and all directories on that device
       pcapDirs.split(";").forEach(function (pcapDir) {
+        if (!pcapDir) {
+          return; // Skip empty elements.  Prevents errors when pcapDir has a trailing or double ;
+        }
         pcapDir = pcapDir.trim();
         var fileStat = fs.statSync(pcapDir);
         var vfsStat = fs.statVFS(pcapDir);


### PR DESCRIPTION
This skips empty elements in the pcapDir list to gracefully handle the case
where pcapDir has extraneous semicolons.  E.g.:

pcapDir=/dir1;/dir2;