### PR TITLE
Slack notifiers should only allow Slack webhook URLs

### DIFF
--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -1358,6 +1358,11 @@ app.post('/notifiers', [noCacheJson, getSettingUser, checkCookieToken], function
     if (field.required) {
       for (let sentField of req.body.notifier.fields) {
         if (sentField.name === field.name && !sentField.value) {
+          if (sentField.name === "slackWebhookUrl"){
+            if (!sentField.value.startsWith('https://hooks.slack.com/')){
+              return res.molochError(403, `Please use a valid slack webhook url`);
+            }
+          }
           return res.molochError(403, `Missing a value for ${field.name}`);
         }
       }


### PR DESCRIPTION
**Clearly describe the problem and solution**
Allowing all values for the Slack webhook URL introduces potential of attacks like SSRF. The only value allowed here should be a valid Slack webhook URL. 

**Relevant issue number(s) if applicable**
HackerOne report # 721512

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
