### PR TITLE
fix error when parsing pcaps without ether data (e.g. from OpenVPN tunnel)

### DIFF
--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -6397,7 +6397,7 @@ function localSessionDetail(req, res) {
     } else if (packets.length === 0) {
       session._err = "No pcap data found";
       localSessionDetailReturn(req, res, session, []);
-    } else if (packets[0].ether.data !== undefined) {
+    } else if (packets[0].ether !== undefined && packets[0].ether.data !== undefined) {
       Pcap.reassemble_generic_ether(packets, +req.query.packets || 200, function(err, results) {
         session._err = err;
         localSessionDetailReturn(req, res, session, results || []);


### PR DESCRIPTION
When opening the session details for a session which does not have ethernet data, for example pcaps obtained by capturing packets within an OpenVPN tunnel, the viewer tries to access `data` of `packets[0].ether`, which is undefined and thus causes the viwer to crash

```
moloch_1               | /data/moloch/viewer/viewer.js:6400
moloch_1               |     } else if (packets[0].ether.data !== undefined) {
moloch_1               |                                 ^
moloch_1               | 
moloch_1               | TypeError: Cannot read property 'data' of undefined
moloch_1               |     at /data/moloch/viewer/viewer.js:6400:33
moloch_1               |     at fixFields (/data/moloch/viewer/viewer.js:4625:12)
moloch_1               |     at /data/moloch/viewer/viewer.js:6177:9
moloch_1               |     at /data/moloch/viewer/viewer.js:6119:5
moloch_1               |     at /data/moloch/node_modules/async/dist/async.js:473:16
moloch_1               |     at iterateeCallback (/data/moloch/node_modules/async/dist/async.js:992:24)
moloch_1               |     at /data/moloch/node_modules/async/dist/async.js:969:16
moloch_1               |     at /data/moloch/viewer/viewer.js:6381:5
moloch_1               |     at /data/moloch/viewer/viewer.js:6062:9
moloch_1               |     at fs.read (/data/moloch/viewer/pcap.js:226:18)
moloch_1               |     at FSReqWrap.wrapper [as oncomplete] (fs.js:467:17)
```

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors:** yes

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`:** No, I only checked that the issue is resolved by rebuilding the Dockerfile and checking manually in a browser since I don't have a dev environment setup, but I am quite confident that this fix should not break anything.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
