### PR TITLE
Capture tcp health check

### DIFF
--- a/capture/plugins/tcphealthcheck.c
+++ b/capture/plugins/tcphealthcheck.c
@@ -1,0 +1,95 @@
+/* tcphealthcheck.c  -- TCP Health Check plugin
+Listens on a TCP socket and immediately closes it to confirm that the capture service is running.
+ */
+
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <ctype.h>
+#include <pthread.h>
+#include "moloch.h"
+
+
+/******************************************************************************/
+
+extern MolochConfig_t        config;
+
+LOCAL  int                   tcp_port;
+
+/******************************************************************************/
+void server(void) {
+    int server_fd, client_fd, err;
+    struct sockaddr_in server, client;
+   
+    server.sin_family = AF_INET;
+    server.sin_port = htons(tcp_port);
+    server.sin_addr.s_addr = htonl(INADDR_ANY);
+    
+    server_fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (server_fd < 0) {
+        LOG("Error creating socket: %d", server_fd);
+        return;
+    }
+    int opt_val = 1;
+    setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR, &opt_val, sizeof opt_val);
+
+    err = bind(server_fd, (struct sockaddr *) &server, sizeof(server));
+    if (err < 0) {
+        LOG("Error binding socket: %d", err);
+        return;
+    }
+
+    err = listen(server_fd, 128);
+    if (err < 0) {
+        LOG("Error listening on socket: %d", err);
+        return;
+    }
+
+    LOG("Listening for TCP health checks on port %d", tcp_port);
+
+    while (1) {
+        socklen_t client_len = sizeof(client);
+        client_fd = accept(server_fd, (struct sockaddr *) &client, &client_len);
+            if (client_fd < 0) {
+                LOG("Error establishing new connection: %d", client_fd);
+                return;
+            }
+            else {
+                close(client_fd);
+            }
+    }
+}
+
+/******************************************************************************/
+void *tcp_listener(void *vargp) 
+{
+    (void) vargp;
+    LOG("Starting TCP server");
+    server();
+    return NULL;
+}
+
+
+/******************************************************************************/
+/*
+ * Called by moloch when the plugin is loaded
+ */
+void moloch_plugin_init()
+{
+  	pthread_t thread_id;
+
+    tcp_port = moloch_config_int(NULL, "tcpHealthCheckPort", 0, 0, 65535);
+    if (tcp_port) {
+        LOG("tcpHealthCheckPort set to %d", tcp_port);
+        pthread_create(&thread_id, NULL, tcp_listener, NULL);
+        LOG("TCP listener thread created"); 
+        moloch_plugins_register("tcphealthcheck", FALSE);
+    }
+    else {
+      LOG("To use TCP health checks, set tcpHealthCheckPort to a value between 1 and 65535");
+    }
+}

--- a/capture/plugins/tcphealthcheck.c
+++ b/capture/plugins/tcphealthcheck.c
@@ -56,7 +56,6 @@ void server(void) {
         client_fd = accept(server_fd, (struct sockaddr *) &client, &client_len);
             if (client_fd < 0) {
                 LOG("Error establishing new connection: %d", client_fd);
-                return;
             }
             else {
                 close(client_fd);

--- a/capture/plugins/tcphealthcheck.c
+++ b/capture/plugins/tcphealthcheck.c
@@ -21,7 +21,7 @@ extern MolochConfig_t        config;
 LOCAL  int                   tcp_port;
 
 /******************************************************************************/
-void server(void) {
+void tcp_server(void) {
     int server_fd, client_fd, err;
     struct sockaddr_in server, client;
    
@@ -68,7 +68,7 @@ void *tcp_listener(void *vargp)
 {
     (void) vargp;
     LOG("Starting TCP server");
-    server();
+    tcp_server();
     return NULL;
 }
 


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->
Capture plugin to respond to TCP health checks made by AWS Network Load Balancer.

**Clearly describe the problem and solution**
Provide a simple TCP socket listener in the capture module so that AWS Network Load Balancer can confirm that the service is up and running. A new setting tcpHealthCheckPort is added to config.ini. The plugin starts a TCP server in a single thread that listens for connections on a socket and immediately closes them.

**Relevant issue number(s) if applicable**
n/a

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**
n/a

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**
Yes

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
