### PR TITLE
show es errors instead of "Oh no, moloch is empty..."

### DIFF
--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -3071,6 +3071,11 @@ app.get('/sessions.json', logAction('sessions'), function(req, res) {
                map: {},
                health: Db.healthCache(),
                data:[]};
+      if (typeof err === "string") {
+        r.error = err;
+      } else if (err && typeof err.message === "string") {
+        r.error = err.message;
+      }
       res.send(r);
     });
   });

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -3069,13 +3069,9 @@ app.get('/sessions.json', logAction('sessions'), function(req, res) {
                recordsFiltered: 0,
                graph: {},
                map: {},
+               error: errorString(err),
                health: Db.healthCache(),
                data:[]};
-      if (typeof err === "string") {
-        r.error = err;
-      } else if (err && typeof err.message === "string") {
-        r.error = err.message;
-      }
       res.send(r);
     });
   });


### PR DESCRIPTION
**Steps to reproduce:** attempt to sort on a field that doesn't have a mapping.  viewer log shows an exception from elasticsearch.  moloch ui shows "Oh no, moloch is empty".

> ERROR - /sessions.json error { Error: [query_shard_exception] No mapping found for [tls.ja3] in order to sort on, with { index_uuid="vXob9QDiSHOumz4Df5p6Fg" & index="sessions2-180718" }
>     at respond (/data/moloch/node_modules/elasticsearch/src/lib/transport.js:307:15)
>     at checkRespForFailure (/data/moloch/node_modules/elasticsearch/src/lib/transport.js:266:7)
>     at HttpConnector.<anonymous> (/data/moloch/node_modules/elasticsearch/src/lib/connectors/http.js:159:7)
>     at IncomingMessage.bound (/data/moloch/node_modules/elasticsearch/node_modules/lodash/dist/lodash.js:729:21)
>     at emitNone (events.js:111:20)
>     at IncomingMessage.emit (events.js:208:7)
>     at endReadableNT (_stream_readable.js:1064:12)
>     at _combinedTickCallback (internal/process/next_tick.js:138:11)
>     at process._tickCallback (internal/process/next_tick.js:180:9)
>   status: 400,
>   displayName: 'BadRequest',
>   message: '[query_shard_exception] No mapping found for [tls.ja3] in order to sort on, with { index_uuid="vXob9QDiSHOumz4Df5p6Fg" & index="sessions2-180718" }',
>   path: '/sessions2-180718/session/_search',
>   query: {},
>   body:
>    { error:
>       { root_cause: [Array],
>         type: 'search_phase_execution_exception',
>         reason: 'all shards failed',
>         phase: 'query',
>         grouped: true,
>         failed_shards: [Array] },
>      status: 400 },
>   statusCode: 400,
>   response: '{"error":{"root_cause":[{"type":"query_shard_exception","reason":"No mapping found for [tls.ja3] in order to sort on","index_uuid":"vXob9QDiSHOumz4Df5p6Fg","index":"sessions2-180718"}],"type":"search_phase_execution_exception","reason":"all shards failed","phase":"query","grouped":true,"failed_shards":[{"shard":0,"index":"sessions2-180718","node":"aG_W93OYRku89-AwiGNhvA","reason":{"type":"query_shard_exception","reason":"No mapping found for [tls.ja3] in order to sort on","index_uuid":"vXob9QDiSHOumz4Df5p6Fg","index":"sessions2-180718"}}]},"status":400}',
>   toString: [Function],
>   toJSON: [Function] }