### PR TITLE
Add the utf8:true field option to support UTF8 strings

### DIFF
--- a/capture/field.c
+++ b/capture/field.c
@@ -113,6 +113,7 @@ void moloch_field_define_json(unsigned char *expression, int expression_len, uns
 int moloch_field_define_text_full(char *field, char *text, int *shortcut)
 {
     int count = 0;
+    int utf8 = 0;
     int nolinked = 0;
     char *kind = 0;
     char *help = 0;
@@ -138,6 +139,8 @@ int moloch_field_define_text_full(char *field, char *text, int *shortcut)
             kind = colon;
         else if (strcmp(elements[e], "group") == 0)
             group = colon;
+        else if (strcmp(elements[e], "utf8") == 0)
+            utf8 = strcmp(colon, "true") == 0;
         else if (strcmp(elements[e], "count") == 0)
             count = strcmp(colon, "true") == 0;
         else if (strcmp(elements[e], "nolinked") == 0)
@@ -215,6 +218,9 @@ int moloch_field_define_text_full(char *field, char *text, int *shortcut)
             category = "ip";
     } else
         type = MOLOCH_FIELD_TYPE_STR_HASH;
+
+    if (utf8)
+        flags |= MOLOCH_FIELD_FLAG_FORCE_UTF8;
 
     if (count)
         flags |= MOLOCH_FIELD_FLAG_CNT;


### PR DESCRIPTION

**Clearly describe the problem and solution**

The problem is that wise did not set the UTF8 flag on the dynamically created field and hence the import process treated the text as being in 8-bit (not entirely clear which character set).

This just adds support for being able to define a field as having utf-8 values.

**Relevant issue number(s) if applicable**

#1312 

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

n/a

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

n/a

I'll submit another PR for the documentation repo.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
