### PR TITLE
Sticky table header

### DIFF
--- a/viewer/vueapp/src/components/sessions/Sessions.vue
+++ b/viewer/vueapp/src/components/sessions/Sessions.vue
@@ -54,6 +54,7 @@
 
       <!-- sessions results -->
       <table class="table-striped sessions-table"
+        :class="{'sticky-header':stickyHeader}"
         :style="tableStyle"
         id="sessionsTable">
         <thead>
@@ -197,7 +198,7 @@
               <th v-for="header of headers"
                 :key="header.dbField"
                 class="moloch-col-header"
-                :style="{'width': header.width + 'px'}"
+                :style="{'width': `${header.width}px`}"
                 :class="{'active':isSorted(header.sortBy || header.dbField) >= 0, 'info-col-header': header.dbField === 'info'}">
                 <!-- non-sortable column -->
                 <span v-if="header.dbField === 'info'"
@@ -391,13 +392,15 @@
             </template>
           </tr>
         </thead>
+
         <tbody class="small">
           <!-- session + detail -->
           <template v-for="(session, index) of sessions.data">
             <tr :key="session.id"
               :id="'session'+session.id">
               <!-- toggle button and ip protocol -->
-              <td style="width: 85px;">
+              <td width="85"
+                style="white-space: nowrap; width: 85px !important;">
                 <toggle-btn class="mt-1"
                   :opened="session.expanded"
                   @toggle="toggleSessionDetail(session)">
@@ -418,7 +421,7 @@
               <!-- field values -->
               <td v-for="col in headers"
                 :key="col.dbField"
-                :style="{'width': col.width + 'px'}">
+                :style="{'width': `${col.width}px`}">
                 <!-- field value is an array -->
                 <span v-if="Array.isArray(session[col.dbField])">
                   <span v-for="value in session[col.dbField]"
@@ -578,7 +581,8 @@ export default {
       viewChanged: false,
       infoFields: customCols.info.children,
       colVisMenuOpen: false,
-      infoFieldVisMenuOpen: false
+      infoFieldVisMenuOpen: false,
+      stickyHeader: false
     };
   },
   created: function () {
@@ -647,6 +651,9 @@ export default {
   watch: {
     'query.view': function (newView, oldView) {
       this.viewChanged = true;
+    },
+    '$store.state.stickyViz': function () {
+      this.stickyHeader = this.$store.state.stickyViz;
     }
   },
   methods: {
@@ -1752,6 +1759,33 @@ table.sessions-table tbody tr td {
 /*!* table.sessions-table column reorder *!*/
 .JColResizer > tbody > tr > td, .JColResizer > tbody > tr > th {
   overflow: visible !important; /* show overflow for clickable fields */
+}
+
+/* sticky table header ----------------------- */
+table.sessions-table.sticky-header > thead {
+  left: 0;
+  right: 0;
+  z-index: 3;
+  position: fixed;
+  overflow: hidden;
+  margin-top: -12px;
+  padding-top: 12px;
+  padding-left: 0.5rem;
+  box-shadow: 0 6px 9px -6px black;
+  background-color: var(--color-background, white);
+}
+table.sessions-table.sticky-header > thead > tr {
+  border-top: 1px solid rgb(238, 238, 238);
+  height: 50px; /* TODO ECR have to set specific height for body? */
+}
+table.sessions-table.sticky-header > tbody > tr:first-child {
+  margin-top: 54px; /* TODO ECR push body down under sticky header */
+}
+/* need this to make sure that the body cells are the correct width */
+table.sessions-table.sticky-header > tbody > tr {
+  width: 100%;
+  display: table;
+  table-layout: fixed;
 }
 
 /* table column headers -------------------- */

--- a/viewer/vueapp/src/components/sessions/Sessions.vue
+++ b/viewer/vueapp/src/components/sessions/Sessions.vue
@@ -52,23 +52,24 @@
         </moloch-sticky-sessions>
       </transition> <!-- /sticky (opened) sessions -->
 
-      <!-- table fit button -->
-      <button type="button"
-        v-if="showFitButton && !loading"
-        class="btn btn-xs btn-theme-quaternary fit-btn"
-        @click="fitTable"
-        v-b-tooltip.hover
-        title="Fit the table to the current window size">
-        <span class="fa fa-arrows-h">
-        </span>
-      </button> <!-- /table fit button -->
-
       <!-- sessions results -->
       <table class="table-striped sessions-table"
         :class="{'sticky-header':stickyHeader}"
         :style="tableStyle"
         id="sessionsTable">
         <thead ref="tableHeader">
+          <!-- table fit button -->
+          <div class="fit-btn-container">
+            <button type="button"
+              v-if="showFitButton && !loading"
+              class="btn btn-xs btn-theme-quaternary fit-btn"
+              @click="fitTable"
+              v-b-tooltip.hover
+              title="Fit the table to the current window size">
+              <span class="fa fa-arrows-h">
+              </span>
+            </button>
+          </div> <!-- /table fit button -->
           <tr ref="draggableColumns">
             <!-- table options -->
             <th class="ignore-element"
@@ -1779,7 +1780,6 @@ form.sessions-paging {
 
 .sessions-content {
   padding-top: 10px;
-  overflow-y: auto;
 }
 
 /* sessions table -------------------------- */
@@ -1919,10 +1919,12 @@ table.sessions-table.sticky-header > tbody > tr.no-table-header-overflow {
 }
 
 /* table fit button -------------------------- */
-button.fit-btn {
-  top: 310px;
-  left: 10px;
-  z-index: 5;
+div.fit-btn-container {
+  top: -18px;
+  z-index: 3;
+  position: relative;
+}
+div.fit-btn-container > button.fit-btn {
   position: absolute;
 }
 

--- a/viewer/vueapp/src/components/visualizations/Visualizations.vue
+++ b/viewer/vueapp/src/components/visualizations/Visualizations.vue
@@ -425,6 +425,8 @@ export default {
     let stickyViz = localStorage && localStorage[`${basePath}-sticky-viz`] &&
       localStorage[`${basePath}-sticky-viz`] !== 'false';
 
+    this.$store.commit('toggleStickyViz', stickyViz);
+
     this.showMap = showMap;
     this.stickyViz = stickyViz;
 
@@ -447,6 +449,7 @@ export default {
     /* exposed functions --------------------------------------------------- */
     toggleStickyViz: function () {
       this.stickyViz = !this.stickyViz;
+      this.$store.commit('toggleStickyViz', this.stickyViz);
       localStorage[`${basePath}-sticky-viz`] = this.stickyViz;
     },
     /* exposed MAP functions */

--- a/viewer/vueapp/src/store.js
+++ b/viewer/vueapp/src/store.js
@@ -13,6 +13,7 @@ const store = new Vuex.Store({
       startTime: undefined,
       stopTime: undefined
     },
+    stickyViz: false,
     showMaps: true,
     showToolBars: true,
     mapSrc: true,
@@ -75,6 +76,9 @@ const store = new Vuex.Store({
     },
     clearExpression (state) {
       state.expression = undefined;
+    },
+    toggleStickyViz (state, value) {
+      state.stickyViz = value;
     },
     toggleMaps (state, value) {
       state.showMaps = value;


### PR DESCRIPTION
Make the sessions table header stick to the top of the page with the sticky visualization. The table is scrollable but the header will always stay at the top in the same position.

One caveat: a user cannot scroll the headers left/right. So if the table is wider than the window, and they scroll right, the table body cells no longer match the header columns.

Fixes #1416
