### PR TITLE
Fix POST body parsing DoS

### DIFF
--- a/wiseService/wiseService.js
+++ b/wiseService/wiseService.js
@@ -588,6 +588,15 @@ app.post("/get", function(req, res) {
         typeName = internals.type2Name[type];
       }
 
+      // prevent ERR_OUT_OF_RANGE DoS
+      if (offset >= buf.length) {
+        return res.end("Error when parsing packet");
+      }
+      // prevent typeName DoS
+      if (!typeName) {
+        return res.end("Error when parsing packet");
+      }
+
       var len  = buf.readUInt16BE(offset);
       offset += 2;
 


### PR DESCRIPTION
wiseService parses the POST body and uses the first byte in call to buf.readUInt16BE eventually reading outside of the buffer leading to a crash of node.

Relevant issue number(s): HackerOne/#722898

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
