### PR TITLE
fix mpls protocol parsing error

### DIFF
--- a/capture/packet.c
+++ b/capture/packet.c
@@ -1673,7 +1673,7 @@ LOCAL int moloch_packet_mpls(MolochPacketBatch_t * batch, MolochPacket_t * const
             return MOLOCH_PACKET_CORRUPT;
         }
 
-        int S = data[3] & 0x1;
+        int S = data[2] & 0x1;
 
         data += 4;
         len -= 4;


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->

Fix MPLS protocol parsing problem

It is the **third byte** that determines whether current mpls layer is at the stack bottom, not the fourth.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.