### PR TITLE
add GeoIP license key to config and update scripts

### DIFF
--- a/release/Configure
+++ b/release/Configure
@@ -107,12 +107,6 @@ while [ -z "$MOLOCH_PASSWORD" ]; do
 done
 if [ -z "$MOLOCH_PASSWORD" ]; then echo "Must provide a password"; exit; fi
 
-while [ -z "$MOLOCH_MAXMIND_LICENSE_KEY" ]; do
-    echo -n "MaxMind GeoIP license key [no-default] "
-    read -r MOLOCH_MAXMIND_LICENSE_KEY
-done
-if [ -z "$MOLOCH_MAXMIND_LICENSE_KEY" ]; then echo "Must provide a license key"; exit; fi
-
 
 ################################################################################
 echo "Moloch - Creating configuration files"
@@ -207,6 +201,12 @@ until [ "$MOLOCH_INET" == "yes" ] || [ "$MOLOCH_INET" == "no" ] || [ "$MOLOCH_IN
 done
 
 if [ "$MOLOCH_INET" != "no" ]; then
+    while [ -z "$MOLOCH_MAXMIND_LICENSE_KEY" ]; do
+        echo -n "MaxMind GeoIP license key [no-default] "
+        read -r MOLOCH_MAXMIND_LICENSE_KEY
+    done
+    if [ -z "$MOLOCH_MAXMIND_LICENSE_KEY" ]; then echo "Must provide a license key"; exit; fi
+
     echo "Moloch - Downloading GEO files"
     $MOLOCH_INSTALL_DIR/bin/moloch_update_geo.sh $MOLOCH_MAXMIND_LICENSE_KEY > /dev/null
 else

--- a/release/Configure
+++ b/release/Configure
@@ -107,6 +107,12 @@ while [ -z "$MOLOCH_PASSWORD" ]; do
 done
 if [ -z "$MOLOCH_PASSWORD" ]; then echo "Must provide a password"; exit; fi
 
+while [ -z "$MOLOCH_MAXMIND_LICENSE_KEY" ]; do
+    echo -n "MaxMind GeoIP license key [no-default] "
+    read -r MOLOCH_MAXMIND_LICENSE_KEY
+done
+if [ -z "$MOLOCH_MAXMIND_LICENSE_KEY" ]; then echo "Must provide a license key"; exit; fi
+
 
 ################################################################################
 echo "Moloch - Creating configuration files"
@@ -202,7 +208,7 @@ done
 
 if [ "$MOLOCH_INET" != "no" ]; then
     echo "Moloch - Downloading GEO files"
-    $MOLOCH_INSTALL_DIR/bin/moloch_update_geo.sh > /dev/null
+    $MOLOCH_INSTALL_DIR/bin/moloch_update_geo.sh $MOLOCH_MAXMIND_LICENSE_KEY > /dev/null
 else
     echo "Moloch - NOT downloading GEO files"
 fi

--- a/release/moloch_update_geo.sh
+++ b/release/moloch_update_geo.sh
@@ -13,7 +13,7 @@ then
   cp ipv4-address-space.csv "${DEST_DIR}"
 fi
 
-wget -N -nv --timeout=${TIMEOUT} -O GeoLite2-Country.mmdb.gz 'https://updates.maxmind.com/app/update_secure?edition_id=GeoLite2-Country'
+wget -N -nv --timeout=${TIMEOUT} -O GeoLite2-Country.mmdb.gz "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country&license_key=$1&suffix=tar.gz"
 if (( $? == 0 ))
 then
   /bin/rm -f "${DEST_DIR}/GeoLite2-Country.mmdb"
@@ -21,7 +21,7 @@ then
 fi
 
 
-wget -N -nv --timeout=${TIMEOUT} -O GeoLite2-ASN.mmdb.gz 'https://updates.maxmind.com/app/update_secure?edition_id=GeoLite2-ASN'
+wget -N -nv --timeout=${TIMEOUT} -O GeoLite2-ASN.mmdb.gz "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-ASN&license_key=$1&suffix=tar.gz"
 if (( $? == 0 ))
 then
   /bin/rm -f "${DEST_DIR}/GeoLite2-ASN.mmdb"

--- a/release/moloch_update_geo.sh
+++ b/release/moloch_update_geo.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Variables
-DEST_DIR="${MOLOCH_DIR:-/data/moloch}/etc"
+DEST_DIR="${MOLOCH_DIR:-BUILD_MOLOCH_INSTALL_DIR}/etc"
 TIMEOUT=${WGET_TIMEOUT:-30}
 
 # Work on temp dir to not affect current working files

--- a/release/moloch_update_geo.sh
+++ b/release/moloch_update_geo.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Variables
-DEST_DIR="${MOLOCH_DIR:-BUILD_MOLOCH_INSTALL_DIR}/etc"
+DEST_DIR="${MOLOCH_DIR:-/data/moloch}/etc"
 TIMEOUT=${WGET_TIMEOUT:-30}
 
 # Work on temp dir to not affect current working files
@@ -17,7 +17,9 @@ wget -N -nv --timeout=${TIMEOUT} -O GeoLite2-Country.mmdb.gz "https://download.m
 if (( $? == 0 ))
 then
   /bin/rm -f "${DEST_DIR}/GeoLite2-Country.mmdb"
-  zcat GeoLite2-Country.mmdb.gz > "${DEST_DIR}/GeoLite2-Country.mmdb"
+  tar xvzf GeoLite2-Country.mmdb.gz
+  mv GeoLite2-Country*/GeoLite2-Country.mmdb ${DEST_DIR}/
+  rm -rf GeoLite2-Country*
 fi
 
 
@@ -25,7 +27,9 @@ wget -N -nv --timeout=${TIMEOUT} -O GeoLite2-ASN.mmdb.gz "https://download.maxmi
 if (( $? == 0 ))
 then
   /bin/rm -f "${DEST_DIR}/GeoLite2-ASN.mmdb"
-  zcat GeoLite2-ASN.mmdb.gz > "${DEST_DIR}/GeoLite2-ASN.mmdb"
+  tar xvzf GeoLite2-ASN.mmdb.gz
+  mv GeoLite2-ASN*/GeoLite2-ASN.mmdb ${DEST_DIR}/
+  rm -rf GeoLite2-ASN*
 fi
 
 
@@ -34,5 +38,3 @@ if (( $? == 0 ))
 then
   cp oui.txt "${DEST_DIR}/oui.txt"
 fi
-
-


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->
Added GeoIP license key to Configure and update_geo scripts

**Clearly describe the problem and solution**
[As of 30 December 2019, MaxMind requires a license key to download free GeoIP databases.](https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-geolite2-databases/)

**Relevant issue number(s) if applicable**
#1350 

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**
No

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**
No

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
