### PR TITLE
Add support for using AWS EC2 IAM Credentials for accessing S3

### DIFF
--- a/capture/db.c
+++ b/capture/db.c
@@ -1241,6 +1241,11 @@ LOCAL void moloch_db_update_stats(int n, gboolean sync)
         totalSpaceM += (uint64_t)(vfs.f_frsize/1000.0*vfs.f_blocks/1000.0);
     }
 
+    if (totalSpaceM == 0) {
+        // Prevents some divide by Zero problems later
+        totalSpaceM = 1;
+    }
+
     const uint64_t cursec = currentTime.tv_sec;
     uint64_t diffms = (currentTime.tv_sec - lastTime[n].tv_sec)*1000 + (currentTime.tv_usec/1000 - lastTime[n].tv_usec/1000);
 

--- a/capture/plugins/writer-s3.c
+++ b/capture/plugins/writer-s3.c
@@ -287,7 +287,7 @@ void writer_s3_request(char *method, char *path, char *qs, unsigned char *data, 
              (s3Token?";x-amz-security-token":""),
              (specifyStorageClass?";x-amz-storage-class":""),
              bodyHash);
-    //LOG("canonicalRequest: %s", canonicalRequest);
+    LOG("canonicalRequest: %s", canonicalRequest);
 
     g_checksum_reset(checksum);
     g_checksum_update(checksum, (guchar*)canonicalRequest, -1);
@@ -303,7 +303,7 @@ void writer_s3_request(char *method, char *path, char *qs, unsigned char *data, 
              datetime,
              s3Region,
              g_checksum_get_string(checksum));
-    //LOG("stringToSign: %s", stringToSign);
+    LOG("stringToSign: %s", stringToSign);
 
     char kSecret[1000];
     snprintf(kSecret, sizeof(kSecret), "AWS4%s", s3SecretAccessKey);
@@ -342,7 +342,7 @@ void writer_s3_request(char *method, char *path, char *qs, unsigned char *data, 
     strcpy(signature, g_hmac_get_string(hmac));
     g_hmac_unref(hmac);
 
-    //LOG("signature: %s", signature);
+    LOG("signature: %s", signature);
 
     snprintf(fullpath, sizeof(fullpath), "/%s%s?%s", s3Bucket, path, qs);
 
@@ -365,11 +365,13 @@ void writer_s3_request(char *method, char *path, char *qs, unsigned char *data, 
             signature
             );
 
+    LOG("strs[0]: %s", strs[0]);
+
     snprintf(strs[1], 1000, "x-amz-content-sha256: %s" , bodyHash);
     snprintf(strs[2], 1000, "x-amz-date: %s", datetime);
 
     if (s3Token) {
-        snprintf(tokenHeader, sizeof(tokenHeader), "x-amz-security-token:%s", s3Token);
+        snprintf(tokenHeader, sizeof(tokenHeader), "x-amz-security-token: %s", s3Token);
         headers[nextHeader++] = tokenHeader;
     }
 

--- a/capture/plugins/writer-s3.c
+++ b/capture/plugins/writer-s3.c
@@ -623,12 +623,7 @@ void writer_s3_init(char *UNUSED(name))
         exit(1);
     }
 
