### PR TITLE
fix moloch_field_define quic.version in moloch 1.0.0

### DIFF
--- a/capture/parsers/quic.c
+++ b/capture/parsers/quic.c
@@ -237,7 +237,7 @@ void moloch_parser_init()
         NULL);
 
     versionField = moloch_field_define("quic", "termfield",
-        "quic.version", "Version", "quic.version-term",
+        "quic.version", "Version", "quic.version",
         "QUIC Version",
         MOLOCH_FIELD_TYPE_STR_HASH,  MOLOCH_FIELD_FLAG_CNT,
         NULL);


### PR DESCRIPTION
Updated moloch_field_define call for quic.version.  Removed "-term" suffix from field name.