### PR TITLE
Fix issue #946, "hunt packet search jobs should skip sessions for which no PCAP exists"

### DIFF
--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -5879,7 +5879,7 @@ function processHuntJob (huntId, hunt) {
     var query = {
       from: 0,
       size: 100, // Only fetch 100 items at a time
-      query: { bool: { filter: [{}] } },
+      query: { bool: { must: [{ exists: { field: 'fileId' } }], filter: [{}] } },
       _source: ['_id', 'node'],
       sort: { lastPacket: { order: 'asc' } }
     };


### PR DESCRIPTION
Fix issue #946, "hunt packet search jobs should skip sessions for which no PCAP exists"

Changed the initial query structure for the hunt session query from:

```
    query: { bool: { filter: [{}] } },
```
to:
```
    query: { bool: { must: [{ exists: { field: 'fileId' } }], filter: [{}] } },
```    
In order to ensure that no sessions missing the fileId field are included in the results.

Tested it on my local moloch installation with both sessions from PCAP files (those containing fileId's) as well as those without, and I no longer get the crash. The correct matches seem to show up