### PR TITLE
Adds two new algorithms for selecting pcap directories

### DIFF
--- a/capture/config.c
+++ b/capture/config.c
@@ -380,6 +380,14 @@ void moloch_config_load()
         exit(1);
     }
 
+    config.pcapDirAlgorithm = moloch_config_str(keyfile, "pcapDirAlgorithm", "round-robin");
+    if (strcmp(config.pcapDirAlgorithm, "round-robin") != 0
+            && strcmp(config.pcapDirAlgorithm, "max-free-percent") != 0
+            && strcmp(config.pcapDirAlgorithm, "max-free-bytes") != 0) {
+        printf("'%s' is not a valid value for pcapDirAlgorithm.  Supported algorithms are round-robin, max-free-percent, and max-free-bytes.\n", config.pcapDirAlgorithm);
+        exit(1);
+    }
+
     config.maxFileSizeG          = moloch_config_double(keyfile, "maxFileSizeG", 4, 0.01, 1024);
     config.maxFileSizeB          = config.maxFileSizeG*1024LL*1024LL*1024LL;
     config.maxFileTimeM          = moloch_config_int(keyfile, "maxFileTimeM", 0, 0, 0xffff);

--- a/capture/db.c
+++ b/capture/db.c
@@ -1568,6 +1568,9 @@ char *moloch_db_create_file(time_t firstPacket, char *name, uint64_t size, int l
     char              *json = moloch_http_get_buffer(MOLOCH_HTTP_BUFFER_SIZE);
     int                json_len;
     const uint64_t     fp = firstPacket;
+    double             maxFreeSpacePercent = 0;
+    uint64_t           maxFreeSpaceBytes   = 0;
+    int                i;
 
 
     MOLOCH_LOCK(nextFileNum);
@@ -1625,9 +1628,38 @@ char *moloch_db_create_file(time_t firstPacket, char *name, uint64_t size, int l
             flen += tlen;
         }
 
-        config.pcapDirPos++;
-        if (!config.pcapDir[config.pcapDirPos])
-            config.pcapDirPos = 0;
+        if (strcmp(config.pcapDirAlgorithm, "max-free-percent") == 0) {
+            // Select the pcapDir with the highest percentage of free space
+            for (i = 0; config.pcapDir[i]; i++) {
+                struct statvfs vfs;
+                statvfs(config.pcapDir[i], &vfs);
+                LOG("%s has %0.2f%% free", config.pcapDir[i], 100 * ((double)vfs.f_bavail / (double)vfs.f_blocks));
+                if ((double)vfs.f_bavail / (double)vfs.f_blocks >= maxFreeSpacePercent)
+                {
+                    maxFreeSpacePercent = (double)vfs.f_bavail / (double)vfs.f_blocks;
+                    config.pcapDirPos = i;
+                }
+            }
+            LOG("%s has the highest percentage of available disk space", config.pcapDir[config.pcapDirPos]);
+        } else if (strcmp(config.pcapDirAlgorithm, "max-free-bytes") == 0) {
+            // Select the pcapDir with the most bytes free
+            for (i = 0; config.pcapDir[i]; i++) {
+                struct statvfs vfs;
+                statvfs(config.pcapDir[i], &vfs);
+                LOG("%s has %lu megabytes available", config.pcapDir[i], (uint64_t)vfs.f_bavail * (uint64_t)vfs.f_frsize / 1024 / 1024);
+                if ((uint64_t)vfs.f_bavail * (uint64_t)vfs.f_frsize >= maxFreeSpaceBytes)
+                {
+                    maxFreeSpaceBytes = (uint64_t)vfs.f_bavail * (uint64_t)vfs.f_frsize;
+                    config.pcapDirPos = i;
+                }
+            }
+            LOG("%s has the most available space", config.pcapDir[config.pcapDirPos]);
+        } else {
+            // Select pcapDir by round robin
+            config.pcapDirPos++;
+            if (!config.pcapDir[config.pcapDirPos])
+                config.pcapDirPos = 0;
+        }
 
         if (filename[flen-1] == '/') {
             flen--;

--- a/capture/moloch.h
+++ b/capture/moloch.h
@@ -336,6 +336,7 @@ typedef struct moloch_config {
     char      compressES;
     char      antiSynDrop;
     char      readTruncatedPackets;
+    char     *pcapDirAlgorithm;
 } MolochConfig_t;
 
 typedef struct {


### PR DESCRIPTION
Selecting pcap directories by round robin results in data expiring before it really needs to when the directories are on differently-sized filesystems.  This adds two options to select the directory based on available space.

Adds a new config file key "pcapDirAlgorithm."  Valid values:

- round-robin: uses each directory in sequence and then starts over at the beginning of the list
- max-free-percent: chooses the directory on the filesystem with the highest percentage of free disk space
- max-free-bytes: chooses the directory on the filesystem with the highest number of available bytes

The default is "round-robin," which is the original behavior.