### PR TITLE
Threatstream zip mode undefined variable bug fix

### DIFF
--- a/capture/plugins/wiseService/source.threatstream.js
+++ b/capture/plugins/wiseService/source.threatstream.js
@@ -44,6 +44,7 @@ function ThreatStreamSource (api, section) {
     this.domains      = new HashTable();
     this.emails       = new HashTable();
     this.md5s         = new HashTable();
+    this.urls         = new HashTable();
     this.cacheTimeout = -1;
     break;
   case "sqlite3":


### PR DESCRIPTION
Fixes this error:

/data/moloch/wiseService/source.threatstream.js:74
  self.urls.clear();
            ^
TypeError: Cannot call method 'clear' of undefined
    at ThreatStreamSource.parseFile (/data/moloch/wiseService/source.threatstream.js:74:13)
    at Object.<anonymous> (/data/moloch/wiseService/source.threatstream.js:142:12)
    at Object.immediate._onImmediate (timers.js:348:16)
    at processImmediate [as _immediateCallback] (timers.js:330:15)