### PR TITLE
Install Java when using "easybutton"

### DIFF
--- a/release/Configure
+++ b/release/Configure
@@ -146,6 +146,7 @@ if [ "$MOLOCH_LOCALELASTICSEARCH" == "yes" ]; then
     echo "Moloch - Downloading and installing demo OSS version of Elasticsearch"
     ES_VERSION=6.5.4
     if [ -f "/etc/redhat-release" ]; then
+        yum install java-openjdk-headless
         yum install https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-${ES_VERSION}.rpm
     else
         wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-${ES_VERSION}.deb

--- a/release/Configure
+++ b/release/Configure
@@ -147,7 +147,7 @@ if [ "$MOLOCH_LOCALELASTICSEARCH" == "yes" ]; then
     ES_VERSION=6.5.4
     if [ -f "/etc/redhat-release" ]; then
         if ! [ -x "$(command -v java)" ]; then
-			    yum install java-openjdk-headless
+          yum install java-openjdk-headless
         fi
         yum install https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-${ES_VERSION}.rpm
     else

--- a/release/Configure
+++ b/release/Configure
@@ -147,7 +147,7 @@ if [ "$MOLOCH_LOCALELASTICSEARCH" == "yes" ]; then
     ES_VERSION=6.5.4
     if [ -f "/etc/redhat-release" ]; then
         if ! [ -x "$(command -v java)" ]; then
-			      yum install java-openjdk-headless
+			    yum install java-openjdk-headless
         fi
         yum install https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-${ES_VERSION}.rpm
     else

--- a/release/Configure
+++ b/release/Configure
@@ -146,7 +146,9 @@ if [ "$MOLOCH_LOCALELASTICSEARCH" == "yes" ]; then
     echo "Moloch - Downloading and installing demo OSS version of Elasticsearch"
     ES_VERSION=6.5.4
     if [ -f "/etc/redhat-release" ]; then
-        yum install java-openjdk-headless
+        if ! [ -x "$(command -v java)" ]; then
+			      yum install java-openjdk-headless
+        fi
         yum install https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-${ES_VERSION}.rpm
     else
         wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-${ES_VERSION}.deb


### PR DESCRIPTION
Installation of Elasticsearch failed on CentOS/RHEL due to missing java (not a dependency for elasticsearch rpm).
Just added the installation of openjdk.