### PR TITLE
support larger queries in /buildQuery.json

### DIFF
--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -154,7 +154,7 @@ app.use(function(req, res, next) {
   return next();
 });
 app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: true }));
+app.use(bodyParser.urlencoded({ limit: "5mb", extended: true }));
 //app.use(multer({dest: Config.get("pcapDir")}));
 
 // send req to access log file or stdout
@@ -2964,7 +2964,13 @@ function flattenFields(fields) {
   return fields;
 }
 
-app.get('/buildQuery.json', logAction('query'), function(req, res) {
+app.use('/buildQuery.json', logAction('query'), function(req, res, next) {
+
+  if (req.method == "POST") {
+    req.query = req.body;
+  } else if (req.method != "GET") {
+    next();
+  }
 
   buildSessionQuery(req, function(bsqErr, query, indices) {
     if (bsqErr) {

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -2966,9 +2966,9 @@ function flattenFields(fields) {
 
 app.use('/buildQuery.json', logAction('query'), function(req, res, next) {
 
-  if (req.method == "POST") {
+  if (req.method === "POST") {
     req.query = req.body;
-  } else if (req.method != "GET") {
+  } else if (req.method !== "GET") {
     next();
   }
 


### PR DESCRIPTION
Calling GET /buildQuery.json with a large query string (>100KB) returns a 400 Bad Request error.

This patch allows posting to the buildQuery.json route and increases the bodyParser.urlencoded size limit from 100KB to 5MB.