### PR TITLE
Modified parliament systemd service / fixed tests for perl 5.26+

### DIFF
--- a/release/molochparliament.systemd.service
+++ b/release/molochparliament.systemd.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Moloch WISE
+Description=Moloch Parliament
 After=network.target
 
 [Service]

--- a/release/molochparliament.systemd.service
+++ b/release/molochparliament.systemd.service
@@ -6,7 +6,9 @@ After=network.target
 Type=simple
 Restart=on-failure
 StandardOutput=tty
-ExecStart=/bin/sh -c 'MOLOCH_INSTALL_DIR/bin/node parliament.js -c MOLOCH_INSTALL_DIR/etc/parliament.json >> MOLOCH_INSTALL_DIR/logs/parliament.log 2>&1'
+EnvironmentFile=-/etc/default/molochparliament
+EnvironmentFile=-/etc/sysconfig/molochparliament
+ExecStart=/bin/sh -c 'MOLOCH_INSTALL_DIR/bin/node parliament.js -c MOLOCH_INSTALL_DIR/etc/parliament.json ${OPTIONS} >> MOLOCH_INSTALL_DIR/logs/parliament.log 2>&1'
 WorkingDirectory=MOLOCH_INSTALL_DIR/parliament
 
 [Install]

--- a/tests/api-connections.t
+++ b/tests/api-connections.t
@@ -1,3 +1,8 @@
+
+use Cwd qw( abs_path );
+use File::Basename qw( dirname );
+use lib dirname(abs_path($0));
+
 use Test::More tests => 8;
 use Cwd;
 use URI::Escape;

--- a/tests/api-files.t
+++ b/tests/api-files.t
@@ -1,3 +1,8 @@
+
+use Cwd qw( abs_path );
+use File::Basename qw( dirname );
+use lib dirname(abs_path($0));
+
 use Test::More tests => 19;
 use Cwd;
 use URI::Escape;

--- a/tests/api-fresh.t
+++ b/tests/api-fresh.t
@@ -1,3 +1,8 @@
+
+use Cwd qw( abs_path );
+use File::Basename qw( dirname );
+use lib dirname(abs_path($0));
+
 # Tests on a fresh install
 use Test::More tests => 45;
 use Cwd;

--- a/tests/api-history.t
+++ b/tests/api-history.t
@@ -1,3 +1,8 @@
+
+use Cwd qw( abs_path );
+use File::Basename qw( dirname );
+use lib dirname(abs_path($0));
+
 use Test::More tests => 41;
 use Cwd;
 use URI::Escape;

--- a/tests/api-hunt.t
+++ b/tests/api-hunt.t
@@ -1,3 +1,8 @@
+
+use Cwd qw( abs_path );
+use File::Basename qw( dirname );
+use lib dirname(abs_path($0));
+
 use Test::More tests => 214;
 use Cwd;
 use URI::Escape;

--- a/tests/api-multies.t
+++ b/tests/api-multies.t
@@ -1,3 +1,8 @@
+
+use Cwd qw( abs_path );
+use File::Basename qw( dirname );
+use lib dirname(abs_path($0));
+
 use Test::More tests => 28;
 use Cwd;
 use URI::Escape;

--- a/tests/api-scrub.t
+++ b/tests/api-scrub.t
@@ -1,3 +1,8 @@
+
+use Cwd qw( abs_path );
+use File::Basename qw( dirname );
+use lib dirname(abs_path($0));
+
 use Test::More tests => 34;
 use Cwd;
 use URI::Escape;

--- a/tests/api-sessionDetail.t
+++ b/tests/api-sessionDetail.t
@@ -1,3 +1,8 @@
+
+use Cwd qw( abs_path );
+use File::Basename qw( dirname );
+use lib dirname(abs_path($0));
+
 use Test::More tests => 19;
 
 use Cwd;

--- a/tests/api-sessions.t
+++ b/tests/api-sessions.t
@@ -1,3 +1,8 @@
+
+use Cwd qw( abs_path );
+use File::Basename qw( dirname );
+use lib dirname(abs_path($0));
+
 use Test::More tests => 67;
 use Cwd;
 use URI::Escape;

--- a/tests/api-spigraph.t
+++ b/tests/api-spigraph.t
@@ -1,3 +1,8 @@
+
+use Cwd qw( abs_path );
+use File::Basename qw( dirname );
+use lib dirname(abs_path($0));
+
 use Test::More tests => 77;
 use Cwd;
 use URI::Escape;

--- a/tests/api-spiview.t
+++ b/tests/api-spiview.t
@@ -1,3 +1,8 @@
+
+use Cwd qw( abs_path );
+use File::Basename qw( dirname );
+use lib dirname(abs_path($0));
+
 use Test::More tests => 70;
 use Cwd;
 use URI::Escape;

--- a/tests/api-stats.t
+++ b/tests/api-stats.t
@@ -1,3 +1,8 @@
+
+use Cwd qw( abs_path );
+use File::Basename qw( dirname );
+use lib dirname(abs_path($0));
+
 use Test::More tests => 48;
 use Cwd;
 use URI::Escape;

--- a/tests/api-tagging.t
+++ b/tests/api-tagging.t
@@ -1,3 +1,8 @@
+
+use Cwd qw( abs_path );
+use File::Basename qw( dirname );
+use lib dirname(abs_path($0));
+
 use Test::More tests => 36;
 use Cwd;
 use URI::Escape;

--- a/tests/api-unique.t
+++ b/tests/api-unique.t
@@ -1,3 +1,8 @@
+
+use Cwd qw( abs_path );
+use File::Basename qw( dirname );
+use lib dirname(abs_path($0));
+
 use Test::More tests => 30;
 use Cwd;
 use URI::Escape;

