### PR TITLE
Updates sample.ini.config with auto-creation example

### DIFF
--- a/release/config.ini.sample
+++ b/release/config.ini.sample
@@ -152,6 +152,34 @@ dropGroup=daemon
 # RequestHeader set MOLOCH_USER %{ENV_RU}e
 #userNameHeader=moloch_user
 
+#
+# Headers to use to determine if user from `userNameHeader` is
+# authorized to use the system, and if so create a new user
+# in the Moloch user database.  This implementation expects that
+# the users LDAP/AD groups (or similar) are populated into an 
+# HTTP header by the Apache (or similar) referenced above.
+# The JSON in userAutoCreateTmpl is used to insert the new
+# user into the moloch database (if not already present)
+# and additional HTTP headers can be sourced from the request
+# to populate various fields.  
+#
+# The example below pulls verifies that an HTTP header called `UserGroup`
+# is present, and contains the value "MOLOCH_ACCESS".  If this authorization
+# check passes, the user database is inspected for the user in `userNameHeader` 
+# and if it is not present it is created.  The system uses the
+# `moloch_user` and `http_auth_mail` headers from the
+# request and uses them to populate `userId` and `userName`
+# fields for the new user record. 
+#
+# Once the user record is created, this functionaity
+# neither updates nor deletes the data, though if the user is no longer
+# reported to be in the group, access is denied regardless of the status
+# in the moloch database.
+#
+#requiredAuthHeader="UserGroup"
+#requiredAuthHeaderVal="MOLOCH_ACCESS"
+#userAutoCreateTmpl={"userId": "${this.moloch_user}", "userName": "${this.http_auth_mail}", "enabled": true, "webEnabled": true, "headerAuthEnabled": true, "emailSearch": true, "createEnabled": false, "removeEnabled": false, "packetSearch": true }
+
 # Should we parse extra smtp traffic info
 parseSMTP=true
 


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->

**Clearly describe the problem and solution**
Per https://github.com/aol/moloch/pull/1120, this is a documentation update to give an example of how to leverage the user auto-creation templates

**Relevant issue number(s) if applicable**

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