-    if (!s3AccessKeyId) {
-        printf("Must set s3AccessKeyId to save to s3\n");
-        exit(1);
-    }
-
-    if (strcmp(s3AccessKeyId, "iam") == 0) {
+    if (!s3AccessKeyId || !s3AccessKeyId[0]) {
         // Fetch the data from the EC2 metadata service
         size_t rlen;
         void *metadataServer = moloch_http_create_server("http://169.254.169.254", 10, 10, 0);
@@ -657,7 +652,7 @@ void writer_s3_init(char *UNUSED(name))
         }
 
         if (!s3AccessKeyId || !s3SecretAccessKey || !s3Token) {
-            printf("Cannot retrieve credentials from metadata servie at %s\n", role_url);
+            printf("Cannot retrieve credentials from metadata service at %s\n", role_url);
             exit(1);
         }
 

--- a/capture/plugins/writer-s3.c
+++ b/capture/plugins/writer-s3.c
@@ -69,6 +69,7 @@ LOCAL  char                   s3Host[100];
 LOCAL  char                  *s3Bucket;
 LOCAL  char                  *s3AccessKeyId;
 LOCAL  char                  *s3SecretAccessKey;
+LOCAL  char                  *s3Token;
 LOCAL  char                   s3Compress;
 LOCAL  char                   s3WriteGzip;
 LOCAL  char                  *s3StorageClass;
@@ -237,6 +238,7 @@ void writer_s3_request(char *method, char *path, char *qs, unsigned char *data, 
     char           fullpath[1000];
     char           bodyHash[1000];
     char           storageClassHeader[1000];
+    char           tokenHeader[1000];
     struct timeval outputFileTime;
 
     gettimeofday(&outputFileTime, 0);
@@ -339,13 +341,14 @@ void writer_s3_request(char *method, char *path, char *qs, unsigned char *data, 
     snprintf(fullpath, sizeof(fullpath), "/%s%s?%s", s3Bucket, path, qs);
 
     char strs[3][1000];
-    char *headers[7];
+    char *headers[8];
     headers[0] = "Expect:";
     headers[1] = "Content-Type:";
     headers[2] = strs[0];
     headers[3] = strs[1];
     headers[4] = strs[2];
-    headers[6] = NULL;
+
+    int nextHeader = 5;
 
     snprintf(strs[0], 1000,
             "Authorization: AWS4-HMAC-SHA256 Credential=%s/%8.8s/%s/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date%s,Signature=%s"
@@ -357,13 +360,19 @@ void writer_s3_request(char *method, char *path, char *qs, unsigned char *data, 
 
     snprintf(strs[1], 1000, "x-amz-content-sha256: %s" , bodyHash);
     snprintf(strs[2], 1000, "x-amz-date: %s", datetime);
+
     if (specifyStorageClass) {
         // Note the missing newline in this place
         snprintf(storageClassHeader, sizeof(storageClassHeader), "x-amz-storage-class: %s", s3StorageClass);
-        headers[5] = storageClassHeader;
-    } else {
-        headers[5] = NULL;
+        headers[nextHeader++] = storageClassHeader;
     }
+
+    if (s3Token) {
+        snprintf(tokenHeader, sizeof(tokenHeader), "x-amz-security-token:%s", s3Token);
+        headers[nextHeader++] = tokenHeader;
+    }
+
+    headers[nextHeader] = NULL;
 
     inprogress++;
     moloch_http_send(s3Server, method, fullpath, strlen(fullpath), (char*)data, len, headers, FALSE, cb, uw);
@@ -607,6 +616,7 @@ void writer_s3_init(char *UNUSED(name))
     s3StorageClass        = moloch_config_str(NULL, "s3StorageClass", "STANDARD");
     s3MaxConns            = moloch_config_int(NULL, "s3MaxConns", 20, 5, 1000);
     s3MaxRequests         = moloch_config_int(NULL, "s3MaxRequests", 500, 10, 5000);
+    s3Token               = NULL;
 
     if (!s3Bucket) {
         printf("Must set s3Bucket to save to s3\n");
@@ -616,6 +626,44 @@ void writer_s3_init(char *UNUSED(name))
     if (!s3AccessKeyId) {
         printf("Must set s3AccessKeyId to save to s3\n");
         exit(1);
+    }
+
+    if (strcmp(s3AccessKeyId, "iam") == 0) {
+        // Fetch the data from the EC2 metadata service
+        size_t rlen;
+        void *metadataServer = moloch_http_create_server("http://169.254.169.254", 10, 10, 0);
+
+        s3AccessKeyId = 0;
+
+        unsigned char *rolename = moloch_http_get(metadataServer, "/latest/meta-data/iam/security-credentials/", -1, &rlen);
+
+        if (!rolename || !rlen || rolename[0] == '<') {
+            printf("Cannot retrieve role name from metadata service\n");
+            exit(1);
+        }
+
+        char role_url[1000];
+        snprintf(role_url, sizeof(role_url), "/latest/meta-data/iam/security-credentials/%.*s", (int) rlen, rolename);
+
+        free(rolename);
+
+        unsigned char *credentials = moloch_http_get(metadataServer, role_url, -1, &rlen);
+
+        if (credentials && rlen) {
+            // Now need to extract access key, secret key and token
+            s3AccessKeyId = moloch_js0n_get_str(credentials, rlen, "AccessKeyId");
+            s3SecretAccessKey = moloch_js0n_get_str(credentials, rlen, "SecretAccessKey");
+            s3Token = moloch_js0n_get_str(credentials, rlen, "Token");
+        }
+
+        if (!s3AccessKeyId || !s3SecretAccessKey || !s3Token) {
+            printf("Cannot retrieve credentials from metadata servie at %s\n", role_url);
+            exit(1);
+        }
+
+        free(credentials);
+
+        moloch_http_free_server(metadataServer);
     }
 
     if (!s3SecretAccessKey) {

--- a/capture/plugins/writer-s3.c
+++ b/capture/plugins/writer-s3.c
@@ -282,10 +282,10 @@ void writer_s3_request(char *method, char *path, char *qs, unsigned char *data, 
              s3Host,
              bodyHash,
              datetime,
-             (specifyStorageClass?storageClassHeader:""),
              (s3Token?tokenHeader:""),
-             (specifyStorageClass?";x-amz-storage-class":""),
+             (specifyStorageClass?storageClassHeader:""),
              (s3Token?";x-amz-security-token":""),
+             (specifyStorageClass?";x-amz-storage-class":""),
              bodyHash);
     //LOG("canonicalRequest: %s", canonicalRequest);
 
@@ -360,23 +360,23 @@ void writer_s3_request(char *method, char *path, char *qs, unsigned char *data, 
             "Authorization: AWS4-HMAC-SHA256 Credential=%s/%8.8s/%s/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date%s%s,Signature=%s"
             , 
             s3AccessKeyId, datetime, s3Region, 
-            (specifyStorageClass?";x-amz-storage-class":""),
             (s3Token?";x-amz-security-token":""),
+            (specifyStorageClass?";x-amz-storage-class":""),
             signature
             );
 
     snprintf(strs[1], 1000, "x-amz-content-sha256: %s" , bodyHash);
     snprintf(strs[2], 1000, "x-amz-date: %s", datetime);
 
+    if (s3Token) {
+        snprintf(tokenHeader, sizeof(tokenHeader), "x-amz-security-token:%s", s3Token);
+        headers[nextHeader++] = tokenHeader;
+    }
+
     if (specifyStorageClass) {
         // Note the missing newline in this place
         snprintf(storageClassHeader, sizeof(storageClassHeader), "x-amz-storage-class: %s", s3StorageClass);
         headers[nextHeader++] = storageClassHeader;
-    }
-
-    if (s3Token) {
-        snprintf(tokenHeader, sizeof(tokenHeader), "x-amz-security-token:%s", s3Token);
-        headers[nextHeader++] = tokenHeader;
     }
 
     headers[nextHeader] = NULL;

--- a/capture/plugins/writer-s3.c
+++ b/capture/plugins/writer-s3.c
@@ -97,7 +97,7 @@ uint32_t writer_s3_queue_length()
     int q = 0;
 
     SavepcapS3File_t *file;
-    DLL_FOREACH(fs3_, &fileQ, file) 
+    DLL_FOREACH(fs3_, &fileQ, file)
     {
         if (config.debug && DLL_COUNT(os3_, &file->outputQ) > 0)
             LOG("Waiting: %s - %d", file->outputFileName, DLL_COUNT(os3_, &file->outputQ));
@@ -243,7 +243,7 @@ void writer_s3_request(char *method, char *path, char *qs, unsigned char *data, 
 
     gettimeofday(&outputFileTime, 0);
     struct tm         *gm = gmtime(&outputFileTime.tv_sec);
-    snprintf(datetime, sizeof(datetime), 
+    snprintf(datetime, sizeof(datetime),
             "%04d%02d%02dT%02d%02d%02dZ",
             gm->tm_year + 1900,
             gm->tm_mon+1,
@@ -271,9 +271,9 @@ void writer_s3_request(char *method, char *path, char *qs, unsigned char *data, 
              "x-amz-date:%s\n"
              "%s"
              "%s"
-             "\n"      
+             "\n"
              // SignedHeaders
-             "host;x-amz-content-sha256;x-amz-date%s%s\n" 
+             "host;x-amz-content-sha256;x-amz-date%s%s\n"
              "%s"     // HexEncode(Hash(RequestPayload))
              ,
              method,
@@ -287,7 +287,7 @@ void writer_s3_request(char *method, char *path, char *qs, unsigned char *data, 
              (s3Token?";x-amz-security-token":""),
              (specifyStorageClass?";x-amz-storage-class":""),
              bodyHash);
-    LOG("canonicalRequest: %s", canonicalRequest);
+    //LOG("canonicalRequest: %s", canonicalRequest);
 
     g_checksum_reset(checksum);
     g_checksum_update(checksum, (guchar*)canonicalRequest, -1);
@@ -303,7 +303,7 @@ void writer_s3_request(char *method, char *path, char *qs, unsigned char *data, 
              datetime,
              s3Region,
              g_checksum_get_string(checksum));
-    LOG("stringToSign: %s", stringToSign);
+    //LOG("stringToSign: %s", stringToSign);
 
     char kSecret[1000];
     snprintf(kSecret, sizeof(kSecret), "AWS4%s", s3SecretAccessKey);
@@ -342,7 +342,7 @@ void writer_s3_request(char *method, char *path, char *qs, unsigned char *data, 
     strcpy(signature, g_hmac_get_string(hmac));
     g_hmac_unref(hmac);
 
-    LOG("signature: %s", signature);
+    //LOG("signature: %s", signature);
 
     snprintf(fullpath, sizeof(fullpath), "/%s%s?%s", s3Bucket, path, qs);
 
@@ -358,14 +358,12 @@ void writer_s3_request(char *method, char *path, char *qs, unsigned char *data, 
 
     snprintf(strs[0], 1000,
             "Authorization: AWS4-HMAC-SHA256 Credential=%s/%8.8s/%s/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date%s%s,Signature=%s"
-            , 
-            s3AccessKeyId, datetime, s3Region, 
+            ,
+            s3AccessKeyId, datetime, s3Region,
             (s3Token?";x-amz-security-token":""),
             (specifyStorageClass?";x-amz-storage-class":""),
             signature
             );
-
-    LOG("strs[0]: %s", strs[0]);
 
     snprintf(strs[1], 1000, "x-amz-content-sha256: %s" , bodyHash);
     snprintf(strs[2], 1000, "x-amz-date: %s", datetime);
@@ -468,7 +466,7 @@ LOCAL void append_to_output(void *data, size_t length, gboolean packetHeader, si
         outputOffsetInBlock += length;
         outputDataSinceLastMiniBlock += length;
 
-        if (!packetHeader && 
+        if (!packetHeader &&
                 (outputOffsetInBlock >= (1 << COMPRESSED_WITHIN_BLOCK_BITS) - 16 ||
                 outputActualFilePos > outputLastBlockStart + COMPRESSED_BLOCK_SIZE)) {
             // We need to make a new block
@@ -548,7 +546,7 @@ void writer_s3_create(const MolochPacket_t *packet)
     int                offset = 6 + strlen(s3Region) + strlen(s3Bucket);
 
     snprintf(filename, sizeof(filename), "s3://%s/%s/%s/#NUMHEX#-%02d%02d%02d-#NUM#.pcap%s", s3Region, s3Bucket, config.nodeName, tmp->tm_year%100, tmp->tm_mon+1, tmp->tm_mday, s3WriteGzip ? ".gz" : "");
-    
+
     currentFile = MOLOCH_TYPE_ALLOC0(SavepcapS3File_t);
     DLL_INIT(os3_, &currentFile->outputQ);
     DLL_PUSH_TAIL(fs3_, &fileQ, currentFile);

--- a/capture/plugins/writer-s3/index.js
+++ b/capture/plugins/writer-s3/index.js
@@ -125,12 +125,18 @@ function processSessionIdS3 (session, headerCb, packetCb, endCb, limit) {
           }
           async.each(data.subPackets, function (sp, nextCb) {
             var block = decompressed[sp.rangeStart];
-            packetCb(pcap, block.subarray(sp.packetStart, sp.packetEnd), nextCb, sp.itemPos);
+            var packetData = block.subarray(sp.packetStart, sp.packetEnd);
+            var len = (pcap.bigEndian?packetData.readUInt32BE(8):packetData.readUInt32LE(8));
+
+            packetCb(pcap, packetData.subarray(0, len + 16), nextCb, sp.itemPos);
           },
           nextCb);
         } else {
           async.each(data.subPackets, function (sp, nextCb) {
-            packetCb(pcap, s3data.Body.subarray(sp.packetStart - data.packetStart, sp.packetEnd - data.packetStart), nextCb, sp.itemPos);
+            var packetData = s3data.Body.subarray(sp.packetStart - data.packetStart, sp.packetEnd - data.packetStart);
+            var len = (pcap.bigEndian?packetData.readUInt32BE(8):packetData.readUInt32LE(8));
+
+            packetCb(pcap, packetData.subarray(0, len + 16), nextCb, sp.itemPos);
           },
           nextCb);
         }

--- a/capture/plugins/writer-s3/index.js
+++ b/capture/plugins/writer-s3/index.js
@@ -41,24 +41,25 @@ function splitRemain (str, separator, limit) {
 }
 /// ///////////////////////////////////////////////////////////////////////////////
 function makeS3 (node, region) {
-  var key = Config.getFull(node, 's3AccessKeyId');
-  if (!key) {
-    console.log('ERROR - No s3AccessKeyId set for ', node);
-    return undefined;
-  }
-
   var s3 = S3s[region + key];
   if (s3) {
     return s3;
   }
 
-  var secret = Config.getFull(node, 's3SecretAccessKey');
-  if (!secret) {
-    console.log('ERROR - No s3SecretAccessKey set for ', node);
+  var s3Params = {region: region};
+
+  var key = Config.getFull(node, 's3AccessKeyId');
+  if (key) {
+    var secret = Config.getFull(node, 's3SecretAccessKey');
+    if (!secret) {
+      console.log('ERROR - No s3SecretAccessKey set for ', node);
+    }
+
+    s3Params.accessKeyId = key;
+    s3Params.secretAccessKey = secret;
   }
-  var s3Params = {region: region,
-    accessKeyId: key,
-    secretAccessKey: secret};
+
+  // Lets hope that we can find a credential provider elsewhere
   var rv = S3s[region + key] = new AWS.S3(s3Params);
   return rv;
 }

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -5474,7 +5474,6 @@ function localSessionDetailReturnFull(req, res, session, incoming) {
   if (req.packetsOnly) { // only return packets
     res.render('sessionPackets.pug', {
       filename: 'sessionPackets',
-      cache: true,
       user: req.user,
       session: session,
       data: incoming,

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -5474,6 +5474,7 @@ function localSessionDetailReturnFull(req, res, session, incoming) {
   if (req.packetsOnly) { // only return packets
     res.render('sessionPackets.pug', {
       filename: 'sessionPackets',
+      cache: true,
       user: req.user,
       session: session,
       data: incoming,
@@ -5700,6 +5701,7 @@ app.get('/:nodeName/session/:id/detail', cspHeader, logAction(), (req, res) => {
     fixFields(session, () => {
       pug.render(internals.sessionDetailNew, {
         filename    : "sessionDetail",
+        cache       : true,
         user        : req.user,
         session     : session,
         Db          : Db,

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -5700,7 +5700,6 @@ app.get('/:nodeName/session/:id/detail', cspHeader, logAction(), (req, res) => {
     fixFields(session, () => {
       pug.render(internals.sessionDetailNew, {
         filename    : "sessionDetail",
-        cache       : true,
         user        : req.user,
         session     : session,
         Db          : Db,


### PR DESCRIPTION
This PR allows the S3 writer (and reader) to use EC2 IAM Roles to access S3. This means that the S3 keys do not need to be configured in the `config.ini`. This improves security. #1210 

This PR also enables caching for the `pug` rendered which dramatically improves the performance when opening a session to see the details.

It also fixes a bug (that I introduced) where downloading the PCAP of a session would return packets that didn't match. It turned out that the packet callback (when creating a PCAP to download) actually uses the entire buffer supplied rather than the first packet (like the display does). Anyway, the code now only passes over a single packet buffer.

`npm run lint` returns no errors

`./tests.pl --viewer` -- all tests pass

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
