### PR TITLE
updated sll logic

### DIFF
--- a/capture/packet.c
+++ b/capture/packet.c
@@ -1023,8 +1023,9 @@ LOCAL int moloch_packet_ieee802(MolochPacketBatch_t *batch, MolochPacket_t * con
     LOG("enter %p %p %d", packet, data, len);
 #endif
 
-    if (len < 6 || memcmp(data+2, "\xfe\xfe\x03", 3) != 0)
+    if (len < 6 || memcmp(data+2, "\xfe\xfe\x03", 3) != 0) {
         return MOLOCH_PACKET_CORRUPT;
+		}
 
     int etherlen = data[0] << 8 | data[+1];
     int ethertype = data[5];
@@ -1080,9 +1081,11 @@ LOCAL int moloch_packet_sll(MolochPacketBatch_t * batch, MolochPacket_t * const 
             return moloch_packet_ip6(batch, packet, data+20, len - 20);
         else
             return moloch_packet_ip4(batch, packet, data+20, len - 20);
-    default:
-			printf ("sll ethertype=%x\n", ethertype);
+		case 4:
       return moloch_packet_ieee802(batch, packet, &(packet->pkt[14]), packet->pktlen-14);
+    default:
+			return moloch_packet_run_ethernet_cb(batch, packet, data+16,len-16, ethertype, "SLL");
+			break;
     } // switch
     return MOLOCH_PACKET_CORRUPT;
 }

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -1080,11 +1080,9 @@ LOCAL int moloch_packet_sll(MolochPacketBatch_t * batch, MolochPacket_t * const 
             return moloch_packet_ip6(batch, packet, data+20, len - 20);
         else
             return moloch_packet_ip4(batch, packet, data+20, len - 20);
-    case 4:
-      // ethertype 4 in sll encap => 802.2 llc
-      return moloch_packet_ieee802(batch, packet, &(packet->pkt[14]), packet->pktlen-14);
     default:
-        return moloch_packet_run_ethernet_cb(batch, packet, data+16,len-16, ethertype, "SLL");
+			printf ("sll ethertype=%x\n", ethertype);
+      return moloch_packet_ieee802(batch, packet, &(packet->pkt[14]), packet->pktlen-14);
     } // switch
     return MOLOCH_PACKET_CORRUPT;
 }

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -1080,6 +1080,9 @@ LOCAL int moloch_packet_sll(MolochPacketBatch_t * batch, MolochPacket_t * const 
             return moloch_packet_ip6(batch, packet, data+20, len - 20);
         else
             return moloch_packet_ip4(batch, packet, data+20, len - 20);
+    case 4:
+      // ethertype 4 in sll encap => 802.2 llc
+      return moloch_packet_ieee802(batch, packet, &(packet->pkt[14]), packet->pktlen-14);
     default:
         return moloch_packet_run_ethernet_cb(batch, packet, data+16,len-16, ethertype, "SLL");
     } // switch

--- a/capture/parsers/isis.c
+++ b/capture/parsers/isis.c
@@ -45,7 +45,8 @@ void isis_pre_process(MolochSession_t *session, MolochPacket_t * const UNUSED(pa
       return;
     }
 
-    switch (packet->pkt[21]) {
+    // different ethernet encap types will change location for msg type field
+    switch (packet->pkt[packet->payloadOffset+3]) {
       case 15:
         moloch_field_string_add(typeField, session, "lan-l1-hello", -1, TRUE);
         break;
@@ -74,7 +75,7 @@ void isis_pre_process(MolochSession_t *session, MolochPacket_t * const UNUSED(pa
         moloch_field_string_add(typeField, session, "l2-psnp", -1, TRUE);
         break;
       default:
-        sprintf (msg, "unk-%d", packet->pkt[21]);
+        sprintf (msg, "unk-%d", packet->pkt[packet->payloadOffset+3]);
         LOG("isis %s\n", msg);
         moloch_field_string_add(typeField, session, msg, -1, TRUE);
     }


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->

On the arista (and possibly other devices) when doing a capture with "-i any" there's an SLL encap layer inserted.  this is a 16 byte field and the last two bytes might contain an ethertype or values 1-4.  the changes in the code are to the sll logic to pass all sll encap'd frames to the ieee802 function and ethernet_cb  parsers/plugins and let them decide if the ethertype/llc encap'd data is known or not.

**Clearly describe the problem and solution**

**Relevant issue number(s) if applicable**

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

6 tests fail but wondering if some of these are unrelated.  eg:

#   Failed test 'pcap/igmp'
#   at ./tests.pl line 125.
# +----+--------------------------------+----+----------------------------------------------------------+
# | Elt|Got                             | Elt|Expected                                                  |
# +----+--------------------------------+----+----------------------------------------------------------+
# |   1|  sessions2 => [                |   1|  sessions2 => [                                          |
# |   2|    {                           |   2|    {                                                     |
# |   3|      body => {                 |   3|      body => {                                           |
# |    |                                *   4|        communityId => '1:SOHn7e+fmmNt1Me8aZJ9FB1RZvs=',  *
# |   4|        dstBytes => 0,          |   5|        dstBytes => 0,                                    |
# |   5|        dstDataBytes => 0,      |   6|        dstDataBytes => 0,                                |
# |   6|        dstIp => '224.0.0.22',  |   7|        dstIp => '224.0.0.22',                            |
# +----+--------------------------------+----+----------------------------------------------------------+



## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
