### PR TITLE
Added installer support for Amazon Linux and Amazon Linux 2

### DIFF
--- a/capture/main.c
+++ b/capture/main.c
@@ -310,6 +310,12 @@ void controlc(int UNUSED(sig))
     moloch_quit();
 }
 /******************************************************************************/
+void terminate(int UNUSED(sig))
+{
+    LOG("Terminate");
+    moloch_quit();
+}
+/******************************************************************************/
 void reload(int UNUSED(sig))
 {
     moloch_plugins_reload();
@@ -771,6 +777,7 @@ int main(int argc, char **argv)
 {
     signal(SIGHUP, reload);
     signal(SIGINT, controlc);
+    signal(SIGTERM, terminate);
     signal(SIGUSR1, exit);
     signal(SIGCHLD, SIG_IGN);
 

--- a/easybutton-build.sh
+++ b/easybutton-build.sh
@@ -88,7 +88,7 @@ UNAME="$(uname)"
 
 # Installing dependencies
 echo "MOLOCH: Installing Dependencies"
-if [ -f "/etc/redhat-release" ]; then
+if [ -f "/etc/redhat-release" ] || [ -f "/etc/system-release" ]; then
   sudo yum -y install wget curl pcre pcre-devel pkgconfig flex bison gcc-c++ zlib-devel e2fsprogs-devel openssl-devel file-devel make gettext libuuid-devel perl-JSON bzip2-libs bzip2-devel perl-libwww-perl libpng-devel xz libffi-devel readline-devel libtool libyaml-devel perl-Socket6 perl-Test-Differences
   if [ $? -ne 0 ]; then
     echo "MOLOCH: yum failed"


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->
Added installer support for Amazon Linux and Amazon Linux 2 with a small change in easybutton-build

**Clearly describe the problem and solution**
When building on Amazon Linux or Amazon Linux 2, dependencies are now installed automatically

**Relevant issue number(s) if applicable**
N/A

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**
N/A

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**
N/A

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
