### PR TITLE
error check on fopen

### DIFF
--- a/capture/packet.c
+++ b/capture/packet.c
@@ -19,6 +19,7 @@
 #include "patricia.h"
 #include <inttypes.h>
 #include <arpa/inet.h>
+#include <errno.h>
 
 //#define DEBUG_PACKET
 
@@ -850,6 +851,14 @@ LOCAL void moloch_packet_save_unknown_packet(int type, MolochPacket_t * const pa
 
         snprintf(str, sizeof(str), "%s/%s.%d.pcap", config.pcapDir[0], names[type], getpid());
         unknownPacketFile[type] = fopen(str, "w");
+
+	// TODO-- should we also add logic to pick right pcapDir when there are multiple?
+        if (unknownPacketFile[type] == NULL) {
+          LOGEXIT("Unable to open pcap file %s to store unknown type %s.  Error %s", str, names[type], strerror (errno));
+          MOLOCH_UNLOCK(lock);
+          return;
+        }
+
         fwrite(&pcapFileHeader, 24, 1, unknownPacketFile[type]);
     }
 


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->
there's no error checking for fopen () for unknown packet types when we want to stare them as pcaps

**Clearly describe the problem and solution**

added code such that if fopen fails, report why (error) and exit.

**Relevant issue number(s) if applicable**

none

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

not applicable.

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

i ran ./tests.pl and all tests passed

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
