### PR TITLE
update DAQ to 2.0.7 in ./easybutton-build.sh

### DIFF
--- a/easybutton-build.sh
+++ b/easybutton-build.sh
@@ -17,7 +17,7 @@ MAXMIND=1.3.2
 PCAP=1.9.1
 CURL=7.68.0
 LUA=5.3.5
-DAQ=2.0.6
+DAQ=2.0.7
 NODE=10.20.1
 
 TDIR="/data/moloch"


### PR DESCRIPTION
daq was updated to `2.0.7` and unfortunately downloading the `2.0.6` version now leads to a 404.

```
--2020-04-21 10:52:01--  https://www.snort.org/downloads/snort/daq-2.0.6.tar.gz
Resolving www.snort.org (www.snort.org)... 104.18.138.9, 104.18.139.9, 2606:4700::6812:8b09, ...
Connecting to www.snort.org (www.snort.org)|104.18.138.9|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2020-04-21 10:52:02 ERROR 404: Not Found.
```

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
