### PR TITLE
prevent packaging log/raw dirs, conditionally handing in Configure instead

### DIFF
--- a/release/Configure
+++ b/release/Configure
@@ -132,9 +132,14 @@ else
 fi
 
 ################################################################################
-mkdir -p $MOLOCH_INSTALL_DIR/logs $MOLOCH_INSTALL_DIR/raw
-chown nobody $MOLOCH_INSTALL_DIR/logs $MOLOCH_INSTALL_DIR/raw
-chmod 0700 $MOLOCH_INSTALL_DIR/raw
+# re-create these directories after installation so they are not part of the package manifest
+CREATEDIRS="logs raw"
+for CREATEDIR in $CREATEDIRS; do
+    if [ ! -e $MOLOCH_INSTALL_DIR/$CREATEDIR ]; then
+        mkdir -m 0700 -p $MOLOCH_INSTALL_DIR/$CREATEDIR && \
+        chown nobody $MOLOCH_INSTALL_DIR/$CREATEDIR
+    fi
+done
 
 ################################################################################
 if [ "$MOLOCH_LOCALELASTICSEARCH" == "yes" ]; then

--- a/release/afterinstall.sh
+++ b/release/afterinstall.sh
@@ -1,2 +1,12 @@
 #!/bin/bash
+
+# re-create these directories after installation so they are not part of the package manifest
+CREATEDIRS="/data/<%= name %>/logs /data/<%= name %>/raw"
+for CREATEDIR in ${CREATEDIRS}; do
+    if [ ! -e ${CREATEDIR} ]; then
+        mkdir -m 0700 -p ${CREATEDIR} && \
+        chown nobody ${CREATEDIR}
+    fi
+done
+
 echo "READ /data/<%= name %>/README.txt and RUN /data/<%= name %>/bin/Configure"

--- a/release/afterinstall.sh
+++ b/release/afterinstall.sh
@@ -1,12 +1,2 @@
 #!/bin/bash
-
-# re-create these directories after installation so they are not part of the package manifest
-CREATEDIRS="/data/<%= name %>/logs /data/<%= name %>/raw"
-for CREATEDIR in ${CREATEDIRS}; do
-    if [ ! -e ${CREATEDIR} ]; then
-        mkdir -m 0700 -p ${CREATEDIR} && \
-        chown nobody ${CREATEDIR}
-    fi
-done
-
 echo "READ /data/<%= name %>/README.txt and RUN /data/<%= name %>/bin/Configure"

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -30,7 +30,7 @@ jobs:
             - build-package: |
                 export MOLOCH_VERSION=`sed 's/.*"\(.*\)\".*$/\1/' /data/moloch/viewer/version.js | tr "-" "_"`
                 if [ "$GIT_BRANCH" = "$MOLOCH_COPY_BRANCH" ]; then
-                  scl enable rh-ruby23 "/opt/rh/rh-ruby23/root/usr/local/bin/fpm -s dir -t rpm -n moloch -x /data/moloch/logs -x /data/moloch/raw -v $MOLOCH_VERSION --iteration $SD_BUILD_ID --template-scripts --after-install 'release/afterinstall.sh' --url "http://molo.ch" --description 'Moloch Full Packet System' -d perl-libwww-perl -d perl-JSON -d ethtool -d libyaml-devel /data/moloch"
+                  scl enable rh-ruby23 "/opt/rh/rh-ruby23/root/usr/local/bin/fpm -s dir -t rpm -n moloch -x data/moloch/logs -x data/moloch/raw -v $MOLOCH_VERSION --iteration $SD_BUILD_ID --template-scripts --after-install 'release/afterinstall.sh' --url "http://molo.ch" --description 'Moloch Full Packet System' -d perl-libwww-perl -d perl-JSON -d ethtool -d libyaml-devel /data/moloch"
                   scl enable python27 "aws s3 cp --quiet moloch*.x86_64.rpm s3://files.molo.ch/moloch-${MOLOCH_FILE_NAME}.centos6.x86_64.rpm --acl public-read"
                   scl enable python27 "aws s3api put-object-acl --bucket files.molo.ch --key moloch-${MOLOCH_FILE_NAME}.centos6.x86_64.rpm --acl public-read"
                 fi
