### PR TITLE
Add action type for config actions

### DIFF
--- a/tests/config.test.ini
+++ b/tests/config.test.ini
@@ -246,7 +246,7 @@ format=tagger
 VTIP=url:https://www.virustotal.com/en/ip-address/%TEXT%/information/;name:Virus Total IP;category:ip
 VTHOST=url:https://www.virustotal.com/en/domain/%HOST%/information/;name:Virus Total Host;category:host
 VTURL=url:https://www.virustotal.com/latest-scan/%URL%;name:Virus Total URL;category:url
-reverseDNS=url:/moloch/reverseDNS.txt?ip=%TEXT%;name:Get Reverse DNS;category:ip;actionType:fetch
+#reverseDNS=url:/moloch/reverseDNS.txt?ip=%TEXT%;name:Get Reverse DNS;category:ip;actionType:fetch
 
 
 [custom-fields]

--- a/tests/config.test.ini
+++ b/tests/config.test.ini
@@ -246,6 +246,8 @@ format=tagger
 VTIP=url:https://www.virustotal.com/en/ip-address/%TEXT%/information/;name:Virus Total IP;category:ip
 VTHOST=url:https://www.virustotal.com/en/domain/%HOST%/information/;name:Virus Total Host;category:host
 VTURL=url:https://www.virustotal.com/latest-scan/%URL%;name:Virus Total URL;category:url
+reverseDNS=url:/moloch/dns.json?ip=%TEXT%;name:Get Reverse DNS;category:ip;actionType:fetch
+
 
 [custom-fields]
 iscool=kind:termfield;count:true;friendly:Is cool;db:iscool;help:Is Cool String

--- a/tests/config.test.ini
+++ b/tests/config.test.ini
@@ -246,7 +246,7 @@ format=tagger
 VTIP=url:https://www.virustotal.com/en/ip-address/%TEXT%/information/;name:Virus Total IP;category:ip
 VTHOST=url:https://www.virustotal.com/en/domain/%HOST%/information/;name:Virus Total Host;category:host
 VTURL=url:https://www.virustotal.com/latest-scan/%URL%;name:Virus Total URL;category:url
