### PR TITLE
Fix pcap writing and link-layer DLT/LINKTYPE handling from issue #1303

### DIFF
--- a/capture/main.c
+++ b/capture/main.c
@@ -644,7 +644,7 @@ gboolean moloch_ready_gfunc (gpointer UNUSED(user_data))
         }
     }
     moloch_reader_start();
-    if (!config.pcapReadOffline && (pcapFileHeader.linktype == 0 || pcapFileHeader.snaplen == 0))
+    if (!config.pcapReadOffline && (pcapFileHeader.dlt == 0 || pcapFileHeader.snaplen == 0))
         LOGEXIT("Reader didn't call moloch_packet_set_linksnap");
     return FALSE;
 }
@@ -728,7 +728,7 @@ LLVMFuzzerInitialize(int *UNUSED(argc), char ***UNUSED(argv))
     config.nodeName = strdup("fuzz");
 
     hashSalt = 0;
-    pcapFileHeader.linktype = 1;
+    pcapFileHeader.dlt = 1;
 
     moloch_free_later_init();
     moloch_hex_init();

--- a/capture/moloch.h
+++ b/capture/moloch.h
@@ -686,7 +686,7 @@ typedef struct {
 	int32_t  thiszone;	/* gmt to local correction */
 	uint32_t sigfigs;	/* accuracy of timestamps */
 	uint32_t snaplen;	/* max length saved portion of each pkt */
-	uint32_t linktype;	/* data link type (LINKTYPE_*) */
+	uint32_t dlt;	/* data link type (DLT_*) */
 } MolochPcapFileHdr_t;
 
 #ifndef likely
@@ -1002,11 +1002,11 @@ void     moloch_packet_batch_init(MolochPacketBatch_t *batch);
 void     moloch_packet_batch_flush(MolochPacketBatch_t *batch);
 void     moloch_packet_batch(MolochPacketBatch_t * batch, MolochPacket_t * const packet);
 
-void     moloch_packet_set_linksnap(int linktype, int snaplen);
+void     moloch_packet_set_linksnap(int dlt, int snaplen);
 void     moloch_packet_drophash_add(MolochSession_t *session, int which, int min);
 
 void     moloch_packet_add_ethernet_cb(uint16_t type, MolochPacketEnqueue_cb enqueueCb);
-
+void     moloch_packet_dlt_to_linktype(MolochPcapFileHdr_t *pcapFileHeader_dlt);
 
 /******************************************************************************/
 /*

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -20,7 +20,7 @@
 #include <inttypes.h>
 #include <arpa/inet.h>
 #include <errno.h>
-#include <pcap/dlt.h>
+#include <net/bpf.h>
 
 //#define DEBUG_PACKET
 

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -20,6 +20,7 @@
 #include <inttypes.h>
 #include <arpa/inet.h>
 #include <errno.h>
+#include <pcap/dlt.h>
 
 //#define DEBUG_PACKET
 
@@ -65,16 +66,9 @@ extern MolochFieldOps_t      readerFieldOps[256];
 LOCAL MolochPacketEnqueue_cb ethernetCbs[0x10000];
 
 /******************************************************************************/
-
 // lookup table https://godoc.org/github.com/0intro/pcap
-#define DLT_FR 11
-#define DLT_C_HDLC 12
-#define DLT_RAW 12
-#define DLT_ATM_RFC1483 13
-#define DLT_SLIP_BSDOS 13
-#define DLT_PPP_BSDOS 14
-#define DLT_ATM_CLIP 19
-
+#define LINKTYPE_PPP_HDLC 50
+#define LINKTYPE_PPP_ETHER 51
 #define LINKTYPE_ATM_RFC1483 100
 #define LINKTYPE_RAW 101
 #define LINKTYPE_SLIP_BSDOS 102
@@ -82,6 +76,8 @@ LOCAL MolochPacketEnqueue_cb ethernetCbs[0x10000];
 #define LINKTYPE_C_HDLC 104
 #define LINKTYPE_ATM_CLIP 106
 #define LINKTYPE_FRELAY 107
+#define LINKTYPE_PFSYNC 246
+#define LINKTYPE_PKTAP 258
 
 #define MOLOCH_PACKET_SUCCESS          0
 #define MOLOCH_PACKET_IP_DROPPED       1
