### PR TITLE
initial unk ip proto support

### DIFF
--- a/capture/moloch.h
+++ b/capture/moloch.h
@@ -63,6 +63,7 @@
 
 #define MOLOCH_ETHERTYPE_ETHER   0
 #define MOLOCH_ETHERTYPE_UNKNOWN 1
+#define MOLOCH_IPPROTO_UNKNOWN 255
 
 #define MOLOCH_SESSION_v6(s) ((s)->sessionId[0] == 37)
 

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -1357,6 +1357,10 @@ int moloch_packet_run_ip_cb(MolochPacketBatch_t * batch, MolochPacket_t * const 
         return ipCbs[type](batch, packet, data, len);
     }
 
+    if (ipCbs[MOLOCH_IPPROTO_UNKNOWN]) {
+        return ipCbs[MOLOCH_IPPROTO_UNKNOWN](batch, packet, data, len);
+    }
+
     if (config.logUnknownProtocols)
         LOG("Unknown %s protocol %d", str, type);
     if (BIT_ISSET(type, config.ipSavePcap))

--- a/capture/plugins/unkIpProtocol.c
+++ b/capture/plugins/unkIpProtocol.c
@@ -1,0 +1,80 @@
+/* Copyright 2019 AOL Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this Software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "moloch.h"
+
+//#define UNKIPPROTODEBUG 1
+
+extern MolochConfig_t        config;
+
+LOCAL MolochPQ_t *unkIpProtocolPq;
+
+LOCAL int unkIpProtocolMProtocol;
+
+/******************************************************************************/
+void unkIpProtocol_create_sessionid(char *sessionId, MolochPacket_t * const UNUSED (packet))
+{
+    // uint8_t *data = packet->pkt + packet->payloadOffset;
+
+    sessionId[0] = 2;
+    sessionId[1] = 0x9a;
+    sessionId[2] = 0x9a;
+
+    // for now, lump all unkIpProtocol into the same session
+}
+/******************************************************************************/
+void unkIpProtocol_pre_process(MolochSession_t *session, MolochPacket_t * const UNUSED(packet), int isNewSession)
+{
+    if (isNewSession)
+        moloch_session_add_protocol(session, "unkIpProtocol");
+}
+/******************************************************************************/
+int unkIpProtocol_process(MolochSession_t *UNUSED(session), MolochPacket_t * const UNUSED(packet))
+{
+    return 1;
+}
+/******************************************************************************/
+int unkIpProtocol_packet_enqueue(MolochPacketBatch_t * UNUSED(batch), MolochPacket_t * const packet, const uint8_t *data, int len)
+{
+    char sessionId[MOLOCH_SESSIONID_LEN];
+
+    // no sanity checks
+
+    packet->payloadOffset = data - packet->pkt;
+    packet->payloadLen = len;
+
+    unkIpProtocol_create_sessionid(sessionId, packet);
+
+    packet->hash = moloch_session_hash(sessionId);
+    packet->mProtocol = unkIpProtocolMProtocol;
+
+    return MOLOCH_PACKET_DO_PROCESS;
+}
+/******************************************************************************/
+LOCAL void unkIpProtocol_pq_cb(MolochSession_t *session, void UNUSED(*uw))
+{
+    session->midSave = 1;
+}
+/******************************************************************************/
+void moloch_plugin_init()
+{
+    moloch_packet_set_ip_cb(MOLOCH_IPPROTO_UNKNOWN, unkIpProtocol_packet_enqueue);
+    unkIpProtocolPq = moloch_pq_alloc(10, unkIpProtocol_pq_cb);
+    unkIpProtocolMProtocol = moloch_mprotocol_register("unkIpProtocol",
+                                             SESSION_OTHER,
+                                             unkIpProtocol_create_sessionid,
+                                             unkIpProtocol_pre_process,
+                                             unkIpProtocol_process,
+                                             NULL);
+}


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->
add means to capture and tag unk ip proto packets-- packets which have an IP protocol value that currently aren't known/parsed by moloch.  this plugin enables these unknown packets to be tagged is unkIpProtocol and agg'd into sessions and SPI data
about them written to elastic.

**Clearly describe the problem and solution**

**Relevant issue number(s) if applicable**

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

NA

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

yup

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