@@ -53,7 +53,7 @@ jobs:
             - build-package: |
                 export MOLOCH_VERSION=`sed 's/.*"\(.*\)\".*$/\1/' /data/moloch/viewer/version.js | tr "-" "_"`
                 if [ "$GIT_BRANCH" = "$MOLOCH_COPY_BRANCH" ]; then
-                  fpm -s dir -t rpm -n moloch -x /data/moloch/logs -x /data/moloch/raw -v $MOLOCH_VERSION --iteration $SD_BUILD_ID --template-scripts --after-install "release/afterinstall.sh" --url "http://molo.ch" --description "Moloch Full Packet System" -d perl-libwww-perl -d perl-JSON -d ethtool -d libyaml-devel /data/moloch
+                  fpm -s dir -t rpm -n moloch -x data/moloch/logs -x data/moloch/raw -v $MOLOCH_VERSION --iteration $SD_BUILD_ID --template-scripts --after-install "release/afterinstall.sh" --url "http://molo.ch" --description "Moloch Full Packet System" -d perl-libwww-perl -d perl-JSON -d ethtool -d libyaml-devel /data/moloch
                   aws s3 cp --quiet moloch*.x86_64.rpm s3://files.molo.ch/moloch-${MOLOCH_FILE_NAME}.centos7.x86_64.rpm --acl public-read
                   aws s3api put-object-acl --bucket files.molo.ch --key moloch-${MOLOCH_FILE_NAME}.centos7.x86_64.rpm --acl public-read
                 fi
@@ -81,7 +81,7 @@ jobs:
             - build-package: |
                 export MOLOCH_VERSION=`sed 's/.*"\(.*\)\".*$/\1/' /data/moloch/viewer/version.js | tr "-" "_"`
                 if [ "$GIT_BRANCH" = "$MOLOCH_COPY_BRANCH" ]; then
-                  fpm -s dir -t rpm -n moloch -x /data/moloch/logs -x /data/moloch/raw -v $MOLOCH_VERSION --iteration $SD_BUILD_ID --template-scripts --after-install "release/afterinstall.sh" --url "http://molo.ch" --description "Moloch Full Packet System" -d perl-libwww-perl -d perl-JSON -d ethtool -d libyaml-devel -d libasan-static /data/moloch
+                  fpm -s dir -t rpm -n moloch -x data/moloch/logs -x data/moloch/raw -v $MOLOCH_VERSION --iteration $SD_BUILD_ID --template-scripts --after-install "release/afterinstall.sh" --url "http://molo.ch" --description "Moloch Full Packet System" -d perl-libwww-perl -d perl-JSON -d ethtool -d libyaml-devel -d libasan-static /data/moloch
                   aws s3 cp --quiet moloch*.x86_64.rpm s3://files.molo.ch/sanitize/moloch-${MOLOCH_FILE_NAME}.centos7.x86_64.rpm --acl public-read
                   aws s3api put-object-acl --bucket files.molo.ch --key sanitize/moloch-${MOLOCH_FILE_NAME}.centos7.x86_64.rpm --acl public-read
                 fi
@@ -103,7 +103,7 @@ jobs:
             - build-package: |
                 export MOLOCH_VERSION=`sed 's/.*"\(.*\)\".*$/\1/' /data/moloch/viewer/version.js`
                 if [ "$GIT_BRANCH" = "$MOLOCH_COPY_BRANCH" ]; then
