### PR TITLE
Fixed a floating point exception with offline PCAP ingestion. 

### DIFF
--- a/capture/main.c
+++ b/capture/main.c
@@ -634,22 +634,21 @@ int main(int argc, char **argv)
 
     g_main_loop_run(mainLoop);
 
+    if (!config.dryRun && config.copyPcap) {
+        moloch_writer_exit();
+    }
+
     LOG("Final cleanup");
     moloch_plugins_exit();
     moloch_parsers_exit();
-    moloch_yara_exit();
     moloch_db_exit();
     moloch_http_exit();
+    moloch_yara_exit();
     moloch_field_exit();
     moloch_config_exit();
     moloch_rules_exit();
 
     g_main_loop_unref(mainLoop);
-
-    if (!config.dryRun && config.copyPcap) {
-        moloch_writer_exit();
-    }
-
 
     free_args();
     exit(0);


### PR DESCRIPTION
The floating point exception happened when offline PCAP ingestion was performed with the --copy command line argument. The floating point issue occurred on line 639 in http.c due to server->namesCnt being 0. server->namesCnt was 0 due to reading from the server structure after it had been freed. To fix this problem I reordered the shutdown function calls in main.c. In limited testing using valgrind I'm not seeing any more reads after frees.