### PR TITLE
Support multi-processes per capture interface with tpacketv3

### DIFF
--- a/capture/reader-tpacketv3.c
+++ b/capture/reader-tpacketv3.c
@@ -213,6 +213,7 @@ void reader_tpacketv3_init(char *UNUSED(name))
         }
     }
 
+    int fanout_group_id = moloch_config_int(NULL, "tpacketv3ClusterId", 0x0000, 0x0000, 0xffff);
 
     for (i = 0; i < MAX_INTERFACES && config.interface[i]; i++) {
         MOLOCH_LOCK_INIT(infos[i].lock);
@@ -273,7 +274,6 @@ void reader_tpacketv3_init(char *UNUSED(name))
         if (bind(infos[i].fd, (struct sockaddr *) &ll, sizeof(ll)) < 0)
             LOGEXIT("Error binding %s: %s", config.interface[i], strerror(errno));
         
-        int fanout_group_id = moloch_config_int(NULL, "tpacketv3ClusterId", 0x0000, 0x0000, 0xffff);
         if (fanout_group_id != 0) {
             int fanout_type = PACKET_FANOUT_HASH;
             int fanout_arg = (fanout_group_id | (fanout_type << 16));

--- a/capture/reader-tpacketv3.c
+++ b/capture/reader-tpacketv3.c
@@ -272,6 +272,14 @@ void reader_tpacketv3_init(char *UNUSED(name))
 
         if (bind(infos[i].fd, (struct sockaddr *) &ll, sizeof(ll)) < 0)
             LOGEXIT("Error binding %s: %s", config.interface[i], strerror(errno));
+        
+        int fanout_group_id = moloch_config_int(NULL, "tpacketv3ClusterId", 0x0000, 0x0000, 0xffff);
+        if(fanout_group_id != 0) {
+            int fanout_type = PACKET_FANOUT_HASH;
+            int fanout_arg = (fanout_group_id | (fanout_type << 16));
+            if(setsockopt(infos[i].fd, SOL_PACKET, PACKET_FANOUT, &fanout_arg, sizeof(fanout_arg)) < 0)
+                LOGEXIT("Error setting packet fanout parameters: (%d,%s)", fanout_group_id, strerror(errno));
+        }
     }
 
     if (i == MAX_INTERFACES) {

--- a/capture/reader-tpacketv3.c
+++ b/capture/reader-tpacketv3.c
@@ -274,7 +274,7 @@ void reader_tpacketv3_init(char *UNUSED(name))
             LOGEXIT("Error binding %s: %s", config.interface[i], strerror(errno));
         
         int fanout_group_id = moloch_config_int(NULL, "tpacketv3ClusterId", 0x0000, 0x0000, 0xffff);
-        if(fanout_group_id != 0) {
+        if (fanout_group_id != 0) {
             int fanout_type = PACKET_FANOUT_HASH;
             int fanout_arg = (fanout_group_id | (fanout_type << 16));
             if(setsockopt(infos[i].fd, SOL_PACKET, PACKET_FANOUT, &fanout_arg, sizeof(fanout_arg)) < 0)


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->

**Clearly describe the problem and solution**
Running multiple processes per captured interface is possible with PF_RING, but not AF_PACKET/tpacketv3.   This submission adds like-in-kind functionality to tpacketv3 by using native PACKET_FANOUT_HASH capabilities.

**Relevant issue number(s) if applicable**
#1085 

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**
Not applicable

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**
Not applicable

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
