### PR TITLE
Maintain a list of active ES cluster

### DIFF
--- a/viewer/multies.js
+++ b/viewer/multies.js
@@ -813,6 +813,7 @@ function getPingPromise(client, node){
         if(result.value === true) { // ES cluster is up
           resolve(result.node);
         } else { // ES cluster is down
+          // remove credential from the url
           var host = result.node.split("://");
           host = host[host.length > 1 ? 1 : 0 ].split("@"); // user:pass@elastic.com:9200
           host = host [host.length > 1 ? host.length-1 : 0];


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->

**Problem Statement**: The MultiViewer cannot display session data if a node provided in the multiESNodes setting is down. The MultiViewer should work if at least one of the nodes from multiESNodes setting is active/up.  

****Solution**:  Maintain a list of active ES nodes by periodically submitting a ping request (HEAD /) to every multiESNodes. The MultiViwer displays data from the active nodes by excluding inactive nodes from the query.

** `npm run lint`**: Shows no error

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
