### PR TITLE
Auto buildversion

### DIFF
--- a/capture/Makefile.in
+++ b/capture/Makefile.in
@@ -1,5 +1,7 @@
 INSTALL_DIR   = @INSTALL_DIR@
 
+BUILD_VERSION := $(@GIT@ describe --tags)
+
 CC            = @CC@
 
 INCLUDE_PCAP  = @PCAP_CFLAGS@
@@ -22,7 +24,8 @@ LIB_OTHER     = @GLIB2_LIBS@ \
 	        thirdparty/http_parser.o \
 	        thirdparty/js0n.o \
 	        thirdparty/patricia.o \
-		@DL_LIB@ -lpthread -lssl -lcrypto
+		@DL_LIB@ -lpthread -lssl -lcrypto \
+		-DBUILD_VERSION=${BUILD_VERSION}
 
 C_FILES         = main.c db.c yara.c http.c config.c parsers.c plugins.c field.c trie.c writers.c writer-inplace.c writer-disk.c writer-null.c writer-simple.c readers.c reader-libpcap-file.c reader-libpcap.c reader-tpacketv3.c packet.c session.c molochmagic.c
 O_FILES         = $(C_FILES:.c=.o)

--- a/capture/main.c
+++ b/capture/main.c
@@ -29,6 +29,10 @@
 #include "pcap.h"
 #include "molochconfig.h"
 
+#ifndef BUILD_VERSION
+#define BUILD_VERSION "unkn"
+#endif
+
 /******************************************************************************/
 MolochConfig_t         config;
 extern void           *esServer;

--- a/capture/main.c
+++ b/capture/main.c
@@ -118,7 +118,7 @@ void parse_args(int argc, char **argv)
         config.configFile = g_strdup("/data/moloch/etc/config.ini");
 
     if (showVersion) {
-        printf("moloch-capture %s session size=%zd packet size=%zd\n", PACKAGE_VERSION, sizeof(MolochSession_t), sizeof(MolochPacket_t));
+        printf("moloch-capture %s/%s session size=%zd packet size=%zd\n", PACKAGE_VERSION, BUILD_VERSION, sizeof(MolochSession_t), sizeof(MolochPacket_t));
         printf("glib2: %u.%u.%u\n", glib_major_version, glib_minor_version, glib_micro_version);
         printf("libpcap: %s\n", pcap_lib_version());
         printf("curl: %s\n", curl_version());

--- a/configure.ac
+++ b/configure.ac
@@ -2,6 +2,7 @@ AC_INIT([moloch], [0.18.1-GIT])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 AC_PROG_CC
 AC_PROG_CXX
+AC_CHECK_TOOL([GIT],[git],[:])
 AC_CONFIG_HEADERS([capture/molochconfig.h])
 AC_PREFIX_DEFAULT(["/data/moloch"])
 AC_CHECK_HEADERS([sys/inotify.h])

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([moloch], [0.18.1-GIT])
+AC_INIT([moloch], m4_esyscmd([git --describe --tags]))
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 AC_PROG_CC
 AC_PROG_CXX

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([moloch], m4_esyscmd([git --describe --tags]))
+AC_INIT([moloch], m4_esyscmd([git describe --tags]))
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 AC_PROG_CC
 AC_PROG_CXX


### PR DESCRIPTION
When you run autoconf, it will figure out the version to write to ./configure, which might be different than build-time.  moloch-capture will print both version strings on startup.