### PR TITLE
Allow on-the-fly updates of the GeoIP databases

### DIFF
--- a/capture/db.c
+++ b/capture/db.c
@@ -2285,7 +2285,7 @@ void moloch_db_init()
     moloch_add_can_quit(moloch_db_can_quit, "DB");
 
     if (config.geoipFile) {
-        gi = GeoIP_open(config.geoipFile, GEOIP_MEMORY_CACHE);
+        gi = GeoIP_open(config.geoipFile, GEOIP_MEMORY_CACHE | GEOIP_CHECK_CACHE);
         if (!gi) {
             printf("Couldn't initialize GeoIP %s from %s", strerror(errno), config.geoipFile);
             exit(1);
@@ -2294,7 +2294,7 @@ void moloch_db_init()
     }
 
     if (config.geoip6File) {
-        gi6 = GeoIP_open(config.geoip6File, GEOIP_MEMORY_CACHE);
+        gi6 = GeoIP_open(config.geoip6File, GEOIP_MEMORY_CACHE | GEOIP_CHECK_CACHE);
         if (!gi6) {
             printf("Couldn't initialize GeoIP %s from %s", strerror(errno), config.geoip6File);
             exit(1);
@@ -2303,7 +2303,7 @@ void moloch_db_init()
     }
 
     if (config.geoipASNFile) {
-        giASN = GeoIP_open(config.geoipASNFile, GEOIP_MEMORY_CACHE);
+        giASN = GeoIP_open(config.geoipASNFile, GEOIP_MEMORY_CACHE | GEOIP_CHECK_CACHE);
         if (!giASN) {
             printf("Couldn't initialize GeoIP ASN %s from %s", strerror(errno), config.geoipASNFile);
             exit(1);
@@ -2312,7 +2312,7 @@ void moloch_db_init()
     }
 
     if (config.geoipASN6File) {
-        giASN6 = GeoIP_open(config.geoipASN6File, GEOIP_MEMORY_CACHE);
+        giASN6 = GeoIP_open(config.geoipASN6File, GEOIP_MEMORY_CACHE | GEOIP_CHECK_CACHE);
         if (!giASN6) {
             printf("Couldn't initialize GeoIP ASN 6 %s from %s", strerror(errno), config.geoipASN6File);
             exit(1);


### PR DESCRIPTION
This change should allow for on-the-fly updates to the GeoIP databases.  If the database is updated then the memory cache is reloaded.

https://github.com/maxmind/geoip-api-c/blob/0cfb181ff20ad9297e745318fdb9f484ba86cd0c/README.md#memory-caching-and-other-options