### PR TITLE
Update viewer.js

### DIFF
--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -3520,6 +3520,8 @@ app.post('/estask/cancel', [noCacheJson, logAction()], function(req, res) {
 });
 
 app.post('/estask/cancelById', [noCacheJson, logAction()], function(req, res) {
+  if (!req.user.createEnabled) { return res.molochError(403, 'Need admin privileges'); }
+
   if (!req.body || !req.body.cancelId) {
     return res.molochError(403, 'Missing cancel ID');
   }


### PR DESCRIPTION
Add permission check to /estask/cancelById

Users can create/cancel/etc tasks when they have the createEnabled property enabled on their user account.
Permissions checks are done on POST receivers in the view.js.
There is a missing check for createEnabled at the /estask/cancelById controller.

**Clearly describe the problem and solution**

**No relevant issue number**

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
