### PR TITLE
wrong call

### DIFF
--- a/viewer/vueapp/src/components/sessions/ExportCsv.vue
+++ b/viewer/vueapp/src/components/sessions/ExportCsv.vue
@@ -133,7 +133,7 @@ export default {
         }
       }
 
-      SessionsService.exportPcap(data, this.$route.query);
+      SessionsService.exportCsv(data, this.$route.query);
 
       this.done('CSV Exported', true);
     }


### PR DESCRIPTION
`exportCsv` method must call `SessionsService.exportCsv` method but it has been calling `SessionsService.exportPcap`! To test the bug on right top arrow menu click `Export CSV` then change the filename from `sessions.csv` to `session1.csv` and then click on `Export Csv` button. Then open downloaded file with `csv` extension! It contains `pcap` binaries because of wrong call via frontend. In `viewer.js` routing to `app.get(/\/sessions.csv.*/, ` placed before `app.get(/\/sessions.pcap.*/,` and on wrong request because of default file named `sessions.csv` correct route will be called although the request has been started with `sessions.pcap`! With one line changed the bug must be resolved.