### PR TITLE
Support custom s3 repositories like minio

### DIFF
--- a/capture/plugins/writer-s3/index.js
+++ b/capture/plugins/writer-s3/index.js
@@ -63,7 +63,9 @@ function makeS3 (node, region) {
     s3Params.endpoint = Config.getFull(node, 's3Host')
   }
 
-  if (Config.getFull(node, 's3PathAccessStyle') === 'true') {
+  var bucket = Config.getFull(node, 's3Bucket')
+  var bucketHasDot = bucket.indexOf('.') >= 0
+  if (Config.getBoolFull(node, 's3PathAccessStyle', bucketHasDot) === true) {
     s3Params.s3ForcePathStyle = true;
   }
 

--- a/capture/plugins/writer-s3/index.js
+++ b/capture/plugins/writer-s3/index.js
@@ -59,6 +59,14 @@ function makeS3 (node, region) {
     s3Params.secretAccessKey = secret;
   }
 
+  if (Config.getFull(node, 's3Host') !== undefined) {
+    s3Params.endpoint = Config.getFull(node, 's3Host')
+  }
+
+  if (Config.getFull(node, 's3PathAccessStyle') === 'true') {
+    s3Params.s3ForcePathStyle = true;
+  }
+
   // Lets hope that we can find a credential provider elsewhere
   var rv = S3s[region + key] = new AWS.S3(s3Params);
   return rv;

--- a/viewer/config.js
+++ b/viewer/config.js
@@ -294,6 +294,24 @@ exports.get = function(key, defaultValue) {
   return exports.getFull(internals.nodeName, key, defaultValue);
 };
 
+exports.getBoolFull = function(node, key, defaultValue) {
+  var value = exports.getFull(node, key);
+  if (value !== undefined) {
+    if (value === "true" || value === "1") {
+      return true;
+    } else if (value === "false" || value === "0") {
+      return false;
+    } else {
+      console.log("ERROR - invalid value for ", key);
+    }
+  }
+  return defaultValue;
+};
+
+exports.getBool = function(key, defaultValue) {
+  return exports.getBoolFull(internals.nodeName, key, defaultValue);
+};
+
 // Return an array split on separator, remove leading/trailing spaces, remove empty elements
 exports.getArray = function(key, separator, defaultValue) {
   return exports.get(key, defaultValue).split(separator).map(s=>s.trim()).filter(s=>s.match(/^\S+$/));

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -8868,8 +8868,12 @@ function main () {
     internals.previousNodesStats.push(info.nodes);
   });
 
-  expireCheckAll();
-  setInterval(expireCheckAll, 60*1000);
+  var pcapWriteMethod = Config.get("pcapWriteMethod");
+  var writer = internals.writers[pcapWriteMethod];
+  if (writer && writer.localNode === true) {
+    expireCheckAll();
+    setInterval(expireCheckAll, 60*1000);
+  }
 
   loadFields();
   setInterval(loadFields, 2*60*1000);

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -8868,17 +8868,17 @@ function main () {
     internals.previousNodesStats.push(info.nodes);
   });
 
+  loadFields();
+  setInterval(loadFields, 2*60*1000);
+
+  loadPlugins();
+
   var pcapWriteMethod = Config.get("pcapWriteMethod");
   var writer = internals.writers[pcapWriteMethod];
   if (writer && writer.localNode === true) {
     expireCheckAll();
     setInterval(expireCheckAll, 60*1000);
   }
-
-  loadFields();
-  setInterval(loadFields, 2*60*1000);
-
-  loadPlugins();
 
   createRightClicks();
   setInterval(createRightClicks, 5*60*1000);


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->

**Clearly describe the problem and solution**

The s3 plugins do work with other implementations of the s3 protocol pretty much as is. We ran moloch against a Pithos s3 instance for over a year pretty successfully but had to carry a custom patch to force the "endpoint" setting for the viewer and to set s3Host in capture. Recently set this up again with a recent version of moloch and minio, and again it is working well.

This patch makes exposes a `s3Host` so that others can choose to use a non-s3 s3 too.

**Relevant issue number(s) if applicable**

N/A

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

No errors for the viewer, and N/A for parliament.

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

Still working on getting these working in my env and its the end of the day here, but wanted to get this up for review in the meantime.

## License

I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
