### PR TITLE
Fix viewer authentication user error handling

### DIFF
--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -209,10 +209,10 @@ if (Config.get("passwordSecret")) {
     if (internals.userNameHeader !== undefined && req.headers[internals.userNameHeader] !== undefined) {
       var userName = req.headers[internals.userNameHeader];
       Db.getUserCache(userName, function(err, suser) {
-        if (err) {return res.send("ERROR - " +  err);}
         if (!suser || !suser.found) {return res.send(userName + " doesn't exist");}
         if (!suser._source.enabled) {return res.send(userName + " not enabled");}
         if (!suser._source.headerAuthEnabled) {return res.send(userName + " header auth not enabled");}
+        if (err) {return res.send("ERROR - " +  err);}
 
         userCleanup(suser._source);
         req.user = suser._source;
@@ -2505,7 +2505,7 @@ function graphMerge(req, query, aggregations) {
     return graph;
   }
 
-  if (req.query.bounding === "database") { 
+  if (req.query.bounding === "database") {
     graph.interval = query.aggregations?(query.aggregations.dbHisto.histogram.interval/1000) || 60 : 60;
     aggregations.dbHisto.buckets.forEach(function (item) {
       var key = item.key;


### PR DESCRIPTION
Right now, the general case error handling code is above the specific case error handling code and prevents it from being reached. This PR flips the order to allow the more specific (and helpful) error messages to be shown where possible.