### PR TITLE
Handle RAW IPV4 pcap layertype

### DIFF
--- a/capture/packet.c
+++ b/capture/packet.c
@@ -1869,6 +1869,9 @@ void moloch_packet_batch(MolochPacketBatch_t * batch, MolochPacket_t * const pac
     case 127: // radiotap
         rc = moloch_packet_radiotap(batch, packet, packet->pkt, packet->pktlen);
         break;
+    case 228: //RAW IPv4
+        rc = moloch_packet_ip4(batch, packet, packet->pkt, packet->pktlen);
+        break;
     case 239: // NFLOG
         rc = moloch_packet_nflog(batch, packet, packet->pkt, packet->pktlen);
         break;


### PR DESCRIPTION
Problem: moloch-capture fails to load a pcap file with the link layer header type 228 (RAW IPv4). However, the handler link layer header type 101 (RAW) works as written. See comments on #661 

Fix: Added a switch for handling pcap link layer header type 228 which is semantically the same as RAW but only contains IPv4 packets instead of both IPv4 and IPv6 packets.

Fixes #661 