### PR TITLE
added right-click replacer for %DBFIELD%

### DIFF
--- a/viewer/vueapp/src/components/sessions/SessionField.vue
+++ b/viewer/vueapp/src/components/sessions/SessionField.vue
@@ -464,6 +464,7 @@ export default {
             .replace('%ISOSTART%', isostart.toISOString())
             .replace('%ISOSTOP%', isostop.toISOString())
             .replace('%FIELD%', info.field)
+            .replace('%DBFIELD%', info.info.dbField)
             .replace('%TEXT%', text)
             .replace('%UCTEXT%', text.toUpperCase())
             .replace('%HOST%', host)
@@ -475,6 +476,7 @@ export default {
 
           name = (name)
             .replace('%FIELD%', info.field)
+            .replace('%DBFIELD%', info.info.dbField)
             .replace('%TEXT%', text)
             .replace('%HOST%', host)
             .replace('%URL%', url);
@@ -484,6 +486,7 @@ export default {
 
           value = (value)
             .replace('%FIELD%', info.field)
+            .replace('%DBFIELD%', info.info.dbField)
             .replace('%TEXT%', text)
             .replace('%HOST%', host)
             .replace('%URL%', url);


### PR DESCRIPTION
When using right-click replacers (see https://molo.ch/settings#right-click) it was possible to use `%FIELD%` to get a field replacement with the internal Moloch field name `ip.src`.

This pull request adds a `%DBFIELD%` replacer which instead is replaced with the elasticsearch field name (`srcIp` instead of `ip.src`).

Very minimal patch. Tested the patch to `master` using latest release branch 2.0.1.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
