### PR TITLE
Prevent tunnelled packets being processed in non-tunnelled sessions

### DIFF
--- a/capture/moloch.h
+++ b/capture/moloch.h
@@ -615,6 +615,7 @@ typedef struct moloch_session {
     uint32_t               packets[2];
     uint32_t               synTime;
     uint32_t               ackTime;
+    uint32_t               tunnel;
 
     uint16_t               port1;
     uint16_t               port2;

--- a/capture/moloch.h
+++ b/capture/moloch.h
@@ -499,6 +499,7 @@ struct moloch_pcap_sf_pkthdr {
 #define MOLOCH_PACKET_TUNNEL_PPP    0x08
 #define MOLOCH_PACKET_TUNNEL_GTP    0x10
 #define MOLOCH_PACKET_TUNNEL_VXLAN  0x20
+#define MOLOCH_PACKET_TUNNEL_EIP    0x40
 
 typedef struct molochpacket_t
 {

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -818,6 +818,10 @@ LOCAL void moloch_packet_process(MolochPacket_t *packet, int thread)
         if (packet->tunnel & MOLOCH_PACKET_TUNNEL_VXLAN) {
             moloch_session_add_protocol(session, "vxlan");
         }
+
+        if (packet->tunnel & MOLOCH_PACKET_TUNNEL_EIP) {
+            moloch_session_add_protocol(session, "encapsulated_ip");
+        }
     }
 
 
@@ -1376,6 +1380,7 @@ LOCAL int moloch_packet_ip4(MolochPacketBatch_t *batch, MolochPacket_t * const p
 
     switch (ip4->ip_p) {
     case IPPROTO_IPV4:
+        packet->tunnel |= MOLOCH_PACKET_TUNNEL_EIP;
         return moloch_packet_ip4(batch, packet, data + ip_hdr_len, len - ip_hdr_len);
         break;
     case IPPROTO_TCP:
@@ -1467,6 +1472,7 @@ LOCAL int moloch_packet_ip4(MolochPacketBatch_t *batch, MolochPacket_t * const p
         packet->vpnIpOffset = packet->ipOffset; // ipOffset will get reset
         return moloch_packet_gre4(batch, packet, data + ip_hdr_len, len - ip_hdr_len);
     case IPPROTO_IPV6:
+        packet->tunnel |= MOLOCH_PACKET_TUNNEL_EIP;
         return moloch_packet_ip6(batch, packet, data + ip_hdr_len, len - ip_hdr_len);
     default:
         if (config.logUnknownProtocols)
@@ -1617,8 +1623,10 @@ LOCAL int moloch_packet_ip6(MolochPacketBatch_t * batch, MolochPacket_t * const 
             done = 1;
             break;
         case IPPROTO_IPV4:
+            packet->tunnel |= MOLOCH_PACKET_TUNNEL_EIP;
             return moloch_packet_ip4(batch, packet, data + ip_hdr_len, len - ip_hdr_len);
         case IPPROTO_IPV6:
+            packet->tunnel |= MOLOCH_PACKET_TUNNEL_EIP;
             return moloch_packet_ip6(batch, packet, data + ip_hdr_len, len - ip_hdr_len);
         default:
             if (config.logUnknownProtocols)

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -194,12 +194,6 @@ LOCAL void moloch_packet_tcp_finish(MolochSession_t *session)
     }
 #endif
 
-    int session_tunnelled = 0;
-    ftd = DLL_PEEK_HEAD(td_, tcpData);
-    if (ftd != NULL) {
-        session_tunnelled = ftd->packet->tunnel?1:0;
-    }
-
     DLL_FOREACH_REMOVABLE(td_, tcpData, ftd, next) {
         const int which = ftd->packet->direction;
         const uint32_t tcpSeq = session->tcpSeq[which];
@@ -216,7 +210,7 @@ LOCAL void moloch_packet_tcp_finish(MolochSession_t *session)
             }
 
             /* If the packet tunnel status is not consistent with the rest of the session, free it */
-            if (ftd->packet->tunnel != session_tunnelled) {
+            if (ftd->packet->tunnel != session->tunnel) {
 #ifdef DEBUG_PACKET
                 LOG("Dropping packet for tunnel state discrepency");
 #endif
@@ -788,6 +782,9 @@ LOCAL void moloch_packet_process(MolochPacket_t *packet, int thread)
             }
 
         }
+
+        if (isNew)
+          session->tunnel = packet->tunnel;
 
         if (packet->vlan)
             moloch_field_int_add(vlanField, session, packet->vlan);


### PR DESCRIPTION
Fix for HackerOne report 732574

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
