### PR TITLE
Ethernet support

### DIFF
--- a/capture/db.c
+++ b/capture/db.c
@@ -1368,6 +1368,7 @@ LOCAL void moloch_db_update_stats(int n, gboolean sync)
     if (n == 0) {
         char     stats_key[200];
         int      stats_key_len = 0;
+				config.pcapReadOffline = 0;
         if (config.pcapReadOffline) {
             stats_key_len = snprintf(stats_key, sizeof(stats_key), "/%sstats/stat/%s", config.prefix, config.nodeName);
         } else {
@@ -1396,6 +1397,8 @@ LOCAL gboolean moloch_db_flush_gfunc (gpointer user_data )
 {
     int             thread;
     struct timeval  currentTime;
+
+		printf ("called flush_gfunc\n");
 
     gettimeofday(&currentTime, NULL);
 
@@ -1596,6 +1599,7 @@ fetch_file_num:
     if (data)
         free(data);
 
+		config.pcapReadOffline = 0;
     if (!config.pcapReadOffline) {
         /* If doing a live file create a file number now */
         snprintf(key, sizeof(key), "fn-%s", config.nodeName);

--- a/capture/db.c
+++ b/capture/db.c
@@ -1398,8 +1398,6 @@ LOCAL gboolean moloch_db_flush_gfunc (gpointer user_data )
     int             thread;
     struct timeval  currentTime;
 
-		printf ("called flush_gfunc\n");
-
     gettimeofday(&currentTime, NULL);
 
     for (thread = 0; thread < config.packetThreads; thread++) {

--- a/capture/main.c
+++ b/capture/main.c
@@ -612,6 +612,7 @@ gboolean moloch_ready_gfunc (gpointer UNUSED(user_data))
     if (config.debug)
         LOG("maxField = %d", config.maxField);
 
+		config.pcapReadOffline = 0;
     if (config.pcapReadOffline) {
         if (config.dryRun || !config.copyPcap) {
             moloch_writers_start("inplace");
@@ -772,6 +773,8 @@ int main(int argc, char **argv)
     if (config.insecure)
         LOG("\n\nDON'T DO IT!!!! `--insecure` is a bad idea\n\n");
 
+		
+
     moloch_free_later_init();
     moloch_hex_init();
     moloch_config_init();
@@ -779,10 +782,12 @@ int main(int argc, char **argv)
     moloch_readers_init();
     moloch_plugins_init();
     moloch_plugins_load(config.rootPlugins);
+
     if (config.pcapReadOffline)
         moloch_readers_set("libpcap-file");
     else
         moloch_readers_set(NULL);
+
     if (!config.pcapReadOffline) {
         moloch_drop_privileges();
         config.copyPcap = 1;

--- a/capture/moloch.h
+++ b/capture/moloch.h
@@ -535,6 +535,9 @@ typedef struct molochpacket_t
     uint8_t        tunnel:6;       // tunnel type
     uint8_t				 sps:1;					 // single packet session flag
     uint8_t				 ethernet:1;		 // ethernet as opposed to IP 
+		uint8_t			 	 sll:1;	 				 // is packet from sll capture
+		char			 	   sll_source[6];	 // sll src, == interface
+		uint8_t			 	 sll_packet_type;	 // sll packet direction
 } MolochPacket_t;
 
 typedef struct

--- a/capture/moloch.h
+++ b/capture/moloch.h
@@ -534,6 +534,7 @@ typedef struct molochpacket_t
     uint8_t        wasfrag:1;      // was a fragment
     uint8_t        tunnel:6;       // tunnel type
     uint8_t				 sps:1;					 // single packet session flag
+    uint8_t				 ethernet:1;		 // ethernet as opposed to IP 
 } MolochPacket_t;
 
 typedef struct

--- a/capture/moloch.h
+++ b/capture/moloch.h
@@ -283,7 +283,8 @@ typedef struct {
 #define SESSION_ICMP  2
 #define SESSION_SCTP  3
 #define SESSION_ESP   4
-#define SESSION_MAX   5
+#define SESSION_SPS		5
+#define SESSION_MAX   6
 
 /******************************************************************************/
 /*
@@ -462,6 +463,15 @@ typedef struct {
     char     *tagsStr[10];
 } MolochIpInfo_t;
 
+typedef struct MolochSinglePacketSession_t MolochSinglePacketSession_t;
+struct MolochSinglePacketSession_t {
+    uint8_t  protocol;
+    uint16_t port;    // 0 => all. account for packet w 0 value port?
+    MolochSinglePacketSession_t *next;
+};
+MolochSinglePacketSession_t *sps;
+
+
 /******************************************************************************/
 /*
  * Parser
@@ -523,6 +533,7 @@ typedef struct molochpacket_t
     uint8_t        copied:1;       // don't need to copy
     uint8_t        wasfrag:1;      // was a fragment
     uint8_t        tunnel:6;       // tunnel type
+    uint8_t				 sps:1;					 // single packet session flag
 } MolochPacket_t;
 
 typedef struct

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -245,8 +245,6 @@ LOCAL void moloch_packet_process_ethernet_frame(MolochSession_t * const UNUSED(s
 {
     const uint8_t *data = packet->pkt;
 	
-		printf ("processing ethernet frame\n");
-
     moloch_session_add_tag(session, "ethernet");
     moloch_session_add_tag(session, "sps");
 		if ((data[14] == 0xfe) && (data[15] == 0xfe) && (data[16] == 03) && (data[17] == 0x83)) {
@@ -263,6 +261,11 @@ LOCAL void moloch_packet_process_ethernet_frame(MolochSession_t * const UNUSED(s
     	moloch_session_add_tag(session, "arp");
 			return;
 		}
+
+		char unknown[64];
+		sprintf (unknown, "unk-eth-%02x-%02x", data[12], data[13]);
+   	moloch_session_add_tag(session, unknown);
+		return;
 
 		int i;
 		for (i = 0; i < packet->pktlen; i++) {
@@ -1927,7 +1930,6 @@ LOCAL int moloch_packet_ether(MolochPacketBatch_t * batch, MolochPacket_t * cons
             n += 2;
             break;
         default:
-            printf ("got unknown ethernet type=%x\n", ethertype);
             char  sessionId[MOLOCH_SESSIONID_LEN];
 
             packet->ethernet = 1;

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -248,7 +248,44 @@ LOCAL void moloch_packet_process_ethernet_frame(MolochSession_t * const UNUSED(s
     moloch_session_add_tag(session, "ethernet");
     moloch_session_add_tag(session, "sps");
 		if ((data[14] == 0xfe) && (data[15] == 0xfe) && (data[16] == 03) && (data[17] == 0x83)) {
+			char tag[64];
+			
     	moloch_session_add_tag(session, "isis");
+
+			switch (data[21]) {
+				case 15:
+    			moloch_session_add_tag(session, "isis-l1-hello");
+					break;
+				case 16:
+    			moloch_session_add_tag(session, "isis-l2-hello");
+					break;
+				case 17:
+    			moloch_session_add_tag(session, "isis-p2p-hello");
+					break;
+				case 18:
+    			moloch_session_add_tag(session, "isis-l1-lsp");
+					break;
+				case 20:
+    			moloch_session_add_tag(session, "isis-l2-lsp");
+					break;
+				case 24:
+    			moloch_session_add_tag(session, "isis-l1-csnp");
+					break;
+				case 25:
+    			moloch_session_add_tag(session, "isis-l2-csnp");
+					break;
+				case 26:
+    			moloch_session_add_tag(session, "isis-l1-psnp");
+					break;
+				case 27:
+    			moloch_session_add_tag(session, "isis-l2-psnp");
+					break;
+				
+				default:
+					sprintf (tag, "isis-unk-%d", data[21]);	
+    			moloch_session_add_tag(session, tag);
+			}
+
 			return;
 		}
 
@@ -1930,9 +1967,10 @@ LOCAL int moloch_packet_ether(MolochPacketBatch_t * batch, MolochPacket_t * cons
             n += 2;
             break;
         default:
-            char  sessionId[MOLOCH_SESSIONID_LEN];
 
             packet->ethernet = 1;
+            char  sessionId[MOLOCH_SESSIONID_LEN];
+
             packet->ses = SESSION_SPS;
             packet->hash = random ();
             sessionId[0] = 37;

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -566,9 +566,7 @@ LOCAL void moloch_packet_process(MolochPacket_t *packet, int thread)
         break;
     }
 
-#define SPS	
 
-#ifdef SPS
 		// overwrite the above if this is a single packet session
     switch (packet->sps) {
       case 0:
@@ -584,21 +582,20 @@ LOCAL void moloch_packet_process(MolochPacket_t *packet, int thread)
       default:
         LOGEXIT ("unexpected value for packet->sps %d", packet->sps);
     }
-#endif
 
     int isNew;
     session = moloch_session_find_or_create(packet->ses, packet->hash, sessionId, &isNew); // Returns locked session
 
 
-#ifdef SPS
     if (packet->sps == 1) {
       if (isNew == 0) {
         LOGEXIT ("packet is sps but session not new.  error.");
       } else {
+#ifdef DEBUG_PACKET
       	moloch_session_add_tag(session, "sps");
+#endif
       }
     }
-#endif
 
 
     if (isNew) {
@@ -1247,8 +1244,6 @@ LOCAL int moloch_packet_ip(MolochPacketBatch_t *batch, MolochPacket_t * const pa
     }
 
 		// sps detection
-
-#ifdef SPS
     packet->sps = 0;
 
     if (sps) {
@@ -1258,7 +1253,6 @@ LOCAL int moloch_packet_ip(MolochPacketBatch_t *batch, MolochPacket_t * const pa
     	struct ip6_hdr      *ip6 = (struct ip6_hdr*)(packet->pkt + packet->ipOffset);
     	struct tcphdr       *tcphdr = 0;
     	struct udphdr       *udphdr = 0;
-
 
 			if (!packet->v6) {
     		int ip_hdr_len = 4 * ip4->ip_hl;
@@ -1303,8 +1297,6 @@ LOCAL int moloch_packet_ip(MolochPacketBatch_t *batch, MolochPacket_t * const pa
 			}	
 		}
 
-
-
 		if (packet->sps == 1) {
 			// make this sessionless
 			// create a 32 bit random value for hash.  the hash is already part of the packet structure
@@ -1314,11 +1306,6 @@ LOCAL int moloch_packet_ip(MolochPacketBatch_t *batch, MolochPacket_t * const pa
 			// normal moloch session logic
     	packet->hash = moloch_session_hash(sessionId);
 		}
-
-#else
-   	packet->hash = moloch_session_hash(sessionId);
-#endif
-
 
     uint32_t thread = packet->hash % config.packetThreads;
 

--- a/capture/reader-libpcap-file.c
+++ b/capture/reader-libpcap-file.c
@@ -472,6 +472,14 @@ LOCAL void reader_libpcapfile_pcap_cb(u_char *UNUSED(user), const struct pcap_pk
 
     if (unlikely(h->caplen != h->len)) {
         if (!config.readTruncatedPackets && !config.ignoreErrors) {
+						int i;
+						for (i = 0; i < h->caplen; i++) {
+							printf ("%02x ", bytes[i]);
+							if (((i+1) % 16) == 0) {
+								printf ("\n");
+							}
+						}
+						printf ("\n");
             LOGEXIT("ERROR - Moloch requires full packet captures caplen: %d pktlen: %d. "
                 "If using tcpdump use the \"-s0\" option, or set readTruncatedPackets in ini file",
                 h->caplen, h->len);

--- a/capture/reader-libpcap-file.c
+++ b/capture/reader-libpcap-file.c
@@ -46,6 +46,8 @@ extern char                *readerFileName[256];
 extern MolochFieldOps_t     readerFieldOps[256];
 extern uint32_t             readerOutputIds[256];
 
+LOCAL  int                  offlineDispatchAfter;
+
 LOCAL struct {
     GRegex    *regex;
     int        field;
@@ -521,7 +523,8 @@ LOCAL gboolean reader_libpcapfile_read()
 
     int r;
     if (pktsToRead > 0) {
-        r = pcap_dispatch(pcap, MIN(pktsToRead, 5000), reader_libpcapfile_pcap_cb, NULL);
+        // r = pcap_dispatch(pcap, MIN(pktsToRead, 5000), reader_libpcapfile_pcap_cb, NULL);
+        r = pcap_dispatch(pcap, MIN(pktsToRead, offlineDispatchAfter), reader_libpcapfile_pcap_cb, NULL);
 
         if (r > 0)
             pktsToRead -= r;
@@ -529,7 +532,8 @@ LOCAL gboolean reader_libpcapfile_read()
         if (pktsToRead == 0)
             r = 0;
     } else {
-        r = pcap_dispatch(pcap, 5000, reader_libpcapfile_pcap_cb, NULL);
+        // r = pcap_dispatch(pcap, 5000, reader_libpcapfile_pcap_cb, NULL);
+        r = pcap_dispatch(pcap, offlineDispatchAfter, reader_libpcapfile_pcap_cb, NULL);
     }
     moloch_packet_batch_flush(&batch);
 
@@ -692,6 +696,9 @@ LOCAL void reader_libpcapfile_start() {
 /******************************************************************************/
 void reader_libpcapfile_init(char *UNUSED(name))
 {
+
+		offlineDispatchAfter        = moloch_config_int(NULL, "offlineDispatchAfter", 1000, 1, 0x7fff);
+
     moloch_reader_start         = reader_libpcapfile_start;
     moloch_reader_stats         = reader_libpcapfile_stats;
 

--- a/capture/session.c
+++ b/capture/session.c
@@ -587,7 +587,7 @@ void moloch_session_init()
     }
 
     if (config.debug)
-        LOG("session hash size %d %d %d %d %d", primes[SESSION_ICMP], primes[SESSION_UDP], primes[SESSION_TCP], primes[SESSION_SCTP], primes[SESSION_ESP]);
+        LOG("session hash size %d %d %d %d %d %d", primes[SESSION_ICMP], primes[SESSION_UDP], primes[SESSION_TCP], primes[SESSION_SCTP], primes[SESSION_ESP], primes[SESSION_SPS]);
 
     int t;
     for (t = 0; t < config.packetThreads; t++) {
@@ -645,13 +645,14 @@ void moloch_session_exit()
     }
 
     if (!config.pcapReadOffline || config.debug)
-        LOG("sessions: %u tcp: %u udp: %u icmp: %u sctp: %u esp: %u",
+        LOG("sessions: %u tcp: %u udp: %u icmp: %u sctp: %u esp: %u sps: %u",
             moloch_session_monitoring(),
             counts[SESSION_TCP],
             counts[SESSION_UDP],
             counts[SESSION_ICMP],
             counts[SESSION_SCTP],
-            counts[SESSION_ESP]
+            counts[SESSION_ESP],
+            counts[SESSION_SPS]
             );
 
     moloch_session_flush();

--- a/capture/session.c
+++ b/capture/session.c
@@ -644,6 +644,7 @@ void moloch_session_exit()
         }
     }
 
+		config.pcapReadOffline = 0;
     if (!config.pcapReadOffline || config.debug)
         LOG("sessions: %u tcp: %u udp: %u icmp: %u sctp: %u esp: %u sps: %u",
             moloch_session_monitoring(),

--- a/capture/writer-simple.c
+++ b/capture/writer-simple.c
@@ -332,7 +332,8 @@ LOCAL void writer_simple_write(const MolochSession_t * const session, MolochPack
         default:
             LOGEXIT("Unknown simpleMode %d", simpleMode);
         }
-
+	
+				config.pcapReadOffline = 0;
         /* If offline pcap honor umask, otherwise disable other RW */
         if (config.pcapReadOffline) {
             currentInfo[thread]->file->fd = open(name,  openOptions, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->

Enable moloch to capture, parse and store ethernet protocol data into elastic search.

**Clearly describe the problem and solution**

Core to my uses cases is the need to support ISIS-- ISIS is an ethernet based IGP commonly used in the service provider space.   This PR enables the acceptance and light touch parsing of a handful of ethernet based protocols including ISIS, LLDP and ARP.   It will also accept other unknown ethernet protocols so these don't go under the radar screen.

Note this PR assumes the presence of the single packet session PR/capability.

**Relevant issue number(s) if applicable**

1150

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

Yes, looks like three tests failed-- mpls-basic, gre-erspan and vxlan.   did a quick check of the mpls-basic pcap, lots of other stuff in that pcap besides mpls, including other ethernet protocols (eg loop, cdp, etc.) which i'm guessing the ethernet enablement is now accepting and causing unexpected results for these three test cases.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