-reverseDNS=url:/moloch/dns.json?ip=%TEXT%;name:Get Reverse DNS;category:ip;actionType:fetch
+reverseDNS=url:/moloch/reverseDNS.txt?ip=%TEXT%;name:Get Reverse DNS;category:ip;actionType:fetch
 
 
 [custom-fields]

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -5198,7 +5198,7 @@ app.get('/reverseDNS.txt', [noCacheJson, logAction()], function (req, res) {
   console.log('reverseDNS.txt', req.query);
   dns.reverse(req.query.ip, function (err, data) {
     if (err) {
-      return res.send("[]");
+      return res.send('[]');
     }
     return res.send(data.join(', '));
   });

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -478,6 +478,7 @@ app.use(function (req, res, next) {
       return {name: "Decoded:", value: atob(value.substring(6))};
     return undefined;
   }` };
+  mrc.reverseDNS = { category: 'ip', name: 'Get Reverse DNS', url: '/moloch/reverseDNS.txt?ip=%TEXT%', actionType: 'fetch' };
   mrc.bodyHashMd5 = { category: 'md5', url: '/%NODE%/%ID%/bodyHash/%TEXT%', name: 'Download File' };
   mrc.bodyHashSha256 = { category: 'sha256', url: '/%NODE%/%ID%/bodyHash/%TEXT%', name: 'Download File' };
 

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -5183,13 +5183,13 @@ app.get('/spiview.json', [noCacheJson, recordResponseTime, logAction('spiview'),
   });
 });
 
-app.get('/dns.json', [noCacheJson, logAction()], function (req, res) {
-  console.log('dns.json', req.query);
+app.get('/reverseDNS.txt', [noCacheJson, logAction()], function (req, res) {
+  console.log('reverseDNS.txt', req.query);
   dns.reverse(req.query.ip, function (err, data) {
     if (err) {
-      return res.send({ hosts: [] });
+      return res.send("[]");
     }
-    return res.send({ hosts: data });
+    return res.send(data.join(', '));
   });
 });
 

--- a/viewer/vueapp/src/components/sessions/SessionField.vue
+++ b/viewer/vueapp/src/components/sessions/SessionField.vue
@@ -70,10 +70,18 @@
             <b-dropdown-divider></b-dropdown-divider>
             <b-dropdown-item
               v-for="(item, key) in menuItems"
-              :key="key"
+              :key="'sync-item-' + key"
               :title="item.name + ' ' + item.value"
               :href="item.url"
               target="_blank">
+              <strong>{{ item.name }}</strong>
+              {{ item.value }}
+            </b-dropdown-item>
+            <b-dropdown-item
+              v-for="(item, key) in asyncMenuItems"
+              :key="'async-item-' + key"
+              :title="item.name"
+              v-on:click="fetchMenuData(item.url, key)">
               <strong>{{ item.name }}</strong>
               {{ item.value }}
             </b-dropdown-item>
@@ -159,6 +167,7 @@
 </template>
 
 <script>
+import Vue from 'vue';
 import ConfigService from '../utils/ConfigService';
 import MolochSessionInfo from './SessionInfo';
 
@@ -182,6 +191,7 @@ export default {
     return {
       isOpen: false,
       menuItems: {},
+      asyncMenuItems: {},
       molochClickables: undefined
     };
   },
@@ -411,6 +421,26 @@ export default {
         }
       }
     },
+    /* Briefly replaces menu value with fetched api data */
+    fetchMenuData: function (url, key) {
+      let options = {
+        method: 'GET',
+        url: url
+      };
+
+      let oldValue = this.asyncMenuItems[key].value;
+
+      Vue.axios(options)
+        .then((response) => {
+          this.$set(this.asyncMenuItems[key], 'value', response.data);
+          setTimeout(() => this.$set(this.asyncMenuItems[key], 'value', oldValue), 5000);
+        })
+        .catch((error) => {
+          this.$set(this.asyncMenuItems[key], 'value', 'Error fetching data');
+          setTimeout(() => this.$set(this.asyncMenuItems[key], 'value', oldValue), 5000);
+          console.log(error);
+        });
+    },
     /* Builds the dropdown menu items to display */
     buildMenu: function () {
       if (!this.parsed[0].value || !this.molochClickables) { return; }
@@ -431,7 +461,6 @@ export default {
 
       let urlParams = this.$route.query;
       let dateparams, isostart, isostop;
-      this.menuItems = {};
 
       if (urlParams.startTime && urlParams.stopTime) {
         dateparams = `startTime=${urlParams.startTime}&stopTime=${urlParams.stopTime}`;
@@ -458,7 +487,7 @@ export default {
           if (this.molochClickables[key].func !== undefined) {
             let v = this.molochClickables[key].func(key, text);
             if (v !== undefined) {
-              this.menuItems[key] = v;
+              this.$set(this.menuItems, key, v);
             }
             continue;
           }
@@ -506,7 +535,14 @@ export default {
             }
           }
 
-          this.menuItems[key] = { name: name, value: value, url: result };
+          if (this.molochClickables[key].actionType !== undefined) {
+            if (this.molochClickables[key].actionType === 'fetch') {
+              this.$set(this.asyncMenuItems, key, { name: name, value: value, url: result });
+              continue;
+            }
+          }
+
+          this.$set(this.menuItems, key, { name: name, value: value, url: result });
         }
       }
     }

--- a/viewer/vueapp/src/components/sessions/SessionField.vue
+++ b/viewer/vueapp/src/components/sessions/SessionField.vue
@@ -192,7 +192,8 @@ export default {
       isOpen: false,
       menuItems: {},
       asyncMenuItems: {},
-      molochClickables: undefined
+      molochClickables: undefined,
+      menuItemTimeout: null
     };
   },
   watch: {
@@ -423,6 +424,10 @@ export default {
     },
     /* Briefly replaces menu value with fetched api data */
     fetchMenuData: function (url, key) {
+      if (this.menuItemTimeout) {
+        return;
+      }
+
       let options = {
         method: 'GET',
         url: url
@@ -433,11 +438,17 @@ export default {
       Vue.axios(options)
         .then((response) => {
           this.$set(this.asyncMenuItems[key], 'value', response.data);
-          setTimeout(() => this.$set(this.asyncMenuItems[key], 'value', oldValue), 5000);
+          this.menuItemTimeout = setTimeout(() => {
+            this.$set(this.asyncMenuItems[key], 'value', oldValue);
+            this.menuItemTimeout = null;
+          }, 5000);
         })
         .catch((error) => {
           this.$set(this.asyncMenuItems[key], 'value', 'Error fetching data');
-          setTimeout(() => this.$set(this.asyncMenuItems[key], 'value', oldValue), 5000);
+          this.menuItemTimeout = setTimeout(() => {
+            this.$set(this.asyncMenuItems[key], 'value', oldValue);
+            this.menuItemTimeout = null;
+          }, 5000);
           console.log(error);
         });
     },


### PR DESCRIPTION
Adds an "actionType" piece for the config.ini actions. If it is equal to "fetch" the action will treat "url" pieces as an api endpoint and will fetch the data when the menu item is clicked. The data will put into the menu item and then hidden again after 5 seconds. 

#28 inspired this PR and has several updates for displaying reverse dns. Calculating the reverse dns is used as an example for this new action type (which also shows how it works with internal endpoints)