### PR TITLE
Report 724128 from HackerOne (Mala Fama team) 

### DIFF
--- a/wiseService/wiseService.js
+++ b/wiseService/wiseService.js
@@ -576,27 +576,32 @@ app.post("/get", function(req, res) {
     buffers.push(chunk);
   }).once('end', (err) => {
     var queries = [];
-    for (var buf = Buffer.concat(buffers); offset < buf.length; ) {
-      var type = buf[offset];
-      offset++;
+    try { 
+      for (var buf = Buffer.concat(buffers); offset < buf.length; ) {
+        var type = buf[offset];
+        offset++;
 
-      var typeName;
-      if (type & 0x80) {
-        typeName = buf.toString('utf8', offset, offset + (type & ~0x80));
-        offset += (type & ~0x80);
-      } else {
-        typeName = internals.type2Name[type];
+        var typeName;
+        if (type & 0x80) {
+          typeName = buf.toString('utf8', offset, offset + (type & ~0x80));
+          offset += (type & ~0x80);
+        } else {
+          typeName = internals.type2Name[type];
+        }
+
+        var len  = buf.readUInt16BE(offset);  // aca crashea
+        offset += 2;
+
+        var value = buf.toString('utf8', offset, offset+len);
+        if (internals.debug > 1) {
+          console.log(typeName, value);
+        }
+        offset += len;
+        queries.push({typeName: typeName, value: value});
       }
-
-      var len  = buf.readUInt16BE(offset);
-      offset += 2;
-
-      var value = buf.toString('utf8', offset, offset+len);
-      if (internals.debug > 1) {
-        console.log(typeName, value);
-      }
-      offset += len;
-      queries.push({typeName: typeName, value: value});
+    } 
+    catch (err) {
+      return res.end("Received malformed packet");
     }
 
     async.map(queries, (query, cb) => {

--- a/wiseService/wiseService.js
+++ b/wiseService/wiseService.js
@@ -589,7 +589,7 @@ app.post("/get", function(req, res) {
           typeName = internals.type2Name[type];
         }
 
-        var len  = buf.readUInt16BE(offset);  // aca crashea
+        var len  = buf.readUInt16BE(offset);
         offset += 2;
 
         var value = buf.toString('utf8', offset, offset+len);


### PR DESCRIPTION
This is a fix for HackerOne report #724128. 

I've noticed that another PR was submitted for this bug https://github.com/aol/moloch/pull/1232

The problem with that PR is that it does not consider all the cases. For example sending \x81\x00\x30 would crash the service, because:

buf.lenght = 3
offset = 2

Then readUInt16BE will try to read two bytes from position 2, which would result in an out of bounds error (trying to read buffer into the fourth byte, which doesn't exist).

I think just catching any exception is the best way to go.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
