### PR TITLE
Add Open Index and Close Index entries to action menu in ES Indices tab

### DIFF
--- a/viewer/db.js
+++ b/viewer/db.js
@@ -300,6 +300,28 @@ exports.optimizeIndex = function (index, options, cb) {
   return internals.elasticSearchClient.indices.forcemerge(params, cb);
 };
 
+// This API does not call fixIndex
+exports.closeIndex = function (index, options, cb) {
+  if (!cb) {
+    cb = options;
+    options = undefined;
+  }
+  var params = {index: index};
+  exports.merge(params, options);
+  return internals.elasticSearchClient.indices.close(params, cb);
+};
+
+// This API does not call fixIndex
+exports.openIndex = function (index, options, cb) {
+  if (!cb) {
+    cb = options;
+    options = undefined;
+  }
+  var params = {index: index};
+  exports.merge(params, options);
+  return internals.elasticSearchClient.indices.open(params, cb);
+};
+
 exports.indexStats = function(index, cb) {
   return internals.elasticSearchClient.indices.stats({index: fixIndex(index)}, cb);
 };

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -3279,7 +3279,7 @@ app.post('/esindices/:index/optimize', logAction(), checkCookieToken, function(r
   if (!req.user.createEnabled) { return res.molochError(403, 'Need admin privileges'); }
 
   if (!req.params.index) {
-    return res.molochError(403, 'Missing index to delete');
+    return res.molochError(403, 'Missing index to optimize');
   }
 
   Db.optimizeIndex([req.params.index], {}, (err, result) => {
@@ -3289,6 +3289,39 @@ app.post('/esindices/:index/optimize', logAction(), checkCookieToken, function(r
   });
 
   // Always return right away, optimizeIndex might block
+  return res.send(JSON.stringify({ success: true, text: {} }));
+});
+
+app.post('/esindices/:index/close', logAction(), checkCookieToken, function(req, res) {
+  if (!req.user.createEnabled) { return res.molochError(403, 'Need admin privileges'); }
+
+  if (!req.params.index) {
+    return res.molochError(403, 'Missing index to close');
+  }
+
+  Db.closeIndex([req.params.index], {}, (err, result) => {
+    if (err) {
+      res.status(404);
+      return res.send(JSON.stringify({ success:false, text:'Error closing index' }));
+    }
+    return res.send(JSON.stringify({ success: true, text: result }));
+  });
+});
+
+app.post('/esindices/:index/open', logAction(), checkCookieToken, function(req, res) {
+  if (!req.user.createEnabled) { return res.molochError(403, 'Need admin privileges'); }
+
+  if (!req.params.index) {
+    return res.molochError(403, 'Missing index to open');
+  }
+
+  Db.openIndex([req.params.index], {}, (err, result) => {
+    if (err) {
+      console.log ("ERROR -", req.params.index, "open failed", err);
+    }
+  });
+
+  // Always return right away, openIndex might block
   return res.send(JSON.stringify({ success: true, text: {} }));
 });
 

--- a/viewer/vueapp/src/components/stats/EsIndices.vue
+++ b/viewer/vueapp/src/components/stats/EsIndices.vue
@@ -45,6 +45,14 @@
               @click="optimizeIndex(item.index)">
               Optimize Index {{ item.index }}
             </b-dropdown-item>
+            <b-dropdown-item
+              @click="closeIndex(item.index)">
+              Close Index {{ item.index }}
+            </b-dropdown-item>
+            <b-dropdown-item
+              @click="openIndex(item.index)">
+              Open Index {{ item.index }}
+            </b-dropdown-item>
           </b-dropdown>
         </template>
       </moloch-table>
@@ -177,6 +185,20 @@ export default {
     },
     optimizeIndex (indexName) {
       this.$http.post(`esindices/${indexName}/optimize`)
+        .then((response) => {
+        }, (error) => {
+          this.$emit('errored', error.text || error);
+        });
+    },
+    closeIndex (indexName) {
+      this.$http.post(`esindices/${indexName}/close`)
+        .then((response) => {
+        }, (error) => {
+          this.$emit('errored', error.text || error);
+        });
+    },
+    openIndex (indexName) {
+      this.$http.post(`esindices/${indexName}/open`)
         .then((response) => {
         }, (error) => {
           this.$emit('errored', error.text || error);


### PR DESCRIPTION
This adds an "Open Index" and "Close Index" entry to the action menu for indices on the ES Indices tab.

![screenshot-20190605_083355](https://user-images.githubusercontent.com/47364876/58964812-c605d700-876c-11e9-9266-25d669b8c8fa.png)

I have basically just mimicked the existing code for Delete Index and Optimize Index [using the official Elasticsearch JS API.](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-open-close.html)

The new functions seem to work correctly (the indexes are opened and closed as expected):

Close:
```
elasticsearch_1  | [2019-06-05T14:21:59,931][INFO ][o.e.c.m.MetaDataIndexStateService] [GVur8ER] closing indices [sessions2-181130/1qe3m0euRS2TjB6jphZvcA]
elasticsearch_1  | [2019-06-05T14:21:59,979][INFO ][o.e.c.m.MetaDataIndexStateService] [GVur8ER] completed closing of indices [sessions2-181130]
```

Open:
```
elasticsearch_1  | [2019-06-05T14:37:27,278][INFO ][o.e.c.m.MetaDataIndexStateService] [GVur8ER] opening indices [[sessions2-181202/9NgurJ2eTjqnyRd1NgGldQ]]
elasticsearch_1  | [2019-06-05T14:37:27,390][INFO ][o.e.c.r.a.AllocationService] [GVur8ER] Cluster health status changed from [RED] to [YELLOW] (reason: [shards started [[sessions2-181202][0]] ...]).
```

There are some improvements that could be made to it still:

- Both "open" and "close" are available even for indexes that are already opened or closed. In other words, the existing index state is not taken into account before presenting the option. This is not a huge deal, though, because if you try to open an already opened index (or close an already closed index) it doesn't do anything.
- Issue #1075 has been logged for the table not handling NaN values

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

Yes, I did run it, but all of the errors seemed to be related to stuff that didn't have anything to do with my change...

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

I really tried to, but with my environment the tests.pl script wouldn't start up a local elasticsearch instance, so I wasn't able to. But the change is very minor, doesn't change any existing code (only adds a few new functions) and the things around it have been tested manually in the viewer. Please feel free to correct or adjust it if you feel to do so.