### PR TITLE
Fix Debian local Elasticsearch installation

### DIFF
--- a/release/Configure
+++ b/release/Configure
@@ -159,8 +159,8 @@ if [ "$MOLOCH_LOCALELASTICSEARCH" == "yes" ]; then
         yum install https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-${ES_VERSION}-${ARCHRPM}.rpm
     else
         wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-${ES_VERSION}-${ARCHDEB}.deb
-        dpkg -i elasticsearch-oss-${ES_VERSION}-$ARCH.deb
-        /bin/rm -f elasticsearch-oss-${ES_VERSION}-$ARCH.deb
+        dpkg -i elasticsearch-oss-${ES_VERSION}-$ARCHDEB.deb
+        /bin/rm -f elasticsearch-oss-${ES_VERSION}-$ARCHDEB.deb
     fi
 fi
 


### PR DESCRIPTION
Fixes the following problem:

    Install Elasticsearch server locally for demo, must have at least 3G of memory, NOT recommended for production use (yes or no) [no] yes
    java command not found, make sure java is installed and in the path and run again
    Password to encrypt S2S and other things [no-default] <redacted>
    Moloch - Creating configuration files
    Installing systemd start files, use systemctl
    Moloch - Downloading and installing demo OSS version of Elasticsearch
    --2020-06-26 11:38:25--  https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-7.7.1-amd64.deb
    Resolving artifacts.elastic.co (artifacts.elastic.co)... 2a04:4e42:14::734, 151.101.86.222
    Connecting to artifacts.elastic.co (artifacts.elastic.co)|2a04:4e42:14::734|:443... connected.
    HTTP request sent, awaiting response... 200 OK
    Length: 229922032 (219M) [application/octet-stream]
    Saving to: ‘elasticsearch-oss-7.7.1-amd64.deb’

    elasticsearch-oss-7.7.1-amd64.deb     100%[========================================================================>] 219.27M  10.9MB/s    in 21s

    2020-06-26 11:38:51 (10.6 MB/s) - ‘elasticsearch-oss-7.7.1-amd64.deb’ saved [229922032/229922032]

    dpkg: error: cannot access archive 'elasticsearch-oss-7.7.1-.deb': No such file or directory

<!-- Provide a clear and descriptive title -->

**Clearly describe the problem and solution**

**Relevant issue number(s) if applicable**

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
