### PR TITLE
db.pl expire --nooptimize

### DIFF
--- a/db/db.pl
+++ b/db/db.pl
@@ -2075,11 +2075,11 @@ if ($ARGV[1] =~ /^users-?import$/) {
     dbESVersion();
     $main::userAgent->timeout(3600);
     optimizeOther();
-    printf ("Expiring %s indices, optimizing %s\n", commify(scalar(keys %{$indices}) - $optimizecnt), commify($optimizecnt));
+    printf ("Expiring %s indices, %s optimizing %s\n", commify(scalar(keys %{$indices}) - $optimizecnt), $NOOPTIMIZE?"Not":"", commify($optimizecnt));
     foreach my $i (sort (keys %{$indices})) {
         progress("$i ");
         if (exists $indices->{$i}->{OPTIMIZEIT}) {
-            esGet("/$i/$main::OPTIMIZE?max_num_segments=4", 1);
+            esGet("/$i/$main::OPTIMIZE?max_num_segments=4", 1) unless $NOOPTIMIZE ;
             if ($REPLICAS != -1) {
                 esGet("/$i/_flush", 1);
                 esPut("/$i/_settings", '{index: {"number_of_replicas":' . $REPLICAS . '}}', 1);

--- a/db/db.pl
+++ b/db/db.pl
@@ -2074,7 +2074,7 @@ if ($ARGV[1] =~ /^users-?import$/) {
 
     dbESVersion();
     $main::userAgent->timeout(3600);
-    optimizeOther();
+    optimizeOther() unless $NOOPTIMIZE ;
     printf ("Expiring %s indices, %s optimizing %s\n", commify(scalar(keys %{$indices}) - $optimizecnt), $NOOPTIMIZE?"Not":"", commify($optimizecnt));
     foreach my $i (sort (keys %{$indices})) {
         progress("$i ");

--- a/db/db.pl
+++ b/db/db.pl
@@ -55,6 +55,7 @@ my $PREFIX = "";
 my $NOCHANGES = 0;
 my $SHARDS = -1;
 my $REPLICAS = -1;
+my $NOOPTIMIZE = 0;
 
 ################################################################################
 sub MIN ($$) { $_[$_[0] > $_[1]] }
@@ -100,6 +101,7 @@ sub showHelp($)
     print "       type                    - Same as rotateIndex in ini file = hourly,daily,weekly,monthly\n";
     print "       num                     - number of indexes to keep\n";
     print "    --replicas <num>           - Number of replicas for older sessions indices, default 0\n";
+    print "    --nooptimize               - Do not optimize session indexes during this operation\n";
     print "  field disable <exp>          - disable a field from being indexed\n";
     print "  field enable <exp>           - enable a field from being indexed\n";
     exit 1;
@@ -1978,6 +1980,8 @@ sub parseArgs {
         } elsif ($ARGV[$pos] eq "--replicas") {
             $pos++;
             $REPLICAS = int($ARGV[$pos]);
+        } elsif ($ARGV[$pos] eq "--nooptimize") {
+	    $NOOPTIMIZE = 1;
         } else {
             print "Unknown option '", $ARGV[$pos], "'\n";
         }


### PR DESCRIPTION
Add option to the expire command that skips optimizing indexes.  Optimizing is an expensive (in terms of I/O, CPU, and memory) and doesn't really need to be run on all indexes every day.  This option allows us to schedule db,pl optimize separately from db.pl expire, so that the optimize runs in non-peak times.