### PR TITLE
Height for users paging was accidentally removed. Re-added to page's css

### DIFF
--- a/viewer/vueapp/src/components/users/Users.vue
+++ b/viewer/vueapp/src/components/users/Users.vue
@@ -872,6 +872,7 @@ export default {
 /* paging/toast navbar */
 .users-paging {
   z-index: 4;
+  height: 40px;
   background-color: var(--color-quaternary-lightest);
 }
 


### PR DESCRIPTION
On the users page, the offset for the paging section was ignored. This caused the page contents to be slightly hidden at the top by the dropdown menu. Re-added the css that was removed in an old commit. 