### PR TITLE
Initial tcp session seq numbers with first packet values.

### DIFF
--- a/capture/packet.c
+++ b/capture/packet.c
@@ -633,6 +633,10 @@ LOCAL void *moloch_packet_thread(void *threadp)
                     session->port1 = ntohs(tcphdr->th_sport);
                     session->port2 = ntohs(tcphdr->th_dport);
                 }
+
+                session->tcpSeq[0] = ntohl(tcphdr->th_seq);
+                session->tcpSeq[1] = ntohl(tcphdr->th_ack);
+
                 if (moloch_http_is_moloch(session->h_hash, sessionId)) {
                     if (config.debug) {
                         char buf[1000];

--- a/tests/pcap/single-packets.test
+++ b/tests/pcap/single-packets.test
@@ -102,7 +102,7 @@
             "protocolCnt" : 2,
             "segmentCnt" : 1,
             "srcBytes" : 628,
-            "srcDataBytes" : 0,
+            "srcDataBytes" : 574,
             "srcIp" : "192.168.25.150",
             "srcMac" : [
                "00:0c:29:6f:84:37"
@@ -113,6 +113,7 @@
             ],
             "srcOuiCnt" : 1,
             "srcPackets" : 1,
+            "srcPayload8" : "474554202f616374",
             "srcPort" : 49677,
             "srcRIR" : "ARIN",
             "tcpflags" : {
@@ -128,7 +129,7 @@
             },
             "timestamp" : "SET",
             "totBytes" : 628,
-            "totDataBytes" : 0,
+            "totDataBytes" : 574,
             "totPackets" : 1
          },
          "header" : {
@@ -277,7 +278,7 @@
             "protocolCnt" : 2,
             "segmentCnt" : 1,
             "srcBytes" : 1378,
-            "srcDataBytes" : 0,
+            "srcDataBytes" : 1324,
             "srcIp" : "192.168.25.150",
             "srcMac" : [
                "00:0c:29:6f:84:37"
@@ -288,6 +289,7 @@
             ],
             "srcOuiCnt" : 1,
             "srcPackets" : 1,
+            "srcPayload8" : "474554202f486f74",
             "srcPort" : 49654,
             "srcRIR" : "ARIN",
             "tcpflags" : {
@@ -303,7 +305,7 @@
             },
             "timestamp" : "SET",
             "totBytes" : 1378,
-            "totDataBytes" : 0,
+            "totDataBytes" : 1324,
             "totPackets" : 1
          },
          "header" : {
@@ -414,7 +416,7 @@
             "protocolCnt" : 2,
             "segmentCnt" : 1,
             "srcBytes" : 454,
-            "srcDataBytes" : 0,
+            "srcDataBytes" : 400,
             "srcIp" : "192.168.25.150",
             "srcMac" : [
                "00:0c:29:6f:84:37"
@@ -425,6 +427,7 @@
             ],
             "srcOuiCnt" : 1,
             "srcPackets" : 1,
+            "srcPayload8" : "474554202f757365",
             "srcPort" : 49683,
             "srcRIR" : "ARIN",
             "tcpflags" : {
@@ -440,7 +443,7 @@
             },
             "timestamp" : "SET",
             "totBytes" : 454,
-            "totDataBytes" : 0,
+            "totDataBytes" : 400,
             "totPackets" : 1
          },
          "header" : {
@@ -574,7 +577,7 @@
             "protocolCnt" : 2,
             "segmentCnt" : 1,
             "srcBytes" : 670,
-            "srcDataBytes" : 0,
+            "srcDataBytes" : 616,
             "srcIp" : "192.168.25.150",
             "srcMac" : [
                "00:0c:29:6f:84:37"
@@ -585,6 +588,7 @@
             ],
             "srcOuiCnt" : 1,
             "srcPackets" : 1,
+            "srcPayload8" : "504f5354202f5254",
             "srcPort" : 49708,
             "srcRIR" : "ARIN",
             "tcpflags" : {
@@ -600,7 +604,7 @@
             },
             "timestamp" : "SET",
             "totBytes" : 670,
-            "totDataBytes" : 0,
+            "totDataBytes" : 616,
             "totPackets" : 1
          },
          "header" : {
@@ -739,7 +743,7 @@
             "protocolCnt" : 2,
             "segmentCnt" : 1,
             "srcBytes" : 632,
-            "srcDataBytes" : 0,
+            "srcDataBytes" : 578,
             "srcIp" : "192.168.25.150",
             "srcMac" : [
                "00:0c:29:6f:84:37"
@@ -750,6 +754,7 @@
             ],
             "srcOuiCnt" : 1,
             "srcPackets" : 1,
+            "srcPayload8" : "474554202f3f6369",
             "srcPort" : 49735,
             "srcRIR" : "ARIN",
             "tcpflags" : {
@@ -765,7 +770,7 @@
             },
             "timestamp" : "SET",
             "totBytes" : 632,
-            "totDataBytes" : 0,
+            "totDataBytes" : 578,
             "totPackets" : 1
          },
          "header" : {
@@ -913,7 +918,7 @@
             "protocolCnt" : 2,
             "segmentCnt" : 1,
             "srcBytes" : 816,
-            "srcDataBytes" : 0,
+            "srcDataBytes" : 762,
             "srcIp" : "192.168.25.150",
             "srcMac" : [
                "00:0c:29:6f:84:37"
@@ -924,6 +929,7 @@
             ],
             "srcOuiCnt" : 1,
             "srcPackets" : 1,
+            "srcPayload8" : "474554202f722f63",
             "srcPort" : 49733,
             "srcRIR" : "ARIN",
             "tcpflags" : {
@@ -939,7 +945,7 @@
             },
             "timestamp" : "SET",
             "totBytes" : 816,
-            "totDataBytes" : 0,
+            "totDataBytes" : 762,
             "totPackets" : 1
          },
          "header" : {
@@ -1053,7 +1059,7 @@
             "protocolCnt" : 2,
             "segmentCnt" : 1,
             "srcBytes" : 558,
-            "srcDataBytes" : 0,
+            "srcDataBytes" : 504,
             "srcIp" : "192.168.25.150",
             "srcMac" : [
                "00:0c:29:6f:84:37"
@@ -1064,6 +1070,7 @@
             ],
             "srcOuiCnt" : 1,
             "srcPackets" : 1,
+            "srcPayload8" : "474554202f6d6170",
             "srcPort" : 49743,
             "srcRIR" : "ARIN",
             "tcpflags" : {
@@ -1079,7 +1086,7 @@
             },
             "timestamp" : "SET",
             "totBytes" : 558,
-            "totDataBytes" : 0,
+            "totDataBytes" : 504,
             "totPackets" : 1
          },
          "header" : {
@@ -1217,7 +1224,7 @@
             "protocolCnt" : 2,
             "segmentCnt" : 1,
             "srcBytes" : 925,
-            "srcDataBytes" : 0,
+            "srcDataBytes" : 871,
             "srcIp" : "192.168.25.150",
             "srcMac" : [
                "00:0c:29:6f:84:37"
@@ -1228,6 +1235,7 @@
             ],
             "srcOuiCnt" : 1,
             "srcPackets" : 1,
+            "srcPayload8" : "474554202f616e61",
             "srcPort" : 49738,
             "srcRIR" : "ARIN",
             "tcpflags" : {
@@ -1243,7 +1251,7 @@
             },
             "timestamp" : "SET",
             "totBytes" : 925,
-            "totDataBytes" : 0,
+            "totDataBytes" : 871,
             "totPackets" : 1
          },
          "header" : {
@@ -1332,7 +1340,7 @@
             "segmentCnt" : 1,
             "srcASN" : "AS26496 GoDaddy.com, LLC",
             "srcBytes" : 243,
-            "srcDataBytes" : 0,
+            "srcDataBytes" : 189,
             "srcGEO" : "US",
             "srcIp" : "68.178.213.61",
             "srcMac" : [
@@ -1344,6 +1352,7 @@
             ],
             "srcOuiCnt" : 1,
             "srcPackets" : 1,
+            "srcPayload8" : "485454502f312e30",
             "srcPort" : 80,
             "srcRIR" : "ARIN",
             "tcpflags" : {
@@ -1359,7 +1368,7 @@
             },
             "timestamp" : "SET",
             "totBytes" : 243,
-            "totDataBytes" : 0,
+            "totDataBytes" : 189,
             "totPackets" : 1
          },
          "header" : {


### PR DESCRIPTION
* Fixes #1004

<!-- Provide a clear and descriptive title -->

**Clearly describe the problem and solution**

**Relevant issue number(s) if applicable**

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**