-                  fpm -s dir -t deb -n moloch -x /data/moloch/logs -x /data/moloch/raw -v $MOLOCH_VERSION --iteration $SD_BUILD_ID --template-scripts --after-install "release/afterinstall.sh" --url "http://molo.ch" --description "Moloch Full Packet System" -d libwww-perl -d libjson-perl -d ethtool -d libyaml-dev /data/moloch
+                  fpm -s dir -t deb -n moloch -x data/moloch/logs -x data/moloch/raw -v $MOLOCH_VERSION --iteration $SD_BUILD_ID --template-scripts --after-install "release/afterinstall.sh" --url "http://molo.ch" --description "Moloch Full Packet System" -d libwww-perl -d libjson-perl -d ethtool -d libyaml-dev /data/moloch
                   aws s3 cp --quiet moloch*amd64.deb s3://files.molo.ch/moloch-${MOLOCH_FILE_NAME}_ubuntu14_amd64.deb --acl public-read
                   aws s3api put-object-acl --bucket files.molo.ch --key moloch-${MOLOCH_FILE_NAME}_ubuntu14_amd64.deb --acl public-read
                 fi
@@ -131,7 +131,7 @@ jobs:
             - build-package: |
                 export MOLOCH_VERSION=`sed 's/.*"\(.*\)\".*$/\1/' /data/moloch/viewer/version.js`
                 if [ "$GIT_BRANCH" = "$MOLOCH_COPY_BRANCH" ]; then
-                  fpm -s dir -t deb -n moloch -x /data/moloch/logs -x /data/moloch/raw -v $MOLOCH_VERSION --iteration $SD_BUILD_ID --template-scripts --after-install "release/afterinstall.sh" --url "http://molo.ch" --description "Moloch Full Packet System" -d libwww-perl -d libjson-perl -d ethtool -d libyaml-dev /data/moloch
+                  fpm -s dir -t deb -n moloch -x data/moloch/logs -x data/moloch/raw -v $MOLOCH_VERSION --iteration $SD_BUILD_ID --template-scripts --after-install "release/afterinstall.sh" --url "http://molo.ch" --description "Moloch Full Packet System" -d libwww-perl -d libjson-perl -d ethtool -d libyaml-dev /data/moloch
                   aws s3 cp --quiet moloch*amd64.deb s3://files.molo.ch/moloch-${MOLOCH_FILE_NAME}_ubuntu16_amd64.deb --acl public-read
                   aws s3api put-object-acl --bucket files.molo.ch --key moloch-${MOLOCH_FILE_NAME}_ubuntu16_amd64.deb --acl public-read
                 fi
@@ -160,7 +160,7 @@ jobs:
             - build-package: |
                 export MOLOCH_VERSION=`sed 's/.*"\(.*\)\".*$/\1/' /data/moloch/viewer/version.js`
                 if [ "$GIT_BRANCH" = "$MOLOCH_COPY_BRANCH" ]; then
-                  fpm -s dir -t deb -n moloch -x /data/moloch/logs -x /data/moloch/raw -v $MOLOCH_VERSION --iteration $SD_BUILD_ID --template-scripts --after-install "release/afterinstall.sh" --url "http://molo.ch" --description "Moloch Full Packet System" -d libwww-perl -d libjson-perl -d ethtool -d libyaml-dev /data/moloch
+                  fpm -s dir -t deb -n moloch -x data/moloch/logs -x data/moloch/raw -v $MOLOCH_VERSION --iteration $SD_BUILD_ID --template-scripts --after-install "release/afterinstall.sh" --url "http://molo.ch" --description "Moloch Full Packet System" -d libwww-perl -d libjson-perl -d ethtool -d libyaml-dev /data/moloch
                   aws s3 cp --quiet moloch*amd64.deb s3://files.molo.ch/sanitize/moloch-${MOLOCH_FILE_NAME}_ubuntu16_amd64.deb --acl public-read
                   aws s3api put-object-acl --bucket files.molo.ch --key sanitize/moloch-${MOLOCH_FILE_NAME}_ubuntu16_amd64.deb --acl public-read
                 fi
@@ -183,7 +183,7 @@ jobs:
             - build-package: |
                 export MOLOCH_VERSION=`sed 's/.*"\(.*\)\".*$/\1/' /data/moloch/viewer/version.js`
                 if [ "$GIT_BRANCH" = "$MOLOCH_COPY_BRANCH" ]; then
