### PR TITLE
add case 228 to pcap.js

### DIFF
--- a/viewer/pcap.js
+++ b/viewer/pcap.js
@@ -708,6 +708,9 @@ Pcap.prototype.pcap = function (buffer, obj) {
   case 127: // radiotap
     this.radiotap(buffer.slice(16, obj.pcap.incl_len + 16), obj, 16);
     break;
+  case 228: // RAW
+    this.ip4(buffer.slice(16, obj.pcap.incl_len + 16), obj, 16);
+    break;
   case 239: // NFLOG
     this.nflog(buffer.slice(16, obj.pcap.incl_len + 16), obj, 16);
     break;


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->

**Clearly describe the problem and solution**

case 228 logic is missing from pcap.js in Pcap.prototype.pcap

**Relevant issue number(s) if applicable**

1097

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

yes

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

yes.  note that i had to set my time to ET for all tests to pass.  note that i don't have a pcap with 228 link type to test against.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
