### PR TITLE
MultiViewer: Add a warning if a comma is misused as a a host delimiter

### DIFF
--- a/viewer/multies.js
+++ b/viewer/multies.js
@@ -787,7 +787,7 @@ if (nodes.length === 0 || nodes[0] === '') {
 
 // First connect
 nodes.forEach((node) => {
-  if (node.toLowerCase().includes(",http")) {
+  if (node.toLowerCase().includes(',http')) {
     console.log('WARNING - multiESNodes may be using a comma as a host delimiter, change to semicolon');
   }
   clients[node] = new ESC.Client({

--- a/viewer/multies.js
+++ b/viewer/multies.js
@@ -787,6 +787,9 @@ if (nodes.length === 0 || nodes[0] === '') {
 
 // First connect
 nodes.forEach((node) => {
+  if (node.toLowerCase().includes(",http")) {
+    console.log('WARNING - multiESNodes may be using a comma as a host delimiter, change to semicolon');
+  }
   clients[node] = new ESC.Client({
     host: node.split(',')[0],
     apiVersion: '6.8',


### PR DESCRIPTION

<!-- Provide a clear and descriptive title -->

**Clearly describe the problem and solution**
In the wild, I've seen several incidents of an administrator using a comma instead of a semicolon in the host list, resulting in the host being silently discarded (and an administrator spending a gigantic amount of time trying to diagnose). This change prints a warning to the log, but doesn't fail the startup in case there is some obscure ES client URL parameter that starts with `http`.

**Relevant issue number(s) if applicable**

This is a usability improvement, not a bugfix per-se.

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
