### PR TITLE
Fix right click menus not appearing without a date=X param

### DIFF
--- a/viewer/app/modules/session/components/session.field.component.js
+++ b/viewer/app/modules/session/components/session.field.component.js
@@ -284,10 +284,15 @@
         isostop  = new Date(parseInt(urlParams.stopTime) * 1000);
       }
       else {
-        dateparams = `date=${urlParams.date}`;
         isostart = new Date();
         isostop  = new Date();
-        isostart.setHours(isostart.getHours() - parseInt(urlParams.date));
+        if (urlParams.date) {
+            isostart.setHours(isostart.getHours() - parseInt(urlParams.date));
+        }
+        else {
+            isostart.setHours(isostart.getHours() - 1);
+        }
+        dateparams = `date=${urlParams.date}`;
       }
 
       for (let key in this.molochClickables) {


### PR DESCRIPTION
This died if urlParams.date didn't exist:

isostart.setHours(isostart.getHours() - parseInt(urlParams.date));