### PR TITLE
Add checks for location of node

### DIFF
--- a/release/moloch_add_user.sh
+++ b/release/moloch_add_user.sh
@@ -1,3 +1,12 @@
 #!/bin/sh
 
-BUILD_MOLOCH_INSTALL_DIR/bin/node BUILD_MOLOCH_INSTALL_DIR/viewer/addUser.js -c BUILD_MOLOCH_INSTALL_DIR/etc/config.ini "$@"
+# Check the existance of a local copy of node and preference that local version
+if command -v "BUILD_MOLOCH_INSTALL_DIR/bin/node" >/dev/null 2>&1; then
+    "BUILD_MOLOCH_INSTALL_DIR/bin/node" "BUILD_MOLOCH_INSTALL_DIR/viewer/addUser.js" -c "BUILD_MOLOCH_INSTALL_DIR/etc/config.ini" "$@"
+# Check if node is installed globally    
+elif command -v node >/dev/null 2>&1; then
+    node "BUILD_MOLOCH_INSTALL_DIR/viewer/addUser.js" -c "BUILD_MOLOCH_INSTALL_DIR/etc/config.ini" "$@"
+# Good luck - maybe you have node elsewhere
+else
+    echo "Node is required to be installed to run this command"
+fi


### PR DESCRIPTION
Added some additional checks for the location of node.  The default install didn't have node installed in the moloch directory, perhaps this happens in the package installs.