### PR TITLE
new:Clean up field values to remove URL information from queries on http.uri or host.* fields

### DIFF
--- a/viewer/molochparser.js
+++ b/viewer/molochparser.js
@@ -511,9 +511,20 @@ function formatQuery(yy, field, op, value)
     throw "Invalid operator '" + op + "' for " + field;
   }
 
-  // Remove the "http:" from http.uri queries
-  if (field == "http.uri" && value.startsWith("http:")) {
-    value = value.substring(5);
+  // Remove the "http:", "https:", etc from http.uri queries
+  if (field == "http.uri") {
+    value = value.replace(/^[a-z]+:/i, '');
+  }
+  
+  // Remove everything but the host from host, host.http,
+  // host.dns, etc
+  // E.g. turn host.dns == http://www.site.com/path into
+  //           host.dns == www.site.com
+  if (field.match(/^host/)) {
+    // Remove e.g. "http://"
+    value = value.replace(/^[a-z]+:\/\//i, '');
+    // Remove everything from the first slash onward
+    value = value.replace(/\/.*/, '');
   }
 
   switch (info.type2 || info.type) {

--- a/viewer/molochparser.js
+++ b/viewer/molochparser.js
@@ -511,6 +511,11 @@ function formatQuery(yy, field, op, value)
     throw "Invalid operator '" + op + "' for " + field;
   }
 
+  // Remove the "http:" from http.uri queries
+  if (field == "http.uri" && value.startsWith("http:")) {
+    value = value.substring(5);
+  }
+
   switch (info.type2 || info.type) {
   case "ip":
     if (value[0] === "/")


### PR DESCRIPTION
Clean up user input by removing the http:// from http.uri queries and all URL information from host.* queries.  E.g.

http.uri = http://somehost.com/path becomes http.uri = //somehost.com/path
host.dns = http://somehost.com/path becomes host.dns = somehost.com

This helps new users, but more importantly it allows us to create right click pivots from URL fields.  For example, we can follow a redirect chain by pivoting from http.location to http.uri.