### PR TITLE
initial unknown ethernet support

### DIFF
--- a/capture/moloch.h
+++ b/capture/moloch.h
@@ -61,6 +61,8 @@
 
 #define MOLOCH_PACKET_MAX_LEN 0x10000
 
+#define MOLOCH_ETHERTYPE_UNKNOWN 1
+
 #define MOLOCH_SESSION_v6(s) ((s)->sessionId[0] == 37)
 
 /******************************************************************************/

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -1330,6 +1330,10 @@ int moloch_packet_run_ethernet_cb(MolochPacketBatch_t * batch, MolochPacket_t * 
         return ethernetCbs[type](batch, packet, data, len);
     }
 
+    if (ethernetCbs[MOLOCH_ETHERTYPE_UNKNOWN]) {
+      return ethernetCbs[MOLOCH_ETHERTYPE_UNKNOWN](batch, packet, data, len);
+    }
+
     if (config.logUnknownProtocols)
         LOG("Unknown %s ethernet protocol 0x%04x(%d)", str, type, type);
     moloch_packet_save_ethernet(packet, type);
@@ -1338,6 +1342,9 @@ int moloch_packet_run_ethernet_cb(MolochPacketBatch_t * batch, MolochPacket_t * 
 /******************************************************************************/
 void moloch_packet_set_ethernet_cb(uint16_t type, MolochPacketEnqueue_cb enqueueCb)
 {
+    if (ethernetCbs[type]) 
+      LOG ("redining existing callback type %d", type);
+
     ethernetCbs[type] = enqueueCb;
 }
 /******************************************************************************/

--- a/capture/plugins/unkEthernet.c
+++ b/capture/plugins/unkEthernet.c
@@ -1,0 +1,82 @@
+/* Copyright 2019 AOL Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this Software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "moloch.h"
+
+//#define UNKETHERNETDEBUG 1
+
+extern MolochConfig_t        config;
+
+LOCAL MolochPQ_t *unkEthernetPq;
+
+LOCAL int unkEthernetMProtocol;
+
+/******************************************************************************/
+void unkEthernet_create_sessionid(char *sessionId, MolochPacket_t * const UNUSED (packet))
+{
+    // uint8_t *data = packet->pkt + packet->payloadOffset;
+
+    sessionId[0] = 2;
+    sessionId[1] = 0x99;
+    sessionId[2] = 0x99;
+
+    // for now, lump all unkEthernet into the same session
+}
+/******************************************************************************/
+void unkEthernet_pre_process(MolochSession_t *session, MolochPacket_t * const UNUSED(packet), int isNewSession)
+{
+    if (isNewSession)
+        moloch_session_add_protocol(session, "unkEthernet");
+}
+/******************************************************************************/
+int unkEthernet_process(MolochSession_t *UNUSED(session), MolochPacket_t * const UNUSED(packet))
+{
+    return 1;
+}
+/******************************************************************************/
+int unkEthernet_packet_enqueue(MolochPacketBatch_t * UNUSED(batch), MolochPacket_t * const packet, const uint8_t *data, int len)
+{
+    char sessionId[MOLOCH_SESSIONID_LEN];
+
+    // no sanity checks until we parse.  the thinking is that it will make sense to 
+    // high level parse to determine unkEthernet packet type (eg hello, csnp/psnp, lsp) and
+    // protocol tag with these additional discriminators
+
+    packet->payloadOffset = data - packet->pkt;
+    packet->payloadLen = len;
+
+    unkEthernet_create_sessionid(sessionId, packet);
+
+    packet->hash = moloch_session_hash(sessionId);
+    packet->mProtocol = unkEthernetMProtocol;
+
+    return MOLOCH_PACKET_DO_PROCESS;
+}
+/******************************************************************************/
+LOCAL void unkEthernet_pq_cb(MolochSession_t *session, void UNUSED(*uw))
+{
+    session->midSave = 1;
+}
+/******************************************************************************/
+void moloch_plugin_init()
+{
+    moloch_packet_set_ethernet_cb(MOLOCH_ETHERTYPE_UNKNOWN, unkEthernet_packet_enqueue);
+    unkEthernetPq = moloch_pq_alloc(10, unkEthernet_pq_cb);
+    unkEthernetMProtocol = moloch_mprotocol_register("unkEthernet",
+                                             SESSION_OTHER,
+                                             unkEthernet_create_sessionid,
+                                             unkEthernet_pre_process,
+                                             unkEthernet_process,
+                                             NULL);
+}


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->

add support such that unknown ethernet frames (ethernet frames which moloch has no knowledge how to parse), if using the corresponding plugin, will cause the unknown frames to be tag as unknown and their SPI info into elastic

**Clearly describe the problem and solution**

**Relevant issue number(s) if applicable**

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

NA

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

test 10 failed, dtls, unrelated

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
