### PR TITLE
Disabled moloch-capture memory limit in systemd unit file

### DIFF
--- a/release/molochcapture.systemd.service
+++ b/release/molochcapture.systemd.service
@@ -10,6 +10,7 @@ ExecStartPre=-MOLOCH_INSTALL_DIR/bin/moloch_config_interfaces.sh
 ExecStart=/bin/sh -c 'MOLOCH_INSTALL_DIR/bin/moloch-capture -c MOLOCH_INSTALL_DIR/etc/config.ini >> MOLOCH_INSTALL_DIR/logs/capture.log 2>&1'
 WorkingDirectory=MOLOCH_INSTALL_DIR
 LimitCORE=infinity
+LimitMEMLOCK=infinity
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
As per information in /etc/security/limits.conf, this file is applied on users logged in via PAM. I updated systemd unit file to archive same behaviour on systemd executed moloch-capture service.