### PR TITLE
Make sure that we reset the views before parsing the tagger file.

### DIFF
--- a/wiseService/wiseSource.js
+++ b/wiseService/wiseSource.js
@@ -164,6 +164,7 @@ WISESource.prototype.parseFieldDef = function(line) {
 //////////////////////////////////////////////////////////////////////////////////
 WISESource.prototype.parseTagger = function(body, setCb, endCb) {
   var lines = body.toString().split(/\r?\n/);
+  this.view = "";
   for (var l = 0, llen = lines.length; l < llen; l++) {
     if (lines[l][0] === "#") {
       this.parseFieldDef(lines[l]);


### PR DESCRIPTION
**Clearly describe the problem and solution**

The problem is that the custom view definition gets appended to the current view definition on a file reload. It should have *replaced* the current definition.

**Relevant issue number(s) if applicable**

#1314

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

n/a

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

n/a

Tested by installing fixed version of the software and then triggering a reload of the tagger file. The view did not get altered.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
