### PR TITLE
Re-enable pattern replacement in menu names for custom right clicks

### DIFF
--- a/viewer/app/modules/session/components/session.field.component.js
+++ b/viewer/app/modules/session/components/session.field.component.js
@@ -318,6 +318,13 @@
              .replace('%URL%', encodeURIComponent('http:' + url));
 
           let name = this.molochClickables[key].name || key;
+
+          name = (name)
+             .replace("%FIELD%", info.field)
+             .replace("%TEXT%", text)
+             .replace("%HOST%", host)
+             .replace("%URL%", url);
+
           let value = '%URL%';
           if (rc.category === 'host') { value = '%HOST%'; }
 


### PR DESCRIPTION
E.g.

FIELDPIVOTIP=url:/?%DATE%&expression=%FIELD%+%3D%3D+%TEXT%;name:Pivot %FIELD%;category:ip

%FIELD% should be replaced with the field value in the menu name as well as the target url.