### PR TITLE
Add an error handling when malloc failed

### DIFF
--- a/capture/plugins/suricata.c
+++ b/capture/plugins/suricata.c
@@ -485,6 +485,8 @@ LOCAL gboolean suricata_timer(gpointer UNUSED(user_data))
 void moloch_plugin_init()
 {
     line = malloc(lineSize);
+    if (!line)
+      LOGEXIT("ERROR - Couldn't initialize plugin by out of memory: %d", lineSize);
 
     suricataAlertFile     = moloch_config_str(NULL, "suricataAlertFile", NULL);
     suricataExpireSeconds = moloch_config_int(NULL, "suricataExpireMinutes", 60, 10, 0xffffff) * 60;


### PR DESCRIPTION
Hello,

We should exit when malloc failed. 
Because if we can't allocate memory, processing thereafter can't continue. 

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.