### PR TITLE
User page fixes

### DIFF
--- a/viewer/vueapp/src/components/users/Users.vue
+++ b/viewer/vueapp/src/components/users/Users.vue
@@ -355,9 +355,14 @@
           </transition-group>
         </table> <!-- /user table -->
 
+        <div v-if="createError"
+          class="alert alert-sm alert-danger p-3  mt-4 text-break">
+          <span class="fa fa-exclamation-triangle">
+          </span>&nbsp;
+          {{ createError }}
+        </div>
         <!-- new user form -->
-        <div class="row new-user-form mr-1 ml-1 mt-4">
-
+        <div class="row new-user-form mr-1 ml-1">
           <div class="col-sm-7">
             <div class="row mb-3">
               <div class="col-sm-9 offset-sm-3">
@@ -455,12 +460,6 @@
                   </span>&nbsp;
                   Create
                 </button>
-                <span v-if="createError"
-                  class="pull-right alert alert-sm alert-danger mr-3">
-                  <span class="fa fa-exclamation-triangle">
-                  </span>&nbsp;
-                  {{ createError }}
-                </span>
               </div>
             </form>
           </div>

--- a/viewer/vueapp/src/components/users/Users.vue
+++ b/viewer/vueapp/src/components/users/Users.vue
@@ -332,7 +332,7 @@
                         </div>
                         <select class="form-control time-limit-select"
                           v-model="listUser[columns[11].sort]"
-                          @change="changeTimeLimit(listUser)">
+                          @change="changeTimeLimit(listUser); userChanged(listUser)">
                           <option value="1">1 hour</option>
                           <option value="6">6 hours</option>
                           <option value="24">24 hours</option>
@@ -423,7 +423,8 @@
                 <div class="col-sm-9">
                   <select :id="columns[11].sort"
                     class="form-control form-control-sm"
-                    v-model="newuser[columns[11].sort]">
+                    v-model="newuser[columns[11].sort]"
+                    @change="changeTimeLimit(newuser)">
                     <option value="1">1 hour</option>
                     <option value="6">6 hours</option>
                     <option value="24">24 hours</option>
@@ -740,7 +741,6 @@ export default {
       } else {
         user.timeLimit = parseInt(user.timeLimit);
       }
-      this.userChanged(user);
     },
     userChanged: function (user) {
       this.$set(user, 'changed', true);


### PR DESCRIPTION
- Fixed #1467 where reselecting "All" option for new users causes an error.
- Moved and centered error message box to top of new user form.
- Instead of using a "changed" boolean flag, I added a reference object to see if fields have changed. 
- "Save" and "Cancel" buttons on "update user" are hidden if at any point the user state matches whats in the DB. Previously buttons had to be clicked to re-hide these. 
- Creating users, updating users, sorting users, or canceling edits will never result in other edits being removed from the page
