### PR TITLE
When running a production express environment, enable pug caching

### DIFF
--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -114,6 +114,10 @@ if (internals.elasticBase[0].lastIndexOf('http', 0) !== 0) {
   internals.elasticBase[0] = "http://" + internals.elasticBase[0];
 }
 
+function isProduction() {
+  return app.get('env') === 'production';
+}
+
 function userCleanup(suser) {
   suser.settings = suser.settings || {};
   if (suser.emailSearch === undefined) { suser.emailSearch = false; }
@@ -5492,6 +5496,8 @@ function localSessionDetailReturnFull(req, res, session, incoming) {
   if (req.packetsOnly) { // only return packets
     res.render('sessionPackets.pug', {
       filename: 'sessionPackets',
+      cache: isProduction(),
+      compileDebug: !isProduction(),
       user: req.user,
       session: session,
       data: incoming,
@@ -5718,6 +5724,8 @@ app.get('/:nodeName/session/:id/detail', cspHeader, logAction(), (req, res) => {
     fixFields(session, () => {
       pug.render(internals.sessionDetailNew, {
         filename    : "sessionDetail",
+        cache       : isProduction(),
+        compileDebug: !isProduction(),
         user        : req.user,
         session     : session,
         Db          : Db,


### PR DESCRIPTION

**Clearly describe the problem and solution**

The solution is to check when the app is running in production mode and, if so, enable pug caching (and turn off the debug compile). This (for me) makes a significant difference in the performance of the viewer when looking at the details of a session.

**Relevant issue number(s) if applicable**

#1272 

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

yes

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

yes

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
