### PR TITLE
fix for everyPacket

### DIFF
--- a/capture/moloch.h
+++ b/capture/moloch.h
@@ -1210,7 +1210,7 @@ typedef enum {
 void moloch_rules_init();
 void moloch_rules_recompile();
 void moloch_rules_run_field_set(MolochSession_t *session, int pos, const gpointer value);
-int moloch_rules_run_every_packet(MolochPacket_t *packet);
+void moloch_rules_run_every_packet(MolochSession_t *session, MolochPacket_t *packet);
 void moloch_rules_session_create(MolochSession_t *session);
 void moloch_rules_run_session_setup(MolochSession_t *session, MolochPacket_t *packet);
 void moloch_rules_run_after_classify(MolochSession_t *session);

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -569,6 +569,8 @@ LOCAL void moloch_packet_process(MolochPacket_t *packet, int thread)
     int isNew;
     session = moloch_session_find_or_create(packet->ses, packet->hash, sessionId, &isNew); // Returns locked session
 
+    moloch_rules_run_every_packet(session, packet);
+
     if (isNew) {
         session->saveTime = packet->ts.tv_sec + config.tcpSaveTimeout;
         session->firstPacket = packet->ts;

--- a/capture/rules.c
+++ b/capture/rules.c
@@ -1068,6 +1068,20 @@ void moloch_rules_run_field_set(MolochSession_t *session, int pos, const gpointe
     }
 }
 /******************************************************************************/
+void moloch_rules_run_every_packet(MolochSession_t *session, MolochPacket_t *packet)
+{
+    int r;
+    MolochRule_t *rule;
+    for (r = 0; (rule = current.rules[MOLOCH_RULE_TYPE_EVERY_PACKET][r]); r++) {
+        if (rule->fieldsLen) {
+            moloch_rules_check_rule_fields(session, rule, -1);
+        } else if (rule->bpfp.bf_len && bpf_filter(rule->bpfp.bf_insns, packet->pkt, packet->pktlen, packet->pktlen)) {
+            MOLOCH_THREAD_INCR(rule->matched);
+            moloch_field_ops_run(session, &rule->ops);
+        }
+    }
+}
+/******************************************************************************/
 void moloch_rules_run_session_setup(MolochSession_t *session, MolochPacket_t *packet)
 {
     int r;


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->

fix for 1151

**Clearly describe the problem and solution**

defined moloch_rules_run_every_packet (in rules.c), updated moloch.h, invoved this new function right after moloch_session_find_or_create () so we'll have the session info for this packet.

**Relevant issue number(s) if applicable**

1151

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

no-- no viewer changes

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

ran ./tests.pl and all test passed.  not sure if there are any tests which verify the bpf stuff is working...

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
