### PR TITLE
Fix ES stats crash on non-data nodes.

### DIFF
--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -2620,7 +2620,7 @@ app.get('/esstats.json', function(req, res) {
       var write = 0;
 
       var oldnode = internals.previousNodeStats[0][nodes[n]];
-      if (node.fs.io_stats !== undefined && oldnode.fs.io_stats !== undefined) {
+      if ("total" in node.fs.io_stats && node.fs.io_stats !== undefined && oldnode.fs.io_stats !== undefined) {
         var timediffsec = (node.timestamp - oldnode.timestamp)/1000.0;
         read = Math.ceil((node.fs.io_stats.total.read_kilobytes - oldnode.fs.io_stats.total.read_kilobytes)/timediffsec*1024);
         write = Math.ceil((node.fs.io_stats.total.write_kilobytes - oldnode.fs.io_stats.total.write_kilobytes)/timediffsec*1024);


### PR DESCRIPTION
On a cluster with non-data nodes (e.g. dedicated master nodes), the viewer will crash when viewing the Elasticsearch tab on the Stats page with the following:

/data/moloch/viewer/viewer.js:2625
        read = Math.ceil((node.fs.io_stats.total.read_kilobytes - oldnode.fs.io_stats.total.read_kilobytes)/timediffsec*1024);
                                                ^

TypeError: Cannot read property 'read_kilobytes' of undefined
    at /data/moloch/viewer/viewer.js:2625:49
    at /data/moloch/viewer/node_modules/async/dist/async.js:3861:9
    at /data/moloch/viewer/node_modules/async/dist/async.js:421:16
    at iterateeCallback (/data/moloch/viewer/node_modules/async/dist/async.js:928:24)
    at /data/moloch/viewer/node_modules/async/dist/async.js:906:16
    at /data/moloch/viewer/node_modules/async/dist/async.js:3858:13
    at internals.elasticSearchClient.nodes.stats (/data/moloch/viewer/db.js:274:85)
    at respond (/data/moloch/viewer/node_modules/elasticsearch/src/lib/transport.js:310:9)
    at checkRespForFailure (/data/moloch/viewer/node_modules/elasticsearch/src/lib/transport.js:248:7)
    at HttpConnector.<anonymous> (/data/moloch/viewer/node_modules/elasticsearch/src/lib/connectors/http.js:164:7)
