### PR TITLE
Only request facets when needed, and check for '1'

### DIFF
--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -2979,7 +2979,7 @@ function buildSessionQuery (req, buildCb) {
       break;
   }
 
-  if (req.query.facets) {
+  if (req.query.facets === '1') {
     query.aggregations = {};
     // only add map aggregations if requested
     if (req.query.map === 'true') {
@@ -4781,7 +4781,7 @@ app.get('/sessions.json', [noCacheJson, recordResponseTime, logAction('sessions'
 });
 
 app.get('/spigraph.json', [noCacheJson, recordResponseTime, logAction('spigraph'), fieldToExp, setCookie], (req, res) => {
-  req.query.facets = 1;
+  req.query.facets = '1';
 
   buildSessionQuery(req, function(bsqErr, query, indices) {
     var results = {items: [], graph: {}, map: {}};
@@ -4960,7 +4960,7 @@ app.get('/spiview.json', [noCacheJson, recordResponseTime, logAction('spiview'),
       query.aggregations = {};
     }
 
-    if (req.query.facets) {
+    if (req.query.facets === '1') {
       query.aggregations.protocols = {terms: {field: "protocol", size:1000}};
     }
 
@@ -5023,7 +5023,7 @@ app.get('/spiview.json', [noCacheJson, recordResponseTime, logAction('spiview'),
         });
       }
 
-      if (req.query.facets) {
+      if (req.query.facets === '1') {
         graph = graphMerge(req, query, sessions.aggregations);
         map = mapMerge(sessions.aggregations);
         protocols = {};

--- a/viewer/vueapp/src/components/hunt/Hunt.vue
+++ b/viewer/vueapp/src/components/hunt/Hunt.vue
@@ -1271,7 +1271,7 @@ export default {
       return { // sessions query defaults
         length: this.$route.query.length || 50, // page length
         start: 0, // first item index
-        facets: 1,
+        facets: 0,
         date: this.$store.state.timeRange,
         startTime: this.$store.state.time.startTime,
         stopTime: this.$store.state.time.stopTime,

--- a/viewer/vueapp/src/components/spiview/Spiview.vue
+++ b/viewer/vueapp/src/components/spiview/Spiview.vue
@@ -786,6 +786,7 @@ export default {
       if (!field) { field = 'dstIp'; }
 
       let query = this.constructQuery(field, 100);
+      query.facets = 1; // Force facets for map data
 
       this.get(query).promise
         .then((response) => {
@@ -799,7 +800,7 @@ export default {
     /* helper functions ---------------------------------------------------- */
     constructQuery: function (dbField, count) {
       return {
-        facets: 1,
+        facets: newQuery ? '1' : '0', // Only get facets for initial query for performance
         spi: `${dbField}:${count}`,
         date: this.query.date,
         startTime: this.query.startTime,


### PR DESCRIPTION
Don't request facets for hunts and only for spiview on the first query that is used to update the map or graph.  This helps a lot with performance to not have the facets.  I couldn't figure out how to NOT send the param so I just now check specifically for '1'.