### PR TITLE
Support multiple NICS in AF_PACKET clustering

### DIFF
--- a/capture/reader-tpacketv3.c
+++ b/capture/reader-tpacketv3.c
@@ -276,7 +276,7 @@ void reader_tpacketv3_init(char *UNUSED(name))
         
         if (fanout_group_id != 0) {
             int fanout_type = PACKET_FANOUT_HASH;
-            int fanout_arg = (fanout_group_id | (fanout_type << 16));
+            int fanout_arg = ((fanout_group_id+i) | (fanout_type << 16));
             if(setsockopt(infos[i].fd, SOL_PACKET, PACKET_FANOUT, &fanout_arg, sizeof(fanout_arg)) < 0)
                 LOGEXIT("Error setting packet fanout parameters: (%d,%s)", fanout_group_id, strerror(errno));
         }


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->

**Clearly describe the problem and solution**
If using AF_PACKET multi-process clustering with multiple NIC interfaces, the process fails to start with an "invalid operation" error. This is due to the same cluster-id being used for multiple NIC's breaking the system-global uniqueness constraint.

This update uses the cluster ID as a base (used for the first specified NIC) and increments the ID by 1 for each additional NIC.

**Relevant issue number(s) if applicable**
#1217 

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Yes
