### PR TITLE
Corrupt ip

### DIFF
--- a/capture/moloch.h
+++ b/capture/moloch.h
@@ -64,7 +64,7 @@
 #define MOLOCH_ETHERTYPE_ETHER   0
 #define MOLOCH_ETHERTYPE_UNKNOWN 1
 
-#define MOLOCH_IP_CORRUPT        0x101
+#define MOLOCH_CORRUPT_IP        0x101
 
 #define MOLOCH_SESSION_v6(s) ((s)->sessionId[0] == 37)
 

--- a/capture/moloch.h
+++ b/capture/moloch.h
@@ -64,6 +64,8 @@
 #define MOLOCH_ETHERTYPE_ETHER   0
 #define MOLOCH_ETHERTYPE_UNKNOWN 1
 
+#define MOLOCH_IP_CORRUPT 0x101
+
 #define MOLOCH_SESSION_v6(s) ((s)->sessionId[0] == 37)
 
 /******************************************************************************/

--- a/capture/moloch.h
+++ b/capture/moloch.h
@@ -1030,7 +1030,7 @@ int      moloch_packet_run_ethernet_cb(MolochPacketBatch_t * batch, MolochPacket
 void     moloch_packet_set_ethernet_cb(uint16_t type, MolochPacketEnqueue_cb enqueueCb);
 
 int      moloch_packet_run_ip_cb(MolochPacketBatch_t * batch, MolochPacket_t * const packet, const uint8_t *data, int len, uint16_t type, const char *str);
-void     moloch_packet_set_ip_cb(uint8_t type, MolochPacketEnqueue_cb enqueueCb);
+void     moloch_packet_set_ip_cb(uint16_t type, MolochPacketEnqueue_cb enqueueCb);
 
 
 /******************************************************************************/

--- a/capture/moloch.h
+++ b/capture/moloch.h
@@ -64,7 +64,7 @@
 #define MOLOCH_ETHERTYPE_ETHER   0
 #define MOLOCH_ETHERTYPE_UNKNOWN 1
 
-#define MOLOCH_IP_CORRUPT 0x101
+#define MOLOCH_IP_CORRUPT        0x101
 
 #define MOLOCH_SESSION_v6(s) ((s)->sessionId[0] == 37)
 

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -1219,7 +1219,9 @@ void moloch_packet_batch(MolochPacketBatch_t * batch, MolochPacket_t * const pac
     }
 
     if (rc == MOLOCH_PACKET_CORRUPT) {
+			printf ("corrupt packet\n");
       if (ipCbs[MOLOCH_CORRUPT_IP]) {
+				printf ("before cb for corrupt packet\n");
         ipCbs[MOLOCH_CORRUPT_IP](batch, packet, packet->pkt, packet->pktlen);
       }
     }
@@ -1372,7 +1374,7 @@ int moloch_packet_run_ip_cb(MolochPacketBatch_t * batch, MolochPacket_t * const 
     return MOLOCH_PACKET_UNKNOWN;
 }
 /******************************************************************************/
-void moloch_packet_set_ip_cb(uint8_t type, MolochPacketEnqueue_cb enqueueCb)
+void moloch_packet_set_ip_cb(uint16_t type, MolochPacketEnqueue_cb enqueueCb)
 {
     ipCbs[type] = enqueueCb;
 }

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -60,7 +60,7 @@ LOCAL patricia_tree_t       *ipTree6 = 0;
 extern MolochFieldOps_t      readerFieldOps[256];
 
 LOCAL MolochPacketEnqueue_cb ethernetCbs[0x10000];
-LOCAL MolochPacketEnqueue_cb ipCbs[0x100];
+LOCAL MolochPacketEnqueue_cb ipCbs[0x110];
 
 int tcpMProtocol;
 int udpMProtocol;

--- a/capture/parsers/corruptIp.c
+++ b/capture/parsers/corruptIp.c
@@ -25,7 +25,7 @@ LOCAL int corruptIpMProtocol;
 /******************************************************************************/
 void corruptIp_create_sessionid(char *sessionId, MolochPacket_t *packet)
 {
-    uint8_t *data = packet->pkt + packet->payloadOffset;
+    // uint8_t *data = packet->pkt + packet->payloadOffset;
 
 		printf ("corruptIp-- creating session id\n");
 

--- a/capture/parsers/corruptIp.c
+++ b/capture/parsers/corruptIp.c
@@ -1,0 +1,95 @@
+/* Copyright 2019 AOL Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this Software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "moloch.h"
+
+//#define CORRUPTDEBUG 1
+
+extern MolochConfig_t        config;
+
+LOCAL MolochPQ_t *corruptIpPq;
+
+LOCAL int corruptIpMProtocol;
+
+/******************************************************************************/
+void corruptIp_create_sessionid(char *sessionId, MolochPacket_t *packet)
+{
+    uint8_t *data = packet->pkt + packet->payloadOffset;
+
+		printf ("corruptIp-- creating session id\n");
+
+    sessionId[0] = 3;
+    sessionId[1] = 0xc;
+    sessionId[2] = 0xc;
+    sessionId[3] = 0xc;
+
+    // for now, lump all corruptIp into the same session
+}
+/******************************************************************************/
+void corruptIp_pre_process(MolochSession_t *session, MolochPacket_t * const UNUSED(packet), int isNewSession)
+{
+		printf ("corruptIp-- pre process\n");
+    if (isNewSession)
+        moloch_session_add_protocol(session, "corruptIp");
+}
+/******************************************************************************/
+int corruptIp_process(MolochSession_t *UNUSED(session), MolochPacket_t * const UNUSED(packet))
+{
+		printf ("corruptIp process\n");
+    return 1;
+}
+/******************************************************************************/
+int corruptIp_packet_enqueue(MolochPacketBatch_t * UNUSED(batch), MolochPacket_t * const packet, const uint8_t *data, int len)
+{
+    char sessionId[MOLOCH_SESSIONID_LEN];
+
+		printf ("corruptIp enqueue\n");
+
+    // no sanity checks until we parse.  the thinking is that it will make sense to 
+    // high level parse to determine corruptIp packet type (eg hello, csnp/psnp, lsp) and
+    // protocol tag with these additional discriminators
+
+    packet->payloadOffset = data - packet->pkt;
+    packet->payloadLen = len;
+
+		printf ("corruptIp packet->payloadLen=%d\n", packet->payloadLen);
+		printf ("corruptIp packet->payloadOffset=%d\n", packet->payloadOffset);
+
+    corruptIp_create_sessionid(sessionId, packet);
+
+    packet->hash = moloch_session_hash(sessionId);
+    packet->mProtocol = corruptIpMProtocol;
+
+		printf ("assigning corruptIp packet->mProtocol=%d\n", packet->mProtocol);
+
+    return MOLOCH_PACKET_DO_PROCESS;
+}
+/******************************************************************************/
+LOCAL void corruptIp_pq_cb(MolochSession_t *session, void UNUSED(*uw))
+{
+		printf ("corruptIp-- pq cb\n");
+    session->midSave = 1;
+}
+/******************************************************************************/
+void moloch_parser_init()
+{
+    moloch_packet_set_ip_cb(MOLOCH_CORRUPT_IP, corruptIp_packet_enqueue);
+    corruptIpPq = moloch_pq_alloc(10, corruptIp_pq_cb);
+    corruptIpMProtocol = moloch_mprotocol_register("corruptIp",
+                                             SESSION_OTHER,
+                                             corruptIp_create_sessionid,
+                                             corruptIp_pre_process,
+                                             corruptIp_process,
+                                             NULL);
+}


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->

support for getting corrupt IP packet SPI data to elastic.

**Clearly describe the problem and solution**

**Relevant issue number(s) if applicable**

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

yes.  erspan and mpls test cases fail but i think its because there are packets there which get flagged as corrupt but they are just not known (eg cdp, possibly eigpr). 

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
