### PR TITLE
Allow more control over the logging in viewer

### DIFF
--- a/release/config.ini.sample
+++ b/release/config.ini.sample
@@ -67,6 +67,12 @@ interface=MOLOCH_INTERFACE
 # Log viewer access requests to a different log file
 #accessLogFile = MOLOCH_INSTALL_DIR/logs/access.log
 
+# Control the log format for access requests. This uses URI % encoding.
+#accessLogFormat = :date :username %1b[1m:method%1b[0m %1b[33m:url%1b[0m :status :res[content-length] bytes :response-time ms
+
+# Control whether requests to /eshealth.json are suppressed from logging
+#accessLogSuppressHealth = true
+
 # The directory to save raw pcap files to
 pcapDir = MOLOCH_INSTALL_DIR/raw
 

--- a/release/config.ini.sample
+++ b/release/config.ini.sample
@@ -70,8 +70,9 @@ interface=MOLOCH_INTERFACE
 # Control the log format for access requests. This uses URI % encoding.
 #accessLogFormat = :date :username %1b[1m:method%1b[0m %1b[33m:url%1b[0m :status :res[content-length] bytes :response-time ms
 
-# Control whether requests to /eshealth.json are suppressed from logging
-#accessLogSuppressHealth = true
+# Control whether requests to certain paths are suppressed from logging. 
+# This is a semicolon seperated list.
+#accessLogSuppressPaths = /eshealth.json
 
 # The directory to save raw pcap files to
 pcapDir = MOLOCH_INSTALL_DIR/raw

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -272,15 +272,10 @@ if (_accesslogfile) {
 
 var _logger_format = decodeURIComponent(Config.get("accessLogFormat",
        ':date :username %1b[1m:method%1b[0m %1b[33m:url%1b[0m :status :res[content-length] bytes :response-time ms'));
-var _logger_options = {stream: _stream};
+var _suppressPaths = Config.getArray("accessLogSuppressPaths", ";", "");
 
-if (Config.get("accessLogSuppressHealth")) {
-  _logger_options.skip = function(req, res) {
-    return req.path === "/eshealth.json";
-  };
-}
-
-app.use(logger(_logger_format, _logger_options));
+app.use(logger(_logger_format, {stream: _stream,
+  skip: (req, res) => { return _suppressPaths.includes(req.path); }}));
 app.use(compression());
 app.use(methodOverride());
 

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -276,7 +276,7 @@ var _logger_options = {stream: _stream};
 
 if (Config.get("accessLogSuppressHealth")) {
   _logger_options.skip = function(req, res) {
-    return req.path == "/eshealth.json";
+    return req.path === "/eshealth.json";
   };
 }
 

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -270,8 +270,17 @@ if (_accesslogfile) {
   _stream = fs.createWriteStream(_accesslogfile, {flags: 'a'});
 }
 
+var _logger_format = decodeURIComponent(Config.get("accessLogFormat",
+       ':date :username %1b[1m:method%1b[0m %1b[33m:url%1b[0m :status :res[content-length] bytes :response-time ms'));
+var _logger_options = {stream: _stream};
 
-app.use(logger(':date :username \x1b[1m:method\x1b[0m \x1b[33m:url\x1b[0m :status :res[content-length] bytes :response-time ms',{stream: _stream}));
+if (Config.get("accessLogSuppressHealth")) {
+  _logger_options.skip = function(req, res) {
+    return req.path == "/eshealth.json";
+  };
+}
+
+app.use(logger(_logger_format, _logger_options));
 app.use(compression());
 app.use(methodOverride());
 


### PR DESCRIPTION


**Clearly describe the problem and solution**

This adds two more configuration items to control the request logging in the viewer. In particular it allows the log format to be chosen (e.g. without any escape sequences) and whether the eshealth.json should be logged as well.

**Relevant issue number(s) if applicable**

#1375 

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

Yes

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

Yes

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
