### PR TITLE
Add clustering capabilities for Myricom SNF

### DIFF
--- a/capture/plugins/snf/README.md
+++ b/capture/plugins/snf/README.md
@@ -1,9 +1,18 @@
 The snf reader plugin now works directly with Myricom SNF
-
+  
 Optional settings
 * ```snfNumRings``` number of rings and threads to use per interface
 * ```snfDataRingSize``` SNF_DATARING_SIZE
-* ```snfFlags``` Variable that controls process-sharing (1), port aggregation (2), and packet duplication (3), see SNF documentation for more details.  
+* ```snfFlags``` Variable that controls process-sharing (1), port aggregation (2), and packet duplication (3), see SNF documentation for more details.
+* ```snfNumProcs``` The number of capture processes sharing a given Myricom board
+* ```snfProcNum``` The process number in the sharing cluster (If snfNumProcs=2, one process should have snfProcNum=1, the other =2)
+
+Multiple capture processes per NIC requires some special settings
+* Set the ```SNF_APP_ID``` environment variable to a unique (per host) value
+* Make sure ```snfFlags``` includes the process sharing flag (0x01)
+* Set ```snfNumProcs``` to the numer of capture processes listening on the shared interface
+* Set the ```snfProcNum``` for each process
+
 
 To use:
 * install the snf package on the build hosts and all hosts that will run moloch-capture
@@ -11,4 +20,3 @@ To use:
 * load the snf plugin by changing configuration file so it has reader-snf.so as a rootPlugins ```rootPlugins=reader-snf.so```
 * tell moloch-capture to use snf as the reader method with ```pcapReadMethod=snf`` in your configuration file
 * change ```interface``` to either the OS interface name or snf# where # is the portnum
-


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->

**Clearly describe the problem and solution**
Current Myricom SNF plugin causes Moloch to fail to start if multiple processes are assigned to a given capture board even when environment variables and flags are set properly.  This adds support for clustered multi-process listeners gaining parity with the features in `pfring` and `tpacketv3`/`AF_PACKET`.

The design of this PR requests rings for all 3 processes (which is required in SNF) within each process, but then binds each process to only its rings.  This is accomplished by multiplying the required number of rings by the number of cluster members, and then binding each cluster member to its own slice of rings.

Further details are in the README changes.

**Relevant issue number(s) if applicable**
Addresses: https://github.com/aol/moloch/issues/1118

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