@@ -2293,7 +2289,7 @@ void moloch_packet_dlt_to_linktype(MolochPcapFileHdr_t *pcapFileHeader_dlt)
     int dlt = pcapFileHeader_dlt->dlt;
     if(dlt <= 10 || dlt >= 104) {
         return;
-    } else if(dlt == DLT_FR) {
+    } else if(dlt == DLT_FRELAY) {
         pcapFileHeader_dlt->dlt =LINKTYPE_FRELAY;
     } else if(dlt == DLT_ATM_RFC1483) {
         pcapFileHeader_dlt->dlt =LINKTYPE_ATM_RFC1483;
@@ -2307,10 +2303,14 @@ void moloch_packet_dlt_to_linktype(MolochPcapFileHdr_t *pcapFileHeader_dlt)
         pcapFileHeader_dlt->dlt =LINKTYPE_FRELAY;
     } else if(dlt == DLT_ATM_CLIP) {
         pcapFileHeader_dlt->dlt =LINKTYPE_ATM_CLIP;
-    // } else if(dlt == DLT_PPP_SERIAL) {        pcapFileHeader_dlt->dlt =LINKTYPE_PPP_HDLC;  // both 50
-    //} else if(dlt == DLT_PPP_ETHER) {        pcapFileHeader_dlt->dlt =LINKTYPE_PPP_ETHER; // both 51
-    //} else if(dlt == DLT_PFSYNC) {     pcapFileHeader_dlt->dlt =LINKTYPE_PFSYNC; // both 246
-    //} else if(dlt == DLT_PKTAP) {    pcapFileHeader_dlt->dlt =LINKTYPE_PKTAP; // both 258
+    } else if(dlt == DLT_PPP_SERIAL) {
+        pcapFileHeader_dlt->dlt =LINKTYPE_PPP_HDLC;  // both 50
+    } else if(dlt == DLT_PPP_ETHER) {
+        pcapFileHeader_dlt->dlt =LINKTYPE_PPP_ETHER; // both 51
+    } else if(dlt == DLT_PFSYNC) {
+        pcapFileHeader_dlt->dlt =LINKTYPE_PFSYNC; // both 246
+    } else if(dlt == DLT_PKTAP) {
+        pcapFileHeader_dlt->dlt =LINKTYPE_PKTAP; // both 258
     } // error handling?
     return;
 }

