### PR TITLE
Enable implicit creation of users and group-authorization from headers

### DIFF
--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -291,6 +291,9 @@ if (Config.get("passwordSecret")) {
                    }
                  });
               }
+              if (suser) {
+                  userCleanup(suser._source);
+              }
               return next();
            });
 

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -289,7 +289,7 @@ if (Config.get("passwordSecret")) {
                 authorized = true;
              }
           });
-          if(!authorized) {
+          if (!authorized) {
               return res.send("Not authorized");
           }
         }

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -276,7 +276,7 @@ if (Config.get("passwordSecret")) {
       if (req.headers[internals.userNameHeader] !== undefined) {
         var userName = req.headers[internals.userNameHeader];
 
-        var ucb = function(err, suser) {
+        function ucb(err, suser) {
           if (err) {return res.send("ERROR - getUser - user: " + userName + " err:" + err);}
           if (!suser || !suser.found) {return res.send(userName + " doesn't exist");}
           if (!suser._source.enabled) {return res.send(userName + " not enabled");}
@@ -290,7 +290,7 @@ if (Config.get("passwordSecret")) {
         Db.getUserCache(userName, function(err, suser) {
           if (internals.userAutoCreateTmpl === undefined) {
              return ucb(err, suser);
-          } else if ((err && (err+"").includes("Not Found")) ||
+          } else if ((err && err.toString().includes("Not Found")) ||
                      (!suser || !suser.found)) { // Try dynamic creation
              var nuser = JSON.parse(new Function("return `" +
                    internals.userAutoCreateTmpl + "`;").call(req.headers));

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -291,7 +291,7 @@ if (Config.get("passwordSecret")) {
                    }
                  });
               }
-              return;
+              return next();
            });
 
         }


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->

**Clearly describe the problem and solution**
Addresses https://github.com/aol/moloch/issues/1095.   Enables implicit creation of users from HTTP headers when using HTTP header auth.  Assumes that authorization is performed upstream, and allows creation of a "default" user profile whose accesses can be overridden using the customary user management tools provided with moloch.  To enable this functionality, a user would enable header auth and provide a JSON document that describes the user as below:

```
# Enable implicit user creation and auth from header
userNameHeader=http_auth_http_user
userAutoCreateTmpl={"userId": "${this.http_auth_http_user}", "userName": "${this.http_auth_mail}", "enabled": true, "webEnabled": true, "headerAuthEnabled": true, "emailSearch": true, "createEnabled": false, "removeEnabled": false, "packetSearch": true }
```

Also added the capability to deny access to the application if a required Header w/a specified value is not present.  This is useful when the external authentication source (via. apache/sso) is also passing in a authorization group (like LDAP group membership, etc...).  The below sample make the app require a header `UserGroup: MOLOCH_ACCESS` before allowing header-based authentication to occur.
```
# Require that the UserGroup: MOLOCH_ACCESS HTTP header is present
requiredAuthHeader="UserGroup"
requiredAuthHeaderVal="MOLOCH_ACCESS"
```

**Relevant issue number(s) if applicable**

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
