### PR TITLE
Enabled local ES install on Amazon Linux

### DIFF
--- a/release/Configure
+++ b/release/Configure
@@ -145,7 +145,7 @@ done
 if [ "$MOLOCH_LOCALELASTICSEARCH" == "yes" ]; then
     echo "Moloch - Downloading and installing demo OSS version of Elasticsearch"
     ES_VERSION=6.8.2
-    if [ -f "/etc/redhat-release" ]; then
+    if [ -f "/etc/redhat-release" ] || [ -f "/etc/system-release" ]; then
         if ! [ -x "$(command -v java)" ]; then
           yum install java-openjdk-headless
         fi


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->
Enabled local Elasticsearch install on Amazon Linux and Amazon Linux 2

**Clearly describe the problem and solution**
Added Amazon Linux detection to Configure script, similar to #1321

**Relevant issue number(s) if applicable**
N/A

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**
N/A

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**
N/A

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