--- a/tests/api-users.t
+++ b/tests/api-users.t
@@ -1,3 +1,8 @@
+
+use Cwd qw( abs_path );
+use File::Basename qw( dirname );
+use lib dirname(abs_path($0));
+
 use Test::More tests => 71;
 use Cwd;
 use URI::Escape;

--- a/tests/cert.t
+++ b/tests/cert.t
@@ -1,3 +1,8 @@
+
+use Cwd qw( abs_path );
+use File::Basename qw( dirname );
+use lib dirname(abs_path($0));
+
 use Test::More tests => 64;
 use Cwd;
 use URI::Escape;

--- a/tests/dhcp.t
+++ b/tests/dhcp.t
@@ -1,3 +1,8 @@
+
+use Cwd qw( abs_path );
+use File::Basename qw( dirname );
+use lib dirname(abs_path($0));
+
 use Test::More tests => 12;
 use Cwd;
 use URI::Escape;

--- a/tests/dns.t
+++ b/tests/dns.t
@@ -1,3 +1,8 @@
+
+use Cwd qw( abs_path );
+use File::Basename qw( dirname );
+use lib dirname(abs_path($0));
+
 use Test::More tests => 80;
 use Cwd;
 use URI::Escape;

--- a/tests/email.t
+++ b/tests/email.t
@@ -1,3 +1,8 @@
+
+use Cwd qw( abs_path );
+use File::Basename qw( dirname );
+use lib dirname(abs_path($0));
+
 use Test::More tests => 92;
 use Cwd;
 use URI::Escape;

--- a/tests/general.t
+++ b/tests/general.t
@@ -1,3 +1,8 @@
+
+use Cwd qw( abs_path );
+use File::Basename qw( dirname );
+use lib dirname(abs_path($0));
+
 use Test::More tests => 606;
 use Cwd;
 use URI::Escape;

--- a/tests/http.t
+++ b/tests/http.t
@@ -1,3 +1,8 @@
+
+use Cwd qw( abs_path );
+use File::Basename qw( dirname );
+use lib dirname(abs_path($0));
+
 use Test::More tests => 288;
 use Cwd;
 use URI::Escape;

--- a/tests/irc.t
+++ b/tests/irc.t
@@ -1,3 +1,8 @@
+
+use Cwd qw( abs_path );
+use File::Basename qw( dirname );
+use lib dirname(abs_path($0));
+
 use Test::More tests => 22;
 use Cwd;
 use URI::Escape;

--- a/tests/mysql.t
+++ b/tests/mysql.t
@@ -1,3 +1,8 @@
+
+use Cwd qw( abs_path );
+use File::Basename qw( dirname );
+use lib dirname(abs_path($0));
+
 use Test::More tests => 10;
 use Cwd;
 use URI::Escape;

--- a/tests/parliament.t
+++ b/tests/parliament.t
@@ -1,3 +1,8 @@
+
+use Cwd qw( abs_path );
+use File::Basename qw( dirname );
+use lib dirname(abs_path($0));
+
 use Test::More tests => 25;
 use Cwd;
 use URI::Escape;

--- a/tests/postgresql.t
+++ b/tests/postgresql.t
@@ -1,3 +1,8 @@
+
+use Cwd qw( abs_path );
+use File::Basename qw( dirname );
+use lib dirname(abs_path($0));
+
 use Test::More tests => 14;
 use Cwd;
 use URI::Escape;

--- a/tests/quic.t
+++ b/tests/quic.t
@@ -1,3 +1,8 @@
+
+use Cwd qw( abs_path );
+use File::Basename qw( dirname );
+use lib dirname(abs_path($0));
+
 use Test::More tests => 12;
 use Cwd;
 use URI::Escape;

--- a/tests/smb.t
+++ b/tests/smb.t
@@ -1,3 +1,8 @@
+
+use Cwd qw( abs_path );
+use File::Basename qw( dirname );
+use lib dirname(abs_path($0));
+
 use Test::More tests => 38;
 use Cwd;
 use URI::Escape;

--- a/tests/socks.t
+++ b/tests/socks.t
@@ -1,3 +1,8 @@
+
+use Cwd qw( abs_path );
+use File::Basename qw( dirname );
+use lib dirname(abs_path($0));
+
 use Test::More tests => 36;
 use Cwd;
 use URI::Escape;

--- a/tests/ssh.t
+++ b/tests/ssh.t
@@ -1,3 +1,8 @@
+
+use Cwd qw( abs_path );
+use File::Basename qw( dirname );
+use lib dirname(abs_path($0));
+
 use Test::More tests => 24;
 use Cwd;
 use URI::Escape;

--- a/tests/tagger.t
+++ b/tests/tagger.t
@@ -1,3 +1,8 @@
+
+use Cwd qw( abs_path );
+use File::Basename qw( dirname );
+use lib dirname(abs_path($0));
+
 use Test::More tests => 56;
 use Cwd;
 use URI::Escape;

--- a/tests/tls.t
+++ b/tests/tls.t
@@ -1,3 +1,8 @@
+
+use Cwd qw( abs_path );
+use File::Basename qw( dirname );
+use lib dirname(abs_path($0));
+
 use Test::More tests => 14;
 use Cwd;
 use URI::Escape;

--- a/tests/wise.t
+++ b/tests/wise.t
@@ -1,3 +1,8 @@
+
+use Cwd qw( abs_path );
+use File::Basename qw( dirname );
+use lib dirname(abs_path($0));
+
 # WISE tests
 use Test::More tests => 74;
 use MolochTest;


### PR DESCRIPTION
- changing test files to make sure they are compatible with perl 5.26+ that excluded "." from @INC
- Modified parliament systemd file to load environment variables and added $OPTIONS to command line. 
- Fixed the name on parliament service description (was wise) 