### PR TITLE
Fix buffer overflow

### DIFF
--- a/capture/http.c
+++ b/capture/http.c
@@ -235,6 +235,10 @@ unsigned char *moloch_http_send_sync(void *serverV, const char *method, const ch
     if (key_len == -1)
         key_len = strlen(key);
 
+    if (key_len > 1000) {
+        LOGEXIT("Url too long %.*s", key_len, key);
+    }
+
     memcpy(server->syncRequest.key, key, key_len);
     server->syncRequest.key[key_len] = 0;
     server->syncRequest.retries = server->maxRetries;


### PR DESCRIPTION
**Relevant issue number(s) if applicable**
This buffer overflow was fixed using the same convention used here: https://github.com/aol/moloch/blob/fccd739fcc4e94531196d8e78f1a3c1126ad206f/capture/http.c#L732-L734

H1 #728585

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
