### PR TITLE
Added SIGTERM handler for graceful termination

### DIFF
--- a/capture/main.c
+++ b/capture/main.c
@@ -310,6 +310,12 @@ void controlc(int UNUSED(sig))
     moloch_quit();
 }
 /******************************************************************************/
+void terminate(int UNUSED(sig))
+{
+    LOG("Terminate");
+    moloch_quit();
+}
+/******************************************************************************/
 void reload(int UNUSED(sig))
 {
     moloch_plugins_reload();
@@ -771,6 +777,7 @@ int main(int argc, char **argv)
 {
     signal(SIGHUP, reload);
     signal(SIGINT, controlc);
+    signal(SIGTERM, terminate);
     signal(SIGUSR1, exit);
     signal(SIGCHLD, SIG_IGN);
 


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->
Added SIGTERM handler for graceful service shutdown, equivalent to SIGINT

**Clearly describe the problem and solution**
SIGTERM handler ensures that all queues are drained before the service is shut down, reducing chances of data loss caused by shutdown or restart.

**Relevant issue number(s) if applicable**
N/A

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**
N/A - no changes to viewer

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**
N/A - no changes to viewer

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
