### PR TITLE
Fix for session tagging

### DIFF
--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -2248,22 +2248,14 @@ function sessionsListFromQuery(req, res, fields, cb) {
 
 function sessionsListFromIds(req, ids, fields, cb) {
   var processSegments = false;
-  if (req && req.query.segments && req.query.segments.match(/^(time|all)$/) && fields.indexOf("rootId") === -1) {
-    fields.push("rootId");
-    processSegments = true;
-  } else if (req && req.body.segments && req.body.segments.match(/^(time|all)$/) && fields.indexOf("rootId") === -1) {
-    fields.push("rootId");
+  if (req && ((req.query.segments && req.query.segments.match(/^(time|all)$/)) || (req.body.segments && req.body.segments.match(/^(time|all)$/)))) {
+    if (fields.indexOf("rootId") === -1) { fields.push("rootId"); }
     processSegments = true;
   }
 
   var list = [];
   var nonArrayFields = ["ipProtocol", "firstPacket", "lastPacket", "srcIp", "srcPort", "srcGEO", "dstIp", "dstPort", "dstGEO", "totBytes", "totDataBytes", "totPackets", "node", "rootId"];
   var fixFields = nonArrayFields.filter(function(x) {return fields.indexOf(x) !== -1;});
-
-  // ES treats _source=no as turning off _source, very sad :(
-  if (fields.length === 1 && fields[0] === "node") {
-    fields.push("lastPacket");
-  }
 
   async.eachLimit(ids, 10, function(id, nextCb) {
     Db.getWithOptions(Db.sid2Index(id), 'session', Db.sid2Id(id), {_source: fields.join(",")}, function(err, session) {

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -2247,6 +2247,15 @@ function sessionsListFromQuery(req, res, fields, cb) {
 }
 
 function sessionsListFromIds(req, ids, fields, cb) {
+  var processSegments = false;
+  if (req && req.query.segments && req.query.segments.match(/^(time|all)$/) && fields.indexOf("rootId") === -1) {
+    fields.push("rootId");
+    processSegments = true;
+  } else if (req && req.body.segments && req.body.segments.match(/^(time|all)$/) && fields.indexOf("rootId") === -1) {
+    fields.push("rootId");
+    processSegments = true;
+  }
+
   var list = [];
   var nonArrayFields = ["ipProtocol", "firstPacket", "lastPacket", "srcIp", "srcPort", "srcGEO", "dstIp", "dstPort", "dstGEO", "totBytes", "totDataBytes", "totPackets", "node", "rootId"];
   var fixFields = nonArrayFields.filter(function(x) {return fields.indexOf(x) !== -1;});
@@ -2273,7 +2282,7 @@ function sessionsListFromIds(req, ids, fields, cb) {
       nextCb(null);
     });
   }, function(err) {
-    if (req && req.query.segments && req.query.segments.match(/^(time|all)$/)) {
+    if (processSegments) {
       buildSessionQuery(req, function(err, query, indices) {
         query._source = fields;
         sessionsListAddSegments(req, indices, query, list, function(err, list) {


### PR DESCRIPTION
The segments selections all and same-time-period  add tags to or remove tags from sessions with the same rootId or captured at the same time period.