### PR TITLE
bug find

### DIFF
--- a/easybutton-build.sh
+++ b/easybutton-build.sh
@@ -282,7 +282,7 @@ fi
 
 if [ $DOINSTALL -eq 1 ]; then
     export PATH=$TDIR/bin:$PATH
-    sudo make install
+    make install
     echo "MOLOCH: Installed, now type sudo make config'"
 else
     echo "MOLOCH: Now type 'sudo make install' and 'sudo make config'"


### PR DESCRIPTION
On around like 284 
    export PATH=$TDIR/bin:$PATH
    sudo -E make install
echo "MOLOCH: Installed, now type sudo make config'"
else
    echo "MOLOCH: Now type 'sudo make install' and 'sudo make config'"
fi

That three part code uses sudo combined with export. Do you see that?
Please read man sudo 
Look at the -E flag 
Seems like sudo doesn't pass environment variables. 

Can you all look at this? Open a bug and fix it?