### PR TITLE
Icmp payload work

### DIFF
--- a/capture/parsers/icmp.c
+++ b/capture/parsers/icmp.c
@@ -119,14 +119,19 @@ int icmp_process(MolochSession_t *session, MolochPacket_t * const packet)
           // icmp header (8) + ip header (20) + proto header (8)
           if (packet->payloadLen >= 36) {
             uint32_t ip;
+						uint32_t offset;;
 
-            ip = ntohl ((packet->pkt[54] << 24) + (packet->pkt[55] << 16) +
-                   (packet->pkt[56] << 8) + packet->pkt[57]);
+						// icmp header (8), 12 bytes into IP paylaod to get first address
+						offset = packet->payloadOffset + 8 + 12;
+
+            ip = ntohl ((packet->pkt[offset] << 24) + (packet->pkt[offset+1] << 16) +
+                   (packet->pkt[offset+2] << 8) + packet->pkt[offset+3]);
+
 
             moloch_field_ip4_add(icmpPayloadSrcIp, session, ip);
 
-            ip = ntohl ((packet->pkt[58] << 24) + (packet->pkt[59] << 16) +
-                   (packet->pkt[60] << 8) + packet->pkt[61]);
+            ip = ntohl ((packet->pkt[offset+4] << 24) + (packet->pkt[offset+5] << 16) +
+                   (packet->pkt[offset+6] << 8) + packet->pkt[offset+7]);
 
             moloch_field_ip4_add(icmpPayloadDstIp, session, ip);
           }


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->

add decoding logic for icmp types which carry ip payload info (type 3 and 11).

**Clearly describe the problem and solution**

**Relevant issue number(s) if applicable**

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

there are some new test case fails because this new code results in new output for icmp type 3 and 11 packets and so we see differences for existing test cases which contain these icmp message types.  for instance this test case: not ok 28 - pcap/gtp-iphone

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
