### PR TITLE
User with "Hide Files Page" should not be able to get any information…

### DIFF
--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -4147,6 +4147,8 @@ app.get('/dstats.json', [noCacheJson], function(req, res) {
 });
 
 app.get('/:nodeName/:fileNum/filesize.json', [noCacheJson], function(req, res) {
+  if (req.user.hideFiles) { return res.molochError(403, 'Need permission to view files'); }
+
   Db.fileIdToFile(req.params.nodeName, req.params.fileNum, function(file) {
     if (!file) {
       return res.send({filesize: -1});


### PR DESCRIPTION
If a user has the permission option "Hide Files Page", he should not be able to get any information from the files, including the filesize.

**Relevant issue number(s) if applicable** h1 #722386

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
