### PR TITLE
Fixed viewer crash that was similar to #522

### DIFF
--- a/viewer/decode.js
+++ b/viewer/decode.js
@@ -92,7 +92,11 @@ ItemTransform.prototype._transform = function (item, encoding, callback) {
     }
     return callback();
   case 1:
-    return self._process(item, callback);
+    try {
+      return self._process(item, callback);
+    } catch (err) {
+      return callback(err);
+    }
   case 2:
     return callback(null, item);
   }


### PR DESCRIPTION
Hello,
today I experienced a bug similar to issue #522:

```
/data/moloch/viewer/decode.js:502
    this.httpstream.push({client: item.client, ts: item.ts, data: buf.slice(0, start)});
                                       ^

TypeError: Cannot read property 'client' of undefined
    at HTTPParser.ItemHTTPStream.onBody (/data/moloch/viewer/decode.js:502:40)
    at ItemHTTPStream._process (/data/moloch/viewer/decode.js:565:41)
    at ItemHTTPStream.ItemTransform._transform (/data/moloch/viewer/decode.js:95:17)
    at ItemHTTPStream.Transform._read (_stream_transform.js:190:10)
    at ItemHTTPStream.Transform._write (_stream_transform.js:178:12)
    at doWrite (_stream_writable.js:415:12)
    at clearBuffer (_stream_writable.js:545:7)
    at onwrite (_stream_writable.js:470:7)
    at ItemHTTPStream.afterTransform (_stream_transform.js:94:3)
    at runCallback (timers.js:705:18)
```

To solve this I added a similar solution as in 06959b4.
I'm sorry but I could not test my change (with `test.pl --viewer`). So maybe this gets tested and reviewed by a maintainer?

Thank you very much :)