### PR TITLE
contrib verbage changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,9 +82,10 @@ Feature requests are tracked as [GitHub Issues](https://guides.github.com/featur
 **To better help us review your pull request, please follow these guidelines:**
 * Provide a clear and descriptive title
 * Clearly describe the problem and solution
-* Include the relevant issue number(s) if applicable
-* Run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors
-* Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`
+* If changes are made to the capture component, verify all tests in the tests direction pass by running `./tests.pl`
+* If changes are mode to the viewer or parlimant components, run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors
+* Additionally, for any viewer or parliament changes, verify that all UI tests pass by runnning `./tests.pl --viewer`
+* The README file in the tests directory provides additional information on the test cases
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,7 @@ Feature requests are tracked as [GitHub Issues](https://guides.github.com/featur
 **To better help us review your pull request, please follow these guidelines:**
 * Provide a clear and descriptive title
 * Clearly describe the problem and solution
+* Include the relevant issue number(s) if applicable
 * If changes are made to the capture component, verify all tests in the tests direction pass by running `./tests.pl`
 * If changes are mode to the viewer or parlimant components, run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors
 * Additionally, for any viewer or parliament changes, verify that all UI tests pass by runnning `./tests.pl --viewer`


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->
made some changes to the CONTRIB.md file that provide additional info on what tests to run based on whether changes are made to the capture or viewer components

**Clearly describe the problem and solution**
provided additional text that would have been useful as to what tests i needed to run for my set of changes

**Relevant issue number(s) if applicable**

none

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

No.  But I didn't make changes there.

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

No-- and this is part of the confusion in the contrib file i tried to clarify-- as I understand it, "tests.pl --viewer" is only required if changed are made to the viewer/parliament components.  Maybe this text here (eg **Did you Ensure) also needs to be clarified?

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
