### PR TITLE
Fixes the problem where the s3 token expires during a capture

### DIFF
--- a/capture/plugins/writer-s3.c
+++ b/capture/plugins/writer-s3.c
@@ -189,9 +189,6 @@ void writer_s3_refresh_s3credentials(void)
         newS3AccessKeyId = moloch_js0n_get_str(credentials, rlen, "AccessKeyId");
         newS3SecretAccessKey = moloch_js0n_get_str(credentials, rlen, "SecretAccessKey");
         newS3Token = moloch_js0n_get_str(credentials, rlen, "Token");
-    } else {
-        printf("Cannot retrieve credentials from metadata service at %s -- no returned data\n", role_url);
-        exit(1);
     }
 
     if (newS3AccessKeyId && newS3SecretAccessKey && newS3Token) {


### PR DESCRIPTION

**Clearly describe the problem and solution**

If moloch-capture is running on AWS, pushing files to S3, and is using IAM Roles for access permissions, then the token can expire during the run. The fix is to refetch the token just before every request to upload a part of the resulting file to S3.

**Relevant issue number(s) if applicable**

This fixes #1366 

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

N/A

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

N/A

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
