### PR TITLE
Wrap noisy non-errors under config.debug

### DIFF
--- a/capture/http.c
+++ b/capture/http.c
@@ -411,7 +411,8 @@ static gboolean moloch_http_curl_watch_open_callback(int fd, GIOCondition condit
         strcat(remoteIp, "]");
     }
 
-    LOG("Connected %d/%d - %s   %d->%s:%d - fd:%d",
+    if (config.debug)
+        LOG("Connected %d/%d - %s   %d->%s:%d - fd:%d",
             server->outstanding,
             server->connections,
             server->names[0],
@@ -508,7 +509,8 @@ int moloch_http_curl_close_callback(void *serverV, curl_socket_t fd)
 
     server->connections--;
 
-    LOG("Close %d/%d - %s   %d->%s:%d fd:%d removed: %s",
+    if (config.debug)
+        LOG("Close %d/%d - %s   %d->%s:%d fd:%d removed: %s",
             server->outstanding,
             server->connections,
             server->names[0],


### PR DESCRIPTION
I think I remember talking about this on slack, but I can't find it right now.

Without this, moloch-capture is very chatty about every connection made or closed to Elasticsearch, generating lines like:

``Oct 20 09:11:46 capturehost moloch-capture[25686]: Oct 20 09:11:46 http.c:519 moloch_http_curl_close_callback(): Close 94/29 - eshost:9200   46348->146.xx.xx.xx:9200 fd:12 removed: true
Oct 20 09:11:46 capturehost moloch-capture[25686]: Oct 20 09:11:46 http.c:421 moloch_http_curl_watch_open_callback(): Connected 93/29 - eshost:9200   3966->146.xx.xx.xx:9200 - fd:12
``

This is just noise in normal operation, and should only be logged if debugging is on.