### PR TITLE
Improve easybutton-build for non-root on Debian-based

### DIFF
--- a/easybutton-build.sh
+++ b/easybutton-build.sh
@@ -53,10 +53,14 @@ if [ -f "/etc/redhat-release" ]; then
 fi
 
 if [ -f "/etc/debian_version" ]; then
-  apt-get -y install wget curl libpcre3-dev uuid-dev libmagic-dev pkg-config g++ flex bison zlib1g-dev libffi-dev gettext libgeoip-dev make libjson-perl libbz2-dev libwww-perl libpng-dev xz-utils libffi-dev libssl-dev
-  if [ $? -ne 0 ]; then
-    echo "MOLOCH - apt-get failed"
-    exit 1
+  DEPS="wget curl libpcre3-dev uuid-dev libmagic-dev pkg-config g++ flex bison zlib1g-dev libffi-dev gettext libgeoip-dev make libjson-perl libbz2-dev libwww-perl libpng-dev xz-utils libffi-dev libssl-dev"
+
+  if ! dpkg -l $DEPS >/dev/null; then
+    apt-get install $DEPS
+    if [ $? -ne 0 ]; then
+      echo "MOLOCH - apt-get failed"
+      exit 1
+    fi
   fi
 fi
 

--- a/easybutton-build.sh
+++ b/easybutton-build.sh
@@ -53,7 +53,10 @@ if [ -f "/etc/redhat-release" ]; then
 fi
 
 if [ -f "/etc/debian_version" ]; then
-  DEPS="wget curl libpcre3-dev uuid-dev libmagic-dev pkg-config g++ flex bison zlib1g-dev libffi-dev gettext libgeoip-dev make libjson-perl libbz2-dev libwww-perl libpng-dev xz-utils libffi-dev libssl-dev"
+  DEPS="wget curl libpcre3-dev uuid-dev libmagic-dev pkg-config g++
+        flex bison zlib1g-dev libffi-dev gettext libgeoip-dev make
+        libjson-perl libbz2-dev libwww-perl libpng-dev xz-utils
+        libffi-dev libssl-dev"
 
   if ! dpkg -l $DEPS >/dev/null; then
     apt-get install $DEPS


### PR DESCRIPTION
If run as a non-root user, easybutton-build.sh will fail due to the call to apt-get.  I'd rather not run the build as root, especially since I've configuration-management'd all of the required packages in place anyway.  This pull will check that all the requisite packages are installed, and bypass the call to apt-get if it not needed.