### PR TITLE
add support to tag unknown bgp msg types

### DIFF
--- a/capture/parsers/bgp.c
+++ b/capture/parsers/bgp.c
@@ -29,8 +29,14 @@ LOCAL int bgp_parser(MolochSession_t *session, void *UNUSED(uw), const unsigned 
     if (len < 19 || memcmp("\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff", data, 16) != 0)
         return 0;
 
-    if (data[18] > 0 && data[18] < 5)
+    if (data[18] > 0 && data[18] < 5) {
         moloch_field_string_add(typeField, session, types[data[18]], -1, TRUE);
+    } else {
+        char msg[16];
+
+        sprintf (msg, "UNKMSG-%d", data[18]);    
+        moloch_field_string_add(typeField, session, msg, -1, TRUE);
+    }
 
     moloch_pq_upsert(bgpPq, session, 5, NULL);
     return 0;


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->

Tweaked the bgp parser code to also tag as UNKMSG-<code> any bgp messages which aren't in the range [0-4].   This is an error condition and bgp will likely tear down the session.  this is to just provide
additional visibility if there's an error.

**Clearly describe the problem and solution**

**Relevant issue number(s) if applicable**

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

4 tests are failing on the protocolrefactor branch-- these were failing before this bgp change.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
