### PR TITLE
Add an explicit sigint handler to wiseService and viewer

### DIFF
--- a/capture/plugins/wiseService/wiseService.js
+++ b/capture/plugins/wiseService/wiseService.js
@@ -123,6 +123,13 @@ function getConfig(section, name, d) {
 function getConfigSections() {
   return Object.keys(internals.config);
 }
+
+// Explicit sigint handler for running under docker
+// See https://github.com/nodejs/node/issues/4182
+process.on('SIGINT', function() {
+    process.exit();
+});
+
 //////////////////////////////////////////////////////////////////////////////////
 //// Sources
 //////////////////////////////////////////////////////////////////////////////////

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -300,6 +300,12 @@ app.use(function(req, res, next) {
 
 logger.token('username', function(req, res){ return req.user?req.user.userId:"-"; });
 
+// Explicit sigint handler for running under docker
+// See https://github.com/nodejs/node/issues/4182
+process.on('SIGINT', function() {
+    process.exit();
+});
+
 function loadFields() {
   Db.loadFields(function (data) {
     Config.loadFields(data);


### PR DESCRIPTION
node ignores sigint when running as pid 1 in a docker container.  An explicit
sigint handler is needed in order for ^C to work or for systemd to manage the
process.  E.g. when running the viewer like ...

docker run --rm moloch /data/moloch/bin/node /data/moloch/viewer/viewer.js

See https://github.com/nodejs/node/issues/4182 for details.