### PR TITLE
Update capture to honor the caTrustFile config option.

### DIFF
--- a/capture/config.c
+++ b/capture/config.c
@@ -478,6 +478,7 @@ void moloch_config_load()
     config.dropGroup        = moloch_config_str(keyfile, "dropGroup", NULL);
     config.pluginsDir       = moloch_config_str_list(keyfile, "pluginsDir", NULL);
     config.parsersDir       = moloch_config_str_list(keyfile, "parsersDir", " /data/moloch/parsers ; ./parsers ");
+    config.caTrustFile      = moloch_config_str(keyfile, "caTrustFile", NULL);
     char *offlineRegex      = moloch_config_str(keyfile, "offlineFilenameRegex", "(?i)\\.(pcap|cap)$");
 
     config.offlineRegex     = g_regex_new(offlineRegex, 0, 0, &error);

--- a/capture/http.c
+++ b/capture/http.c
@@ -208,6 +208,10 @@ unsigned char *moloch_http_send_sync(void *serverV, const char *method, const ch
         curl_easy_setopt(easy, CURLOPT_SSL_VERIFYHOST, 0L);
     }
 
+    if (config.caTrustFile) {
+        curl_easy_setopt(easy, CURLOPT_CAINFO, config.caTrustFile);
+    }
+
     // Send client certs if so configured
     if(server->clientAuth) {
        curl_easy_setopt(easy, CURLOPT_SSLCERT, server->clientAuth->clientCert);

--- a/capture/moloch.h
+++ b/capture/moloch.h
@@ -389,6 +389,7 @@ typedef struct moloch_config {
     char     *bpf;
     char     *yara;
     char     *emailYara;
+    char     *caTrustFile;
     char     *geoLite2ASN;
     char     *geoLite2Country;
     char     *rirFile;


### PR DESCRIPTION
This updates moloch-capture to use the caTrustFile specified in the config file.