### PR TITLE
The size of the packet offset can be quite large for compressed s3 files....

### DIFF
--- a/capture/db.c
+++ b/capture/db.c
@@ -403,7 +403,7 @@ void moloch_db_save_session(MolochSession_t *session, int final)
     }
 
     /* jsonSize is an estimate of how much space it will take to encode the session */
-    jsonSize = 1100 + session->filePosArray->len*12 + 10*session->fileNumArray->len;
+    jsonSize = 1100 + session->filePosArray->len*17 + 10*session->fileNumArray->len;
     if (config.enablePacketLen) {
         jsonSize += 10*session->fileLenArray->len;
     }
@@ -1028,7 +1028,7 @@ void moloch_db_save_session(MolochSession_t *session, int final)
     }
 
     if (jsonSize < (uint32_t)(BSB_WORK_PTR(jbsb) - startPtr)) {
-        LOG("WARNING - %s BIGGER then expected json %u %d\n", id, jsonSize,  (int)(BSB_WORK_PTR(jbsb) - startPtr));
+        LOG("WARNING - %s BIGGER than expected json %u %d\n", id, jsonSize,  (int)(BSB_WORK_PTR(jbsb) - startPtr));
         if (config.debug)
             LOG("Data:\n%.*s\n", (int)(BSB_WORK_PTR(jbsb) - startPtr), startPtr);
     }


### PR DESCRIPTION

**Clearly describe the problem and solution**

Warning messages were being printed during capture if using s3 compressed storage. It turned out that the reason was that the packet offsets are much larger (to deal with the compressed blocks) and this was confusing the calculations of space. The solution was to increase the size estimate for the packet offset. I also fixed the spelling of the error message.

**Relevant issue number(s) if applicable**

#1270 


**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

No changes to any JS file.

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

Yes

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