-                  fpm -s dir -t deb -n moloch -x /data/moloch/logs -x /data/moloch/raw -v $MOLOCH_VERSION --iteration $SD_BUILD_ID --template-scripts --after-install "release/afterinstall.sh" --url "http://molo.ch" --description "Moloch Full Packet System" -d libwww-perl -d libjson-perl -d ethtool -d libyaml-dev /data/moloch
+                  fpm -s dir -t deb -n moloch -x data/moloch/logs -x data/moloch/raw -v $MOLOCH_VERSION --iteration $SD_BUILD_ID --template-scripts --after-install "release/afterinstall.sh" --url "http://molo.ch" --description "Moloch Full Packet System" -d libwww-perl -d libjson-perl -d ethtool -d libyaml-dev /data/moloch
                   aws s3 cp --quiet moloch*amd64.deb s3://files.molo.ch/moloch-${MOLOCH_FILE_NAME}_ubuntu18_amd64.deb --acl public-read
                   aws s3api put-object-acl --bucket files.molo.ch --key moloch-${MOLOCH_FILE_NAME}_ubuntu18_amd64.deb --acl public-read
                 fi

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -30,7 +30,7 @@ jobs:
             - build-package: |
                 export MOLOCH_VERSION=`sed 's/.*"\(.*\)\".*$/\1/' /data/moloch/viewer/version.js | tr "-" "_"`
                 if [ "$GIT_BRANCH" = "$MOLOCH_COPY_BRANCH" ]; then
-                  scl enable rh-ruby23 "/opt/rh/rh-ruby23/root/usr/local/bin/fpm -s dir -t rpm -n moloch -v $MOLOCH_VERSION --iteration $SD_BUILD_ID --template-scripts --after-install 'release/afterinstall.sh' --url "http://molo.ch" --description 'Moloch Full Packet System' -d perl-libwww-perl -d perl-JSON -d ethtool -d libyaml-devel /data/moloch"
+                  scl enable rh-ruby23 "/opt/rh/rh-ruby23/root/usr/local/bin/fpm -s dir -t rpm -n moloch -x /data/moloch/logs -x /data/moloch/raw -v $MOLOCH_VERSION --iteration $SD_BUILD_ID --template-scripts --after-install 'release/afterinstall.sh' --url "http://molo.ch" --description 'Moloch Full Packet System' -d perl-libwww-perl -d perl-JSON -d ethtool -d libyaml-devel /data/moloch"
                   scl enable python27 "aws s3 cp --quiet moloch*.x86_64.rpm s3://files.molo.ch/moloch-${MOLOCH_FILE_NAME}.centos6.x86_64.rpm --acl public-read"
                   scl enable python27 "aws s3api put-object-acl --bucket files.molo.ch --key moloch-${MOLOCH_FILE_NAME}.centos6.x86_64.rpm --acl public-read"
                 fi
@@ -53,7 +53,7 @@ jobs:
             - build-package: |
                 export MOLOCH_VERSION=`sed 's/.*"\(.*\)\".*$/\1/' /data/moloch/viewer/version.js | tr "-" "_"`
                 if [ "$GIT_BRANCH" = "$MOLOCH_COPY_BRANCH" ]; then
-                  fpm -s dir -t rpm -n moloch -v $MOLOCH_VERSION --iteration $SD_BUILD_ID --template-scripts --after-install "release/afterinstall.sh" --url "http://molo.ch" --description "Moloch Full Packet System" -d perl-libwww-perl -d perl-JSON -d ethtool -d libyaml-devel /data/moloch
+                  fpm -s dir -t rpm -n moloch -x /data/moloch/logs -x /data/moloch/raw -v $MOLOCH_VERSION --iteration $SD_BUILD_ID --template-scripts --after-install "release/afterinstall.sh" --url "http://molo.ch" --description "Moloch Full Packet System" -d perl-libwww-perl -d perl-JSON -d ethtool -d libyaml-devel /data/moloch
                   aws s3 cp --quiet moloch*.x86_64.rpm s3://files.molo.ch/moloch-${MOLOCH_FILE_NAME}.centos7.x86_64.rpm --acl public-read
                   aws s3api put-object-acl --bucket files.molo.ch --key moloch-${MOLOCH_FILE_NAME}.centos7.x86_64.rpm --acl public-read
                 fi
