### PR TITLE
Allow SSL client auth for `usersElasticSearchClient`

### DIFF
--- a/viewer/db.js
+++ b/viewer/db.js
@@ -98,7 +98,7 @@ exports.initialize = function (info, cb) {
         keepAlive: true,
         minSockets: 5,
         maxSockets: 6,
-        ssl: {rejectUnauthorized: !internals.info.insecure, ca: internals.info.ca}
+        ssl: esSSLOptions
       });
     } else {
       internals.usersElasticSearchClient = internals.elasticSearchClient;


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->

**Clearly describe the problem and solution**
In PR https://github.com/aol/moloch/pull/1090 we missed enabling client auth for `usersElasticSearch`.  This addresses the issue.

**Relevant issue number(s) if applicable**

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
