### PR TITLE
Change /:nodeName/delete/:whatToRemove/:sid to POST

### DIFF
--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -7618,7 +7618,7 @@ function pcapScrub(req, res, sid, whatToRemove, endCb) {
   });
 }
 
-app.get('/:nodeName/delete/:whatToRemove/:sid', [checkProxyRequest], function (req, res) {
+app.post('/:nodeName/delete/:whatToRemove/:sid', [checkProxyRequest], function (req, res) {
   noCache(req, res);
   if (!req.user.removeEnabled) { return res.molochError(200, 'Need remove data privileges'); }
 


### PR DESCRIPTION
The endpoint at /:nodeName/delete/:whatToRemove/:sid is used via GET and therefore lacks a proper CSRF protection

Relevant issue number(s): HackerOne/#722809

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
