### PR TITLE
Suricata Plugin: Support IANA protocol numbers

### DIFF
--- a/capture/plugins/suricata.c
+++ b/capture/plugins/suricata.c
@@ -337,11 +337,13 @@ LOCAL void suricata_process()
             item->flow_id = g_strndup(line + out[i+2], out[i+3]);
             item->flow_id_len = out[i+3];
         } else if (MATCH(line, "proto")) {
-            if (strncmp("TCP", line + out[i+2], 3) == 0)
+            // Match on prototol by name or by
+            // IANA number: https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
+            if (strncmp("TCP", line + out[i+2], 3) == 0 || strncmp("006", line + out[i+2], 3) == 0)
                 item->ses = SESSION_TCP;
-            else if (strncmp("UDP", line + out[i+2], 3) == 0)
+            else if (strncmp("UDP", line + out[i+2], 3) == 0 || strncmp("017", line + out[i+2], 3) == 0)
                 item->ses = SESSION_UDP;
-            else if (strncmp("ICMP", line + out[i+2], 3) == 0)
+            else if (strncmp("ICMP", line + out[i+2], 3) == 0 || strncmp("001", line + out[i+2], 3) == 0)
                 item->ses = SESSION_ICMP;
             else {
                 suricata_item_free(item);


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->

**Clearly describe the problem and solution**
Suricata allows expressing the protocol field as an IANA number (001=ICMP, 006=tcp, 017=UDP). If in this format, the suricata plugin silent discards the alerts.  This PR allows the Suricata plugin to accept protocol field that contains IANA numbers in addition to protocol names.

**Relevant issue number(s) if applicable**
https://github.com/aol/moloch/issues/1123

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