@@ -81,7 +81,7 @@ jobs:
             - build-package: |
                 export MOLOCH_VERSION=`sed 's/.*"\(.*\)\".*$/\1/' /data/moloch/viewer/version.js | tr "-" "_"`
                 if [ "$GIT_BRANCH" = "$MOLOCH_COPY_BRANCH" ]; then
-                  fpm -s dir -t rpm -n moloch -v $MOLOCH_VERSION --iteration $SD_BUILD_ID --template-scripts --after-install "release/afterinstall.sh" --url "http://molo.ch" --description "Moloch Full Packet System" -d perl-libwww-perl -d perl-JSON -d ethtool -d libyaml-devel -d libasan-static /data/moloch
+                  fpm -s dir -t rpm -n moloch -x /data/moloch/logs -x /data/moloch/raw -v $MOLOCH_VERSION --iteration $SD_BUILD_ID --template-scripts --after-install "release/afterinstall.sh" --url "http://molo.ch" --description "Moloch Full Packet System" -d perl-libwww-perl -d perl-JSON -d ethtool -d libyaml-devel -d libasan-static /data/moloch
                   aws s3 cp --quiet moloch*.x86_64.rpm s3://files.molo.ch/sanitize/moloch-${MOLOCH_FILE_NAME}.centos7.x86_64.rpm --acl public-read
                   aws s3api put-object-acl --bucket files.molo.ch --key sanitize/moloch-${MOLOCH_FILE_NAME}.centos7.x86_64.rpm --acl public-read
                 fi
@@ -103,7 +103,7 @@ jobs:
             - build-package: |
                 export MOLOCH_VERSION=`sed 's/.*"\(.*\)\".*$/\1/' /data/moloch/viewer/version.js`
                 if [ "$GIT_BRANCH" = "$MOLOCH_COPY_BRANCH" ]; then
-                  fpm -s dir -t deb -n moloch -v $MOLOCH_VERSION --iteration $SD_BUILD_ID --template-scripts --after-install "release/afterinstall.sh" --url "http://molo.ch" --description "Moloch Full Packet System" -d libwww-perl -d libjson-perl -d ethtool -d libyaml-dev /data/moloch
+                  fpm -s dir -t deb -n moloch -x /data/moloch/logs -x /data/moloch/raw -v $MOLOCH_VERSION --iteration $SD_BUILD_ID --template-scripts --after-install "release/afterinstall.sh" --url "http://molo.ch" --description "Moloch Full Packet System" -d libwww-perl -d libjson-perl -d ethtool -d libyaml-dev /data/moloch
                   aws s3 cp --quiet moloch*amd64.deb s3://files.molo.ch/moloch-${MOLOCH_FILE_NAME}_ubuntu14_amd64.deb --acl public-read
                   aws s3api put-object-acl --bucket files.molo.ch --key moloch-${MOLOCH_FILE_NAME}_ubuntu14_amd64.deb --acl public-read
                 fi
@@ -131,7 +131,7 @@ jobs:
             - build-package: |
                 export MOLOCH_VERSION=`sed 's/.*"\(.*\)\".*$/\1/' /data/moloch/viewer/version.js`
                 if [ "$GIT_BRANCH" = "$MOLOCH_COPY_BRANCH" ]; then
