### PR TITLE
Fix deadlock during capture.

### DIFF
--- a/capture/plugins/wise.c
+++ b/capture/plugins/wise.c
@@ -210,9 +210,7 @@ void wise_cb(int UNUSED(code), unsigned char *data, int data_len, gpointer uw)
     WiseRequest_t *request = uw;
     int             i;
 
-    MOLOCH_LOCK(iRequest);
     inflight -= request->numItems;
-    MOLOCH_UNLOCK(iRequest);
 
     BSB_INIT(bsb, data, data_len);
 


### PR DESCRIPTION
wise_flush() is acquiring a lock on iRequest, then calling wise_flush_locked(), which can call wise_cb() which tries to acquire a lock on the already locked iRequest.

Here is the relevant portion of a traceback during deadlock from gdb:
#2  0x00007f3f58d28c08 in pthread_mutex_lock () from /lib64/libpthread.so.0
#3  0x00007f3f1d2a1230 in wise_cb (code=code@entry=500, data=data@entry=0x0, data_len=data_len@entry=0, 
    uw=0x7f3ef8896ca0) at wise.c:213
#4  0x00007f3f1d2a1780 in wise_flush_locked () at wise.c:473
#5  0x00007f3f1d2a1847 in wise_flush (user_data=<error reading variable: value has been optimized out>) at wise.c:483
