### PR TITLE
Change /:nodeName/delete/:whatToRemove/:sid to POST

### DIFF
--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -7618,7 +7618,7 @@ function pcapScrub(req, res, sid, whatToRemove, endCb) {
   });
 }
 
-app.get('/:nodeName/delete/:whatToRemove/:sid', [checkProxyRequest], function (req, res) {
+app.post('/:nodeName/delete/:whatToRemove/:sid', [checkProxyRequest], function (req, res) {
   noCache(req, res);
   if (!req.user.removeEnabled) { return res.molochError(200, 'Need remove data privileges'); }
 

--- a/wiseService/wiseService.js
+++ b/wiseService/wiseService.js
@@ -588,6 +588,16 @@ app.post("/get", function(req, res) {
         typeName = internals.type2Name[type];
       }
 
+      // prevent ERR_OUT_OF_RANGE when parsing raw HTTP requests
+      if (offset => buf.length) {
+        return res.end("Error parsing packet");
+      }
+      
+      // prevent dereferencing error in typeName
+      if (!typeName) {
+        return res.end("Error parsing packet");
+      }
+
       var len  = buf.readUInt16BE(offset);
       offset += 2;
 


### PR DESCRIPTION
The endpoint at /:nodeName/delete/:whatToRemove/:sid is used via GET and therefore lacks a proper CSRF protection

Relevant issue number(s): HackerOne/#722809

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
