### PR TITLE
Single packet session support

### DIFF
--- a/capture/moloch.h
+++ b/capture/moloch.h
@@ -283,7 +283,8 @@ typedef struct {
 #define SESSION_ICMP  2
 #define SESSION_SCTP  3
 #define SESSION_ESP   4
-#define SESSION_MAX   5
+#define SESSION_SPS		5
+#define SESSION_MAX   6
 
 /******************************************************************************/
 /*
@@ -462,6 +463,15 @@ typedef struct {
     char     *tagsStr[10];
 } MolochIpInfo_t;
 
+typedef struct MolochSinglePacketSession_t MolochSinglePacketSession_t;
+struct MolochSinglePacketSession_t {
+    uint8_t  protocol;
+    uint16_t port;    // 0 => all. account for packet w 0 value port?
+    MolochSinglePacketSession_t *next;
+};
+MolochSinglePacketSession_t *sps;
+
+
 /******************************************************************************/
 /*
  * Parser
@@ -523,6 +533,7 @@ typedef struct molochpacket_t
     uint8_t        copied:1;       // don't need to copy
     uint8_t        wasfrag:1;      // was a fragment
     uint8_t        tunnel:6;       // tunnel type
+    uint8_t				 sps:1;					 // single packet session flag
 } MolochPacket_t;
 
 typedef struct

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -566,9 +566,7 @@ LOCAL void moloch_packet_process(MolochPacket_t *packet, int thread)
         break;
     }
 
-#define SPS	
 
-#ifdef SPS
 		// overwrite the above if this is a single packet session
     switch (packet->sps) {
       case 0:
@@ -584,21 +582,20 @@ LOCAL void moloch_packet_process(MolochPacket_t *packet, int thread)
       default:
         LOGEXIT ("unexpected value for packet->sps %d", packet->sps);
     }
-#endif
 
     int isNew;
     session = moloch_session_find_or_create(packet->ses, packet->hash, sessionId, &isNew); // Returns locked session
 
 
-#ifdef SPS
     if (packet->sps == 1) {
       if (isNew == 0) {
         LOGEXIT ("packet is sps but session not new.  error.");
       } else {
+#ifdef DEBUG_PACKET
       	moloch_session_add_tag(session, "sps");
+#endif
       }
     }
-#endif
 
 
     if (isNew) {
@@ -1247,8 +1244,6 @@ LOCAL int moloch_packet_ip(MolochPacketBatch_t *batch, MolochPacket_t * const pa
     }
 
 		// sps detection
-
-#ifdef SPS
     packet->sps = 0;
 
     if (sps) {
@@ -1258,7 +1253,6 @@ LOCAL int moloch_packet_ip(MolochPacketBatch_t *batch, MolochPacket_t * const pa
     	struct ip6_hdr      *ip6 = (struct ip6_hdr*)(packet->pkt + packet->ipOffset);
     	struct tcphdr       *tcphdr = 0;
     	struct udphdr       *udphdr = 0;
-
 
 			if (!packet->v6) {
     		int ip_hdr_len = 4 * ip4->ip_hl;
@@ -1303,8 +1297,6 @@ LOCAL int moloch_packet_ip(MolochPacketBatch_t *batch, MolochPacket_t * const pa
 			}	
 		}
 
-
-
 		if (packet->sps == 1) {
 			// make this sessionless
 			// create a 32 bit random value for hash.  the hash is already part of the packet structure
@@ -1314,11 +1306,6 @@ LOCAL int moloch_packet_ip(MolochPacketBatch_t *batch, MolochPacket_t * const pa
 			// normal moloch session logic
     	packet->hash = moloch_session_hash(sessionId);
 		}
-
-#else
-   	packet->hash = moloch_session_hash(sessionId);
-#endif
-
 
     uint32_t thread = packet->hash % config.packetThreads;
 

--- a/capture/session.c
+++ b/capture/session.c
@@ -587,7 +587,7 @@ void moloch_session_init()
     }
 
     if (config.debug)
-        LOG("session hash size %d %d %d %d %d", primes[SESSION_ICMP], primes[SESSION_UDP], primes[SESSION_TCP], primes[SESSION_SCTP], primes[SESSION_ESP]);
+        LOG("session hash size %d %d %d %d %d %d", primes[SESSION_ICMP], primes[SESSION_UDP], primes[SESSION_TCP], primes[SESSION_SCTP], primes[SESSION_ESP], primes[SESSION_SPS]);
 
     int t;
     for (t = 0; t < config.packetThreads; t++) {
@@ -645,13 +645,14 @@ void moloch_session_exit()
     }
 
     if (!config.pcapReadOffline || config.debug)
-        LOG("sessions: %u tcp: %u udp: %u icmp: %u sctp: %u esp: %u",
+        LOG("sessions: %u tcp: %u udp: %u icmp: %u sctp: %u esp: %u sps: %u",
             moloch_session_monitoring(),
             counts[SESSION_TCP],
             counts[SESSION_UDP],
             counts[SESSION_ICMP],
             counts[SESSION_SCTP],
-            counts[SESSION_ESP]
+            counts[SESSION_ESP],
+            counts[SESSION_SPS]
             );
 
     moloch_session_flush();


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->

enable single packet sessions

**Clearly describe the problem and solution**

for  number of network use cases, performing session aggregation results in loss of important data needed in the analytic space.   this PR allows the user to identify a subset of protocol and/or protocol+port values where default session aggregation is disabled.  Instead each packet which matches one of the protocol and/or protocol+port rules is treated as a single packet session.

**Relevant issue number(s) if applicable**

1149

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

no.  no UI changes.

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

ran ./tests.pl, all passed.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