-                  fpm -s dir -t deb -n moloch -v $MOLOCH_VERSION --iteration $SD_BUILD_ID --template-scripts --after-install "release/afterinstall.sh" --url "http://molo.ch" --description "Moloch Full Packet System" -d libwww-perl -d libjson-perl -d ethtool -d libyaml-dev /data/moloch
+                  fpm -s dir -t deb -n moloch -x /data/moloch/logs -x /data/moloch/raw -v $MOLOCH_VERSION --iteration $SD_BUILD_ID --template-scripts --after-install "release/afterinstall.sh" --url "http://molo.ch" --description "Moloch Full Packet System" -d libwww-perl -d libjson-perl -d ethtool -d libyaml-dev /data/moloch
                   aws s3 cp --quiet moloch*amd64.deb s3://files.molo.ch/moloch-${MOLOCH_FILE_NAME}_ubuntu16_amd64.deb --acl public-read
                   aws s3api put-object-acl --bucket files.molo.ch --key moloch-${MOLOCH_FILE_NAME}_ubuntu16_amd64.deb --acl public-read
                 fi
@@ -160,7 +160,7 @@ jobs:
             - build-package: |
                 export MOLOCH_VERSION=`sed 's/.*"\(.*\)\".*$/\1/' /data/moloch/viewer/version.js`
                 if [ "$GIT_BRANCH" = "$MOLOCH_COPY_BRANCH" ]; then
-                  fpm -s dir -t deb -n moloch -v $MOLOCH_VERSION --iteration $SD_BUILD_ID --template-scripts --after-install "release/afterinstall.sh" --url "http://molo.ch" --description "Moloch Full Packet System" -d libwww-perl -d libjson-perl -d ethtool -d libyaml-dev /data/moloch
+                  fpm -s dir -t deb -n moloch -x /data/moloch/logs -x /data/moloch/raw -v $MOLOCH_VERSION --iteration $SD_BUILD_ID --template-scripts --after-install "release/afterinstall.sh" --url "http://molo.ch" --description "Moloch Full Packet System" -d libwww-perl -d libjson-perl -d ethtool -d libyaml-dev /data/moloch
                   aws s3 cp --quiet moloch*amd64.deb s3://files.molo.ch/sanitize/moloch-${MOLOCH_FILE_NAME}_ubuntu16_amd64.deb --acl public-read
                   aws s3api put-object-acl --bucket files.molo.ch --key sanitize/moloch-${MOLOCH_FILE_NAME}_ubuntu16_amd64.deb --acl public-read
                 fi
@@ -183,7 +183,7 @@ jobs:
             - build-package: |
                 export MOLOCH_VERSION=`sed 's/.*"\(.*\)\".*$/\1/' /data/moloch/viewer/version.js`
                 if [ "$GIT_BRANCH" = "$MOLOCH_COPY_BRANCH" ]; then
-                  fpm -s dir -t deb -n moloch -v $MOLOCH_VERSION --iteration $SD_BUILD_ID --template-scripts --after-install "release/afterinstall.sh" --url "http://molo.ch" --description "Moloch Full Packet System" -d libwww-perl -d libjson-perl -d ethtool -d libyaml-dev /data/moloch
+                  fpm -s dir -t deb -n moloch -x /data/moloch/logs -x /data/moloch/raw -v $MOLOCH_VERSION --iteration $SD_BUILD_ID --template-scripts --after-install "release/afterinstall.sh" --url "http://molo.ch" --description "Moloch Full Packet System" -d libwww-perl -d libjson-perl -d ethtool -d libyaml-dev /data/moloch
                   aws s3 cp --quiet moloch*amd64.deb s3://files.molo.ch/moloch-${MOLOCH_FILE_NAME}_ubuntu18_amd64.deb --acl public-read
                   aws s3api put-object-acl --bucket files.molo.ch --key moloch-${MOLOCH_FILE_NAME}_ubuntu18_amd64.deb --acl public-read
                 fi


### PR DESCRIPTION
Modifies all `fpm` commands to exclude the `logs` and `raw` directories, which are created in the administrative `Configure` process anyway.

This _should_ fix #963, but I do not have an fpm environment to test.