### PR TITLE
add maxFileTimeM setting to s3 writer

### DIFF
--- a/capture/plugins/writer-s3.c
+++ b/capture/plugins/writer-s3.c
@@ -40,6 +40,7 @@ typedef struct writer_s3_file {
     uint16_t                   fs3_count;
 
     char                      *outputFileName;
+    struct timespec            outputFileTime;
     char                      *outputPath;
     SavepcapS3Output_t         outputQ;
     char                      *uploadId;
@@ -561,6 +562,7 @@ void writer_s3_create(const MolochPacket_t *packet)
 
     currentFile->outputFileName = moloch_db_create_file(packet->ts.tv_sec, filename, 0, 0, &outputId);
     currentFile->outputPath = currentFile->outputFileName + offset;
+    clock_gettime(CLOCK_REALTIME_COARSE, &currentFile->outputFileTime);
     outputFilePos = 0;
     outputActualFilePos = 0;
     outputLastBlockStart = 0;
@@ -717,7 +719,26 @@ void writer_s3_init(char *UNUSED(name))
     DLL_INIT(fs3_, &fileQ);
 }
 /******************************************************************************/
+LOCAL gboolean writer_s3_file_time_gfunc (gpointer UNUSED(user_data))
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME_COARSE, &ts);
+
+    MOLOCH_LOCK(output);
+    if (currentFile && outputFilePos > 24 && (ts.tv_sec - currentFile->outputFileTime.tv_sec) >= config.maxFileTimeM*60) {
+        writer_s3_flush(TRUE);
+    }
+    MOLOCH_UNLOCK(output);
+
+    return TRUE;
+}
+
+/******************************************************************************/
 void moloch_plugin_init()
 {
     moloch_writers_add("s3", writer_s3_init);
+
+    if (config.maxFileTimeM > 0) {
+        g_timeout_add_seconds( 30, writer_s3_file_time_gfunc, 0);
+    }
 }


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->
Added handling of **maxFileTimeM** setting to s3 writer

**Clearly describe the problem and solution**
Objects cannot be read from S3 until they are fully written, so setting **maxFileTimeM** to a low value causes objects to be flushed to S3 at a set interval and would allow viewing of recently captured pcaps. This setting is now implemented.

**Relevant issue number(s) if applicable**
n/a

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
