### PR TITLE
Pcapfile pkt count limit

### DIFF
--- a/capture/main.c
+++ b/capture/main.c
@@ -78,6 +78,7 @@ static GOptionEntry entries[] =
     { "nospi",       0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE,           &config.noSPI,         "no SPI data written to ES", NULL },
     { "tests",       0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE,           &config.tests,         "Output test suite information", NULL },
     { "noLoadTags",  0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE,           &config.noLoadTags,    "Don't load tags at startup", NULL },
+    { "pktcnt",      0,                    0, G_OPTION_ARG_INT,            &config.pcapFilePktsToRead, "Number of pkts to read from each offline file", NULL},
     { NULL,          0, 0,                                    0,           NULL, NULL, NULL }
 };
 
@@ -107,6 +108,7 @@ void parse_args(int argc, char **argv)
     extern char *pcre_version(void);
     extern char *GeoIP_lib_version(void);
 
+    config.pcapFilePktsToRead = 0;
     context = g_option_context_new ("- capture");
     g_option_context_add_main_entries (context, entries, NULL);
     if (!g_option_context_parse (context, &argc, &argv, &error))

--- a/capture/reader-libpcap-file.c
+++ b/capture/reader-libpcap-file.c
@@ -404,7 +404,7 @@ gboolean reader_libpcapfile_read()
     if(config.pcapFilePktsToRead == 0){
         pkts_to_read_this_time = 5000;
         pkts_to_read = 5000;
-    //Otherwise read --pcapFilePktsToRead number of packets
+    //Otherwise read --pktcnt number of packets
     }else{
         if(pkts_to_read >= 5000){
             pkts_to_read_this_time = 5000;


### PR DESCRIPTION
This pull request adds the --pktcnt option with intended behaviour to be the same as tcpdump's -c option. When reading from pcap files, capture should read --pktcnt number of packets before stopping. Not specifying this option or when --pktcnt 0 all the packets in a file will be read.