### PR TITLE
passing -1 to the flags param in snf_open

### DIFF
--- a/capture/plugins/snf/README.md
+++ b/capture/plugins/snf/README.md
@@ -3,7 +3,7 @@ The snf reader plugin now works directly with Myricom SNF
 Optional settings
 * ```snfNumRings``` number of rings and threads to use per interface
 * ```snfDataRingSize``` SNF_DATARING_SIZE
-
+* ```snfFlags``` Variable that controls process-sharing (1), port aggregation (2), and packet duplication (3), see SNF documentation for more details.  
 
 To use:
 * install the snf package on the build hosts and all hosts that will run moloch-capture

--- a/capture/plugins/snf/reader-snf.c
+++ b/capture/plugins/snf/reader-snf.c
@@ -111,6 +111,7 @@ void reader_snf_init(char *UNUSED(name))
 
     snfNumRings = moloch_config_int(NULL, "snfNumRings", 1, 1, MAX_RINGS);
     int snfDataRingSize = moloch_config_int(NULL, "snfDataRingSize", 0, 0, 0x7fffffff);
+    int snfFlags = moloch_config_int(NULL, "snfFlags", -1, 0, -1);
 
     int err;
     if ( (err = snf_init(SNF_VERSION_API)) != 0) {
@@ -139,7 +140,7 @@ void reader_snf_init(char *UNUSED(name))
         }
 
         int err;
-        err  = snf_open(portnums[i], snfNumRings, NULL, snfDataRingSize, -1, &handles[i]);
+        err  = snf_open(portnums[i], snfNumRings, NULL, snfDataRingSize, snfFlags, &handles[i]);
         if (err != 0) {
             LOGEXIT("Myricom: Couldn't open interface '%s' %d", config.interface[i], err);
         }

--- a/capture/plugins/snf/reader-snf.c
+++ b/capture/plugins/snf/reader-snf.c
@@ -139,7 +139,7 @@ void reader_snf_init(char *UNUSED(name))
         }
 
         int err;
-        err  = snf_open(portnums[i], snfNumRings, NULL, snfDataRingSize, 0, &handles[i]);
+        err  = snf_open(portnums[i], snfNumRings, NULL, snfDataRingSize, -1, &handles[i]);
         if (err != 0) {
             LOGEXIT("Myricom: Couldn't open interface '%s' %d", config.interface[i], err);
         }


### PR DESCRIPTION
fixes #873 

As per SNF API Reference, passing -1 to the flags param will cause it to read the SNF_FLAGS environment variable.

The reference doc for snf_open_defaults says that calling it is equivalent to calling: 
```snf_open(portnum, 0, NULL, 0, -1, devhandle);```


