### PR TITLE
Fix cyberchef in Firefox

### DIFF
--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -173,6 +173,7 @@ app.use('/bootstrap', express.static(__dirname + '/node_modules/bootstrap', { ma
 
 app.use('/cyberchef.htm', function(req, res, next) {
   res.setHeader("Vary", "Accept-Encoding");
+  res.setHeader("Content-Type", "text/html");
   res.setHeader("Content-Encoding", "gzip");
   res.sendFile(__dirname + "/public/cyberchef.htm.gz");
 });


### PR DESCRIPTION
Cyberchef downloads in Firefox and Safari if not given a content-type.
Cyberchef in Safari still doesn't work fully, but that is a fix for
another day. Fixes issue #769.