### PR TITLE
[MALA FAMA TEAM] Improve coverage of the fuzzer 

### DIFF
--- a/capture/main.c
+++ b/capture/main.c
@@ -741,6 +741,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     MolochPacket_t       *packet = MOLOCH_TYPE_ALLOC0(MolochPacket_t);
     static uint64_t       ts = 10000;
 
+    pcapFileHeader.linktype = 1;
+
     packet->pktlen        = size;
     packet->pkt           = (u_char *)data;
     packet->ts.tv_sec     = ts >> 4;


### PR DESCRIPTION
Hi!

This one is related to HackerOne reports 725149 and 725151.

The reason behind this PR is that the fuzzer is only fuzzing the ipv6/ipv4 packets (see 
 https://github.com/aol/moloch/blob/master/capture/packet.c#L1916). If we modify the
linkType to be 1 we are going to get to the ether packet level, meaning that we will fuzz *everything*. Depending on the type, will select the type of packet that we want and trigger so we will end up with much more coverage of the program. On our tests we got around 15% more coverage and found some new crashes doing so.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
