### PR TITLE
check filenane permissions for possible viewer access issue

### DIFF
--- a/capture/reader-libpcap-file.c
+++ b/capture/reader-libpcap-file.c
@@ -21,6 +21,9 @@
 #include <sys/stat.h>
 #include "pcap.h"
 #include "molochconfig.h"
+#include <pwd.h>
+#include <grp.h>
+#include <sys/stat.h>
 
 extern MolochPcapFileHdr_t   pcapFileHeader;
 
@@ -179,6 +182,9 @@ LOCAL void reader_libpcapfile_init_monitor()
 LOCAL int reader_libpcapfile_process(char *filename)
 {
     char         errbuf[1024];
+    char 				 path [256];
+    char         *p;
+    struct 			 stat stats;
 
     if (!realpath(filename, offlinePcapFilename)) {
         LOG("ERROR - pcap open failed - Couldn't realpath file: '%s' with %d", filename, errno);
@@ -195,6 +201,51 @@ LOCAL int reader_libpcapfile_process(char *filename)
         LOG("Can't reprocess %s", filename);
         return 1;
     }
+
+    // check to see if viewer might have access issues to non-copied pcap file
+    if (config.copyPcap == 0) {
+
+      if (strlen (filename) > 255) {
+        // filename bigger than path buffer, skip check
+      } else if ((config.dropUser == NULL) && (config.dropGroup == NULL)) {
+        // drop.User,Group not defined -- skip check
+      } else if (strncmp (filename, "/", 1) != 0) {
+        LOG("WARNING using a relative path may make pcap inaccessible to viewer");
+      } else {
+
+    		path[0] = 0;
+
+        p = strtok (filename, "/");
+
+        while (p != NULL) {
+          // path is being rebuilt to become contents of filename
+          strcat (path, "/");
+          strcat (path, p);
+
+          if (stat(path, &stats) != -1) {
+            struct group *gr = getgrgid (stats.st_gid);
+            struct passwd *pw = getpwuid (stats.st_uid);
+
+            if (stats.st_mode & S_IROTH)  {
+              // world readable
+            } else if ((stats.st_mode & S_IRGRP) && (strcmp (config.dropGroup, gr->gr_name) == 0)) {
+              // group readable, dropGroup matches file group
+              // TODO compare group id values as opposed to group name
+            } else if ((stats.st_mode & S_IRUSR) && (strcmp (config.dropUser, pw->pw_name) == 0)) {
+              // user readable, dropUser matches file user
+              // TODO compare user id values as opposed to user name
+            } else
+              LOG("WARNING -- permission issues with %s might make pcap inaccessible to viewer", path);
+          } else
+            LOG("WARNING -- Can't stat %s.  Pcap might not be accessible to viewer", path);
+
+          p = strtok (NULL, "/");
+        }
+
+        strcpy (filename, path);
+      }
+    }
+
 
     errbuf[0] = 0;
     LOG ("Processing %s", filename);


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->
check filename permissions for possible view access issue

**Clearly describe the problem and solution**
it's possible that when one ingests a capture but doesn't set the --copy flag, that permissions on the path to the capture flag might not be accessible when viewer runs as dropUser and dropGroup.  the purpose of this code change is to generate a warning if path permission issues might be present which would result in the viewer not being able to open the capture file.

**Relevant issue number(s) if applicable**
1088

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**
not relevant

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**
ran ./tests.pl and all tests passed

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