--- a/capture/plugins/pfring/reader-pfring.c
+++ b/capture/plugins/pfring/reader-pfring.c
@@ -88,9 +88,7 @@ LOCAL void *reader_pfring_thread(void *posv)
 }
 /******************************************************************************/
 void reader_pfring_start() {
-    int dlt_to_linktype(int dlt);
-
-    moloch_packet_set_linksnap(1, config.snapLen);
+    moloch_packet_set_linksnap(DLT_EN10MB, config.snapLen);
 
     int i;
     for (i = 0; i < MAX_INTERFACES && config.interface[i]; i++) {

--- a/capture/plugins/writer-s3.c
+++ b/capture/plugins/writer-s3.c
@@ -561,7 +561,9 @@ void writer_s3_create(const MolochPacket_t *packet)
 
     outputBuffer = moloch_http_get_buffer(config.pcapWriteSize + MOLOCH_PACKET_MAX_LEN);
     outputPos = 0;
-    append_to_output(&pcapFileHeader, 24, FALSE, 0);
+    MolochPcapFileHdr_t pcapFileHeader_dlt_link = pcapFileHeader; // create copy
+    moloch_packet_dlt_to_linktype(&pcapFileHeader_dlt_link);
+    append_to_output(&pcapFileHeader_dlt_link, sizeof(MolochPcapFileHdr_t), FALSE, 0);
     make_new_block();                   // So we can read the header in a small amount of data fetched
 
     if (config.debug)

--- a/capture/plugins/writer-s3.c
+++ b/capture/plugins/writer-s3.c
@@ -538,7 +538,7 @@ void writer_s3_exit()
     writer_s3_flush(TRUE);
 }
 /******************************************************************************/
-extern MolochPcapFileHdr_t pcapFileHeader;
+extern MolochPcapFileHdr_t pcapFileHeader   ;
 void writer_s3_create(const MolochPacket_t *packet)
 {
     char               filename[1000];

--- a/capture/reader-libpcap-file.c
+++ b/capture/reader-libpcap-file.c
@@ -554,16 +554,14 @@ LOCAL gboolean reader_libpcapfile_read()
 /******************************************************************************/
 LOCAL void reader_libpcapfile_opened()
 {
-    int dlt_to_linktype(int dlt);
-
     if (config.flushBetween)
         moloch_session_flush();
 
-    moloch_packet_set_linksnap(dlt_to_linktype(pcap_datalink(pcap)) | pcap_datalink_ext(pcap), pcap_snapshot(pcap));
+    moloch_packet_set_linksnap(pcap_datalink(pcap), pcap_snapshot(pcap));
 
     offlineFile = pcap_file(pcap);
 
-    if (config.bpf && pcapFileHeader.linktype != 239) {
+    if (config.bpf && pcapFileHeader.dlt != DLT_NFLOG) {
         struct bpf_program   bpf;
 
         if (pcap_compile(pcap, &bpf, config.bpf, 1, PCAP_NETMASK_UNKNOWN) == -1) {

--- a/capture/reader-libpcap.c
+++ b/capture/reader-libpcap.c
@@ -91,10 +91,8 @@ LOCAL void *reader_libpcap_thread(gpointer posv)
 }
 /******************************************************************************/
 void reader_libpcap_start() {
-    int dlt_to_linktype(int dlt);
-
     //ALW - Bug: assumes all linktypes are the same
-    moloch_packet_set_linksnap(dlt_to_linktype(pcap_datalink(pcaps[0])) | pcap_datalink_ext(pcaps[0]), pcap_snapshot(pcaps[0]));
+    moloch_packet_set_linksnap(pcap_datalink(pcaps[0]), pcap_snapshot(pcaps[0]));
 
     int i;
     for (i = 0; i < MAX_INTERFACES && config.interface[i]; i++) {

--- a/capture/reader-tpacketv3.c
+++ b/capture/reader-tpacketv3.c
@@ -203,9 +203,9 @@ void reader_tpacketv3_init(char *UNUSED(name))
         LOGEXIT("block size %d not divisible by %u", blocksize, config.snapLen);
     }
 
-    moloch_packet_set_linksnap(1, config.snapLen);
+    moloch_packet_set_linksnap(DLT_EN10MB, config.snapLen);
 
-    pcap_t *dpcap = pcap_open_dead(pcapFileHeader.linktype, pcapFileHeader.snaplen);
+    pcap_t *dpcap = pcap_open_dead(pcapFileHeader.dlt, pcapFileHeader.snaplen);
 
     if (config.bpf) {
         if (pcap_compile(dpcap, &bpf, config.bpf, 1, PCAP_NETMASK_UNKNOWN) == -1) {

--- a/capture/rules.c
+++ b/capture/rules.c
@@ -710,7 +710,7 @@ void moloch_rules_recompile()
     if (deadPcap)
         pcap_close(deadPcap);
 
-    deadPcap = pcap_open_dead(pcapFileHeader.linktype, pcapFileHeader.snaplen);
+    deadPcap = pcap_open_dead(pcapFileHeader.dlt, pcapFileHeader.snaplen);
     MolochRule_t *rule;
     for (t = 0; t < MOLOCH_RULE_TYPE_NUM; t++) {
         for (r = 0; (rule = current.rules[t][r]); r++) {
@@ -718,7 +718,7 @@ void moloch_rules_recompile()
                 continue;
 
             pcap_freecode(&rule->bpfp);
-            if (pcapFileHeader.linktype != 239) {
+            if (pcapFileHeader.dlt != 239) {
                 if (pcap_compile(deadPcap, &rule->bpfp, rule->bpf, 1, PCAP_NETMASK_UNKNOWN) == -1) {
                     LOGEXIT("ERROR - Couldn't compile filter %s: '%s' with %s", rule->filename, rule->bpf, pcap_geterr(deadPcap));
                 }

--- a/capture/writer-disk.c
+++ b/capture/writer-disk.c
@@ -341,7 +341,9 @@ LOCAL void writer_disk_create(MolochPacket_t * const packet)
     clock_gettime(CLOCK_REALTIME_COARSE, &outputFileTime);
 
     output->fileId = outputId;
-    memcpy(output->buf, &pcapFileHeader, 24);
+    MolochPcapFileHdr_t pcapFileHeader_dlt_link = pcapFileHeader; // create copy
+    moloch_packet_dlt_to_linktype(&pcapFileHeader_dlt_link);
+    memcpy(output->buf, &pcapFileHeader_dlt_link, sizeof(MolochPcapFileHdr_t));
 }
 /******************************************************************************/
 struct pcap_timeval {

--- a/capture/writer-simple.c
+++ b/capture/writer-simple.c
@@ -350,8 +350,12 @@ LOCAL void writer_simple_write(const MolochSession_t * const session, MolochPack
         if (currentInfo[thread]->file->fd < 0) {
             LOGEXIT("ERROR - pcap open failed - Couldn't open file: '%s' with %s  (%d)", name, strerror(errno), errno);
         }
-        info->file->pos = currentInfo[thread]->bufpos = 24;
-        memcpy(info->buf, &pcapFileHeader, 24);
+        info->file->pos = currentInfo[thread]->bufpos = sizeof(MolochPcapFileHdr_t);
+
+        MolochPcapFileHdr_t pcapFileHeader_dlt_link = pcapFileHeader; // create copy
+        moloch_packet_dlt_to_linktype(&pcapFileHeader_dlt_link);
+        memcpy(info->buf, &pcapFileHeader_dlt_link, sizeof(MolochPcapFileHdr_t));
+
         if (config.debug)
             LOG("opened %d %s %d", thread, name, info->file->fd);
         g_free(name);


### PR DESCRIPTION
Rename pcapFileHeader.linktype to pcapFileHeader.dlt
Use DLT_EN10MB instead of 1 when using moloch_packet_set_linksnap
Use sizeof(MolochPcapFileHdr_t) instead of 24
Fix moloch package headers on write via copy + modify if needed + write copy
Add DLT_* and LINKTYPE_* defines, as pcap doesn't export them
Remove references to dlt_to_linktype as pcap doesn't export them (this broke .so compatibility with libpcap)
Fix broken calls to moloch_packet_set_linksnap( dlt_to_linktype | ..)