### PR TITLE
add --nolockpcap flag to moloch capture. "Don't lock offline pcap files (ie., allow deletion)"

### DIFF
--- a/capture/main.c
+++ b/capture/main.c
@@ -114,6 +114,7 @@ LOCAL  GOptionEntry entries[] =
     { "tests",       0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE,           &config.tests,         "Output test suite information", NULL },
     { "nostats",     0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE,           &config.noStats,       "Don't send node stats", NULL },
     { "insecure",    0,                    0, G_OPTION_ARG_NONE,           &config.insecure,      "insecure https calls", NULL },
+    { "nolockpcap",  0,                    0, G_OPTION_ARG_NONE,           &config.noLockPcap,    "Don't lock offline pcap files (ie., allow deletion)", NULL },
     { NULL,          0, 0,                                    0,           NULL, NULL, NULL }
 };
 

--- a/capture/moloch.h
+++ b/capture/moloch.h
@@ -336,6 +336,7 @@ typedef struct moloch_config {
     gboolean  flushBetween;
     gboolean  noLoadTags;
     gboolean  trackESP;
+    gboolean  noLockPcap;
     gint      pktsToRead;
 
     GHashTable *override;

--- a/capture/writer-inplace.c
+++ b/capture/writer-inplace.c
@@ -54,7 +54,7 @@ LOCAL long writer_inplace_create(MolochPacket_t * const packet)
     if (config.pcapReprocess) {
         moloch_db_file_exists(readerName, &outputId);
     } else {
-        char *filename = moloch_db_create_file(packet->ts.tv_sec, readerName, st.st_size, 1, &outputId);
+        char *filename = moloch_db_create_file(packet->ts.tv_sec, readerName, st.st_size, !config.noLockPcap, &outputId);
         g_free(filename);
     }
     outputIds[packet->readerPos] = outputId;


### PR DESCRIPTION
add --nolockpcap flag to moloch capture. "Don't lock offline pcap files (ie., allow deletion)"

Got a bit of feedback from @awick in the slack channel, thanks.