### PR TITLE
Bugfix: Support add user scripts w/ES Client Auth

### DIFF
--- a/viewer/addUser.js
+++ b/viewer/addUser.js
@@ -132,7 +132,16 @@ if (process.argv.length < 5) {
   help();
 }
 
+// Use Xinsecure instead of insecure as node
+// consumes the --insecure flag anywhere in the command line
+var insecure = process.argv.includes("-Xinsecure") ||
+               process.argv.includes("--Xinsecure");
+
 Db.initialize({host : escInfo,
                prefix: Config.get("prefix", ""),
+               esClientKey: Config.get("esClientKey", null),
+               esClientCert: Config.get("esClientCert", null),
+               esClientKeyPass: Config.get("esClientKeyPass", null),
+               insecure: insecure,
                usersHost: Config.get("usersElasticsearch"),
                usersPrefix: Config.get("usersPrefix")}, main);

--- a/viewer/addUser.js
+++ b/viewer/addUser.js
@@ -43,6 +43,7 @@ function help() {
   console.log("Config Options:");
   console.log("  -c <config file>      Config file to use");
   console.log("  -n <node name>        Node name section to use in config file");
+  console.log("  --insecure            Allow insecure HTTPS");
 
   process.exit(0);
 }
@@ -132,16 +133,11 @@ if (process.argv.length < 5) {
   help();
 }
 
-// Use Xinsecure instead of insecure as node
-// consumes the --insecure flag anywhere in the command line
-var insecure = process.argv.includes("-Xinsecure") ||
-               process.argv.includes("--Xinsecure");
-
 Db.initialize({host : escInfo,
                prefix: Config.get("prefix", ""),
                esClientKey: Config.get("esClientKey", null),
                esClientCert: Config.get("esClientCert", null),
                esClientKeyPass: Config.get("esClientKeyPass", null),
-               insecure: insecure,
+               insecure: Config.insecure,
                usersHost: Config.get("usersElasticsearch"),
                usersPrefix: Config.get("usersPrefix")}, main);


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->

**Clearly describe the problem and solution**
The `addUser.js` was not updated when client-auth support was added to the rest of the project.  This PR adds client-auth and "insecure" capabilities to the `add_user.sh`/`addUser.js` script.

**Relevant issue number(s) if applicable**
https://github.com/aol/moloch/issues/1119

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
