### PR TITLE
allow build on arm64; bumped up ES to 7.7.1

### DIFF
--- a/easybutton-build.sh
+++ b/easybutton-build.sh
@@ -97,7 +97,7 @@ UNAME="$(uname)"
 # Installing dependencies
 echo "MOLOCH: Installing Dependencies"
 if [ -f "/etc/redhat-release" ] || [ -f "/etc/system-release" ]; then
-  sudo yum -y install wget curl pcre pcre-devel pkgconfig flex bison gcc-c++ zlib-devel e2fsprogs-devel openssl-devel file-devel make gettext libuuid-devel perl-JSON bzip2-libs bzip2-devel perl-libwww-perl libpng-devel xz libffi-devel readline-devel libtool libyaml-devel python perl-Socket6 perl-Test-Differences
+  sudo yum -y install wget curl pcre pcre-devel pkgconfig flex bison gcc-c++ zlib-devel e2fsprogs-devel openssl-devel file-devel make gettext libuuid-devel perl-JSON bzip2-libs bzip2-devel perl-libwww-perl libpng-devel xz libffi-devel readline-devel libtool libyaml-devel perl-Socket6 perl-Test-Differences
   if [ $? -ne 0 ]; then
     echo "MOLOCH: yum failed"
     exit 1

--- a/easybutton-build.sh
+++ b/easybutton-build.sh
@@ -97,7 +97,7 @@ UNAME="$(uname)"
 # Installing dependencies
 echo "MOLOCH: Installing Dependencies"
 if [ -f "/etc/redhat-release" ] || [ -f "/etc/system-release" ]; then
-  sudo yum -y install wget curl pcre pcre-devel pkgconfig flex bison gcc-c++ zlib-devel e2fsprogs-devel openssl-devel file-devel make gettext libuuid-devel perl-JSON bzip2-libs bzip2-devel perl-libwww-perl libpng-devel xz libffi-devel readline-devel libtool libyaml-devel perl-Socket6 perl-Test-Differences
+  sudo yum -y install wget curl pcre pcre-devel pkgconfig flex bison gcc-c++ zlib-devel e2fsprogs-devel openssl-devel file-devel make gettext libuuid-devel perl-JSON bzip2-libs bzip2-devel perl-libwww-perl libpng-devel xz libffi-devel readline-devel libtool libyaml-devel python perl-Socket6 perl-Test-Differences
   if [ $? -ne 0 ]; then
     echo "MOLOCH: yum failed"
     exit 1
@@ -105,7 +105,7 @@ if [ -f "/etc/redhat-release" ] || [ -f "/etc/system-release" ]; then
 fi
 
 if [ -f "/etc/debian_version" ]; then
-  sudo apt-get -qq install wget curl libpcre3-dev uuid-dev libmagic-dev pkg-config g++ flex bison zlib1g-dev libffi-dev gettext libgeoip-dev make libjson-perl libbz2-dev libwww-perl libpng-dev xz-utils libffi-dev libssl-dev libreadline-dev libtool libyaml-dev dh-autoreconf libsocket6-perl libtest-differences-perl
+  sudo apt-get -qq install wget curl libpcre3-dev uuid-dev libmagic-dev pkg-config g++ flex bison zlib1g-dev libffi-dev gettext libgeoip-dev make libjson-perl libbz2-dev libwww-perl libpng-dev xz-utils libffi-dev libssl-dev libreadline-dev libtool libyaml-dev dh-autoreconf python libsocket6-perl libtest-differences-perl
   if [ $? -ne 0 ]; then
     echo "MOLOCH: apt-get failed"
     exit 1
@@ -311,14 +311,23 @@ if [ $DORMINSTALL -eq 1 ]; then
 fi
 
 # Install node if not already there
+case "$(uname -m)" in
+    "x86_64")
+        ARCH="x64"
+        ;;
+    "aarch64")
+        ARCH="arm64"
+        ;;
+esac
+
 if [ $DONODE -eq 1 ] && [ ! -f "$TDIR/bin/node" ]; then
     echo "MOLOCH: Installing node $NODE"
     sudo mkdir -p $TDIR/bin $TDIR/etc
     if [ ! -f node-v$NODE-linux-x64.tar.xz ] ; then
-        wget https://nodejs.org/download/release/v$NODE/node-v$NODE-linux-x64.tar.xz
+        wget https://nodejs.org/download/release/v$NODE/node-v$NODE-linux-$ARCH.tar.xz
     fi
-    sudo tar xfC node-v$NODE-linux-x64.tar.xz $TDIR
-    (cd $TDIR/bin ; sudo ln -sf ../node-v$NODE-linux-x64/bin/* .)
+    sudo tar xfC node-v$NODE-linux-$ARCH.tar.xz $TDIR
+    (cd $TDIR/bin ; sudo ln -sf ../node-v$NODE-linux-$ARCH/bin/* .)
 fi
 
 if [ $DOINSTALL -eq 1 ]; then

--- a/release/Configure
+++ b/release/Configure
@@ -142,15 +142,25 @@ for CREATEDIR in $CREATEDIRS; do
 done
 
 ################################################################################
+ARCHR=$(uname -m)
+case $ARCHR in
+    "x86_64")
+        ARCH="x86_64"
+        ;;
+    "aarch64")
+        ARCH="arm64"
+        ;;
+esac
+
 if [ "$MOLOCH_LOCALELASTICSEARCH" == "yes" ]; then
     echo "Moloch - Downloading and installing demo OSS version of Elasticsearch"
-    ES_VERSION=7.6.2
+    ES_VERSION=7.7.0
     if [ -f "/etc/redhat-release" ] || [ -f "/etc/system-release" ]; then
-        yum install https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-${ES_VERSION}-x86_64.rpm
+        yum install https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-${ES_VERSION}-$ARCHR.rpm
     else
-        wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-${ES_VERSION}-amd64.deb
-        dpkg -i elasticsearch-oss-${ES_VERSION}-amd64.deb
-        /bin/rm -f elasticsearch-oss-${ES_VERSION}-amd64.deb
+        wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-${ES_VERSION}-$ARCH.deb
+        dpkg -i elasticsearch-oss-${ES_VERSION}-$ARCH.deb
+        /bin/rm -f elasticsearch-oss-${ES_VERSION}-$ARCH.deb
     fi
 fi
 

--- a/release/Configure
+++ b/release/Configure
@@ -154,7 +154,7 @@ esac
 
 if [ "$MOLOCH_LOCALELASTICSEARCH" == "yes" ]; then
     echo "Moloch - Downloading and installing demo OSS version of Elasticsearch"
-    ES_VERSION=7.7.0
+    ES_VERSION=7.7.1
     if [ -f "/etc/redhat-release" ] || [ -f "/etc/system-release" ]; then
         yum install https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-${ES_VERSION}-$ARCHR.rpm
     else


### PR DESCRIPTION
Allow building with easybutton on arm64.


**Clearly describe the problem and solution**
Allow building on arm64.
Minor changes to easybutton and Configure scripts.
I couldn't find downloadable ES arm64 binaries before version 7.7.0, so bumped up ES version in the Configure script to 7.7.0.
Also had to add python dependency.

**Relevant issue number(s) if applicable**
n/a

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**
n/a

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**
n/a

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
