### PR TITLE
corruptIp plugin

### DIFF
--- a/capture/moloch.h
+++ b/capture/moloch.h
@@ -64,6 +64,7 @@
 #define MOLOCH_ETHERTYPE_ETHER   0
 #define MOLOCH_ETHERTYPE_UNKNOWN 1
 #define MOLOCH_IPPROTO_UNKNOWN 255
+#define MOLOCH_IPPROTO_CORRUPT 256
 
 #define MOLOCH_SESSION_v6(s) ((s)->sessionId[0] == 37)
 
@@ -1029,7 +1030,7 @@ int      moloch_packet_run_ethernet_cb(MolochPacketBatch_t * batch, MolochPacket
 void     moloch_packet_set_ethernet_cb(uint16_t type, MolochPacketEnqueue_cb enqueueCb);
 
 int      moloch_packet_run_ip_cb(MolochPacketBatch_t * batch, MolochPacket_t * const packet, const uint8_t *data, int len, uint16_t type, const char *str);
-void     moloch_packet_set_ip_cb(uint8_t type, MolochPacketEnqueue_cb enqueueCb);
+void     moloch_packet_set_ip_cb(uint16_t type, MolochPacketEnqueue_cb enqueueCb);
 
 
 /******************************************************************************/

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -1407,7 +1407,7 @@ int moloch_packet_run_ip_cb(MolochPacketBatch_t * batch, MolochPacket_t * const 
 void moloch_packet_set_ip_cb(uint16_t type, MolochPacketEnqueue_cb enqueueCb)
 {
     if (type > 0x110) 
-      LOGEXIT ("type value to large 5d", type);
+      LOGEXIT ("type value to large %d", type);
 
     ipCbs[type] = enqueueCb;
 }

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -1385,7 +1385,7 @@ int moloch_packet_run_ip_cb(MolochPacketBatch_t * batch, MolochPacket_t * const 
     LOG("enter %p %d %s %p %d", packet, type, str, data, len);
 #endif
 
-    if (type > 0x110) {
+    if (type >= 0x110) {
         return MOLOCH_PACKET_CORRUPT;
     }
 

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -60,7 +60,7 @@ LOCAL patricia_tree_t       *ipTree6 = 0;
 extern MolochFieldOps_t      readerFieldOps[256];
 
 LOCAL MolochPacketEnqueue_cb ethernetCbs[0x10000];
-LOCAL MolochPacketEnqueue_cb ipCbs[0x100];
+LOCAL MolochPacketEnqueue_cb ipCbs[0x110];
 
 int tcpMProtocol;
 int udpMProtocol;
@@ -1234,16 +1234,24 @@ void moloch_packet_batch(MolochPacketBatch_t * batch, MolochPacket_t * const pac
         rc = MOLOCH_PACKET_UNKNOWN;
     }
 
-    if (unlikely(rc == MOLOCH_PACKET_CORRUPT) && config.corruptSavePcap) {
-        moloch_packet_save_unknown_packet(2, packet);
+    if (rc == MOLOCH_PACKET_CORRUPT) {
+      if (ipCbs[MOLOCH_IPPROTO_CORRUPT]) {
+        ipCbs[MOLOCH_IPPROTO_CORRUPT](batch, packet, packet->pkt, packet->pktlen);
+      }
     }
+
 
     MOLOCH_THREAD_INCR(packetStats[rc]);
 
     if (rc) {
+      if (unlikely(rc == MOLOCH_PACKET_CORRUPT) && config.corruptSavePcap) {
+          moloch_packet_save_unknown_packet(2, packet);
+      }
+      if (! ((rc == MOLOCH_PACKET_CORRUPT) && (ipCbs[MOLOCH_IPPROTO_CORRUPT]))) {
         if (rc != MOLOCH_PACKET_DONT_PROCESS_OR_FREE)
             moloch_packet_free(packet);
         return;
+      }
     }
 
     /* This packet we are going to process */
@@ -1377,7 +1385,7 @@ int moloch_packet_run_ip_cb(MolochPacketBatch_t * batch, MolochPacket_t * const 
     LOG("enter %p %d %s %p %d", packet, type, str, data, len);
 #endif
 
-    if (type > 255) {
+    if (type > 0x110) {
         return MOLOCH_PACKET_CORRUPT;
     }
 
@@ -1396,8 +1404,11 @@ int moloch_packet_run_ip_cb(MolochPacketBatch_t * batch, MolochPacket_t * const 
     return MOLOCH_PACKET_UNKNOWN;
 }
 /******************************************************************************/
-void moloch_packet_set_ip_cb(uint8_t type, MolochPacketEnqueue_cb enqueueCb)
+void moloch_packet_set_ip_cb(uint16_t type, MolochPacketEnqueue_cb enqueueCb)
 {
+    if (type > 0x110) 
+      LOGEXIT ("type value to large 5d", type);
+
     ipCbs[type] = enqueueCb;
 }
 /******************************************************************************/


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->

add logic to make corrupt IP packets a first class citizen-- publlish its SPI data to elastic in order for downstream tool to access/process

**Clearly describe the problem and solution**

**Relevant issue number(s) if applicable**

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

NA

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

yes

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
