### PR TITLE
switch from linktype to dlt everywhere, fixes #1303 and #1479

### DIFF
--- a/capture/main.c
+++ b/capture/main.c
@@ -653,8 +653,8 @@ gboolean moloch_ready_gfunc (gpointer UNUSED(user_data))
         }
     }
     moloch_reader_start();
-    if (!config.pcapReadOffline && (pcapFileHeader.linktype == 0 || pcapFileHeader.snaplen == 0))
-        LOGEXIT("Reader didn't call moloch_packet_set_linksnap");
+    if (!config.pcapReadOffline && (pcapFileHeader.dlt == DLT_NULL || pcapFileHeader.snaplen == 0))
+        LOGEXIT("Reader didn't call moloch_packet_set_dltsnap");
     return FALSE;
 }
 /******************************************************************************/
@@ -737,7 +737,7 @@ LLVMFuzzerInitialize(int *UNUSED(argc), char ***UNUSED(argv))
     config.nodeName = strdup("fuzz");
 
     hashSalt = 0;
-    pcapFileHeader.linktype = 1;
+    pcapFileHeader.dlt = DLT_EN10MB;
 
     moloch_free_later_init();
     moloch_hex_init();

--- a/capture/moloch.h
+++ b/capture/moloch.h
@@ -706,7 +706,7 @@ typedef struct {
 	int32_t  thiszone;	/* gmt to local correction */
 	uint32_t sigfigs;	/* accuracy of timestamps */
 	uint32_t snaplen;	/* max length saved portion of each pkt */
-	uint32_t linktype;	/* data link type (LINKTYPE_*) */
+	uint32_t dlt;	        /* data link type - see https://github.com/aol/moloch/issues/1303#issuecomment-554684749 */
 } MolochPcapFileHdr_t;
 
 #ifndef likely
@@ -1039,7 +1039,9 @@ void     moloch_packet_batch_flush(MolochPacketBatch_t *batch);
 void     moloch_packet_batch(MolochPacketBatch_t * batch, MolochPacket_t * const packet);
 void     moloch_packet_batch_process(MolochPacketBatch_t * batch, MolochPacket_t * const packet, int thread);
 
-void     moloch_packet_set_linksnap(int linktype, int snaplen);
+void     moloch_packet_set_dltsnap(int dlt, int snaplen);
+void     moloch_packet_set_linksnap(int linktype, int snaplen); // Don't use, backwards compat
+uint32_t moloch_packet_dlt_to_linktype(int dlt);
 void     moloch_packet_drophash_add(MolochSession_t *session, int which, int min);
 
 void     moloch_packet_save_ethernet(MolochPacket_t * const packet, uint16_t type);

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -1232,7 +1232,7 @@ void moloch_packet_batch(MolochPacketBatch_t * batch, MolochPacket_t * const pac
     case DLT_IPV4: //RAW IPv4
         rc = moloch_packet_ip4(batch, packet, packet->pkt, packet->pktlen);
         break;
-    case DLT_IPV6: //RAW IPv4
+    case DLT_IPV6: //RAW IPv6
         rc = moloch_packet_ip6(batch, packet, packet->pkt, packet->pktlen);
         break;
     case DLT_NFLOG: // NFLOG

--- a/capture/plugins/daq/reader-daq.c
+++ b/capture/plugins/daq/reader-daq.c
@@ -91,7 +91,7 @@ void reader_daq_start() {
     int err;
 
     //ALW - Bug: assumes all linktypes are the same
-    moloch_packet_set_linksnap(daq_get_datalink_type(module, handles[0]), config.snapLen);
+    moloch_packet_set_dltsnap(daq_get_datalink_type(module, handles[0]), config.snapLen);
 
     int i;
     for (i = 0; i < MAX_INTERFACES && config.interface[i]; i++) {

--- a/capture/plugins/pfring/reader-pfring.c
+++ b/capture/plugins/pfring/reader-pfring.c
@@ -88,8 +88,6 @@ LOCAL void *reader_pfring_thread(void *posv)
 }
 /******************************************************************************/
 void reader_pfring_start() {
-    int dlt_to_linktype(int dlt);
-
     moloch_packet_set_dltsnap(DLT_EN10MB, config.snapLen);
 
     int i;

--- a/capture/plugins/pfring/reader-pfring.c
+++ b/capture/plugins/pfring/reader-pfring.c
@@ -90,7 +90,7 @@ LOCAL void *reader_pfring_thread(void *posv)
 void reader_pfring_start() {
     int dlt_to_linktype(int dlt);
 
-    moloch_packet_set_linksnap(1, config.snapLen);
+    moloch_packet_set_dltsnap(DLT_EN10MB, config.snapLen);
 
     int i;
     for (i = 0; i < MAX_INTERFACES && config.interface[i]; i++) {

--- a/capture/plugins/snf/reader-snf.c
+++ b/capture/plugins/snf/reader-snf.c
@@ -121,7 +121,7 @@ LOCAL void *reader_snf_thread(gpointer posv)
 }
 /******************************************************************************/
 void reader_snf_start() {
-    moloch_packet_set_linksnap(DLT_EN10MB, config.snapLen);
+    moloch_packet_set_dltsnap(DLT_EN10MB, config.snapLen);
 
     int ringStartOffset = (snfProcNum-1)*snfNumRings;
     int i, r;

--- a/capture/plugins/writer-s3.c
+++ b/capture/plugins/writer-s3.c
@@ -627,7 +627,9 @@ void writer_s3_create(const MolochPacket_t *packet)
 
     outputBuffer = moloch_http_get_buffer(config.pcapWriteSize + MOLOCH_PACKET_MAX_LEN);
     outputPos = 0;
-    append_to_output(&pcapFileHeader, 24, FALSE, 0);
+    uint32_t linktype = moloch_packet_dlt_to_linktype(pcapFileHeader.dlt);
+    append_to_output(&pcapFileHeader, 20, FALSE, 0);
+    append_to_output(&linktype, 4, FALSE, 0);
     make_new_block();                   // So we can read the header in a small amount of data fetched
 
     if (config.debug)

--- a/capture/reader-libpcap-file.c
+++ b/capture/reader-libpcap-file.c
@@ -557,7 +557,6 @@ LOCAL gboolean reader_libpcapfile_read()
 /******************************************************************************/
 LOCAL void reader_libpcapfile_opened()
 {
-    int dlt_to_linktype(int dlt);
     int moloch_db_can_quit();
 
     if (config.flushBetween) {

--- a/capture/reader-libpcap-file.c
+++ b/capture/reader-libpcap-file.c
@@ -574,11 +574,11 @@ LOCAL void reader_libpcapfile_opened()
         }
     }
 
-    moloch_packet_set_linksnap(dlt_to_linktype(pcap_datalink(pcap)) | pcap_datalink_ext(pcap), pcap_snapshot(pcap));
+    moloch_packet_set_dltsnap(pcap_datalink(pcap), pcap_snapshot(pcap));
 
     offlineFile = pcap_file(pcap);
 
-    if (config.bpf && pcapFileHeader.linktype != 239) {
+    if (config.bpf && pcapFileHeader.dlt != DLT_NFLOG) {
         struct bpf_program   bpf;
 
         if (pcap_compile(pcap, &bpf, config.bpf, 1, PCAP_NETMASK_UNKNOWN) == -1) {

--- a/capture/reader-libpcap.c
+++ b/capture/reader-libpcap.c
@@ -91,8 +91,6 @@ LOCAL void *reader_libpcap_thread(gpointer posv)
 }
 /******************************************************************************/
 void reader_libpcap_start() {
-    int dlt_to_linktype(int dlt);
-
     //ALW - Bug: assumes all linktypes are the same
     moloch_packet_set_dltsnap(pcap_datalink(pcaps[0]), pcap_snapshot(pcaps[0]));
 

--- a/capture/reader-libpcap.c
+++ b/capture/reader-libpcap.c
@@ -94,7 +94,7 @@ void reader_libpcap_start() {
     int dlt_to_linktype(int dlt);
 
     //ALW - Bug: assumes all linktypes are the same
-    moloch_packet_set_linksnap(dlt_to_linktype(pcap_datalink(pcaps[0])) | pcap_datalink_ext(pcaps[0]), pcap_snapshot(pcaps[0]));
+    moloch_packet_set_dltsnap(pcap_datalink(pcaps[0]), pcap_snapshot(pcaps[0]));
 
     int i;
     for (i = 0; i < MAX_INTERFACES && config.interface[i]; i++) {

--- a/capture/reader-tpacketv3.c
+++ b/capture/reader-tpacketv3.c
@@ -203,7 +203,7 @@ void reader_tpacketv3_init(char *UNUSED(name))
         LOGEXIT("block size %d not divisible by %u", blocksize, config.snapLen);
     }
 
-    moloch_packet_set_linksnap(1, config.snapLen);
+    moloch_packet_set_dltsnap(DLT_EN10MB, config.snapLen);
 
     pcap_t *dpcap = pcap_open_dead(pcapFileHeader.linktype, pcapFileHeader.snaplen);
 

--- a/capture/reader-tpacketv3.c
+++ b/capture/reader-tpacketv3.c
@@ -205,7 +205,7 @@ void reader_tpacketv3_init(char *UNUSED(name))
 
     moloch_packet_set_dltsnap(DLT_EN10MB, config.snapLen);
 
-    pcap_t *dpcap = pcap_open_dead(pcapFileHeader.linktype, pcapFileHeader.snaplen);
+    pcap_t *dpcap = pcap_open_dead(pcapFileHeader.dlt, pcapFileHeader.snaplen);
 
     if (config.bpf) {
         if (pcap_compile(dpcap, &bpf, config.bpf, 1, PCAP_NETMASK_UNKNOWN) == -1) {

--- a/capture/rules.c
+++ b/capture/rules.c
@@ -713,7 +713,7 @@ void moloch_rules_recompile()
     if (deadPcap)
         pcap_close(deadPcap);
 
-    deadPcap = pcap_open_dead(pcapFileHeader.linktype, pcapFileHeader.snaplen);
+    deadPcap = pcap_open_dead(pcapFileHeader.dlt, pcapFileHeader.snaplen);
     MolochRule_t *rule;
     for (t = 0; t < MOLOCH_RULE_TYPE_NUM; t++) {
         for (r = 0; (rule = current.rules[t][r]); r++) {
@@ -721,7 +721,7 @@ void moloch_rules_recompile()
                 continue;
 
             pcap_freecode(&rule->bpfp);
-            if (pcapFileHeader.linktype != 239) {
+            if (pcapFileHeader.dlt != DLT_NFLOG) {
                 if (pcap_compile(deadPcap, &rule->bpfp, rule->bpf, 1, PCAP_NETMASK_UNKNOWN) == -1) {
                     LOGEXIT("ERROR - Couldn't compile filter %s: '%s' with %s", rule->filename, rule->bpf, pcap_geterr(deadPcap));
                 }

--- a/capture/writer-disk.c
+++ b/capture/writer-disk.c
@@ -340,7 +340,9 @@ LOCAL void writer_disk_create(MolochPacket_t * const packet)
     clock_gettime(CLOCK_REALTIME_COARSE, &outputFileTime);
 
     output->fileId = outputId;
-    memcpy(output->buf, &pcapFileHeader, 24);
+    memcpy(output->buf, &pcapFileHeader, 20);
+    uint32_t linktype = moloch_packet_dlt_to_linktype(pcapFileHeader.dlt);
+    memcpy(output->buf+20, &linktype, 4);
 }
 /******************************************************************************/
 struct pcap_timeval {

--- a/capture/writer-simple.c
+++ b/capture/writer-simple.c
@@ -266,7 +266,7 @@ LOCAL char *writer_simple_get_kekId ()
         {
             int namelen = strlen(config.nodeName);
             int bufboundary = j + namelen;
-            
+
             if(bufboundary >= (int) sizeof(okek)) {
                 LOGEXIT("ERROR - node name '%s' is too long", config.nodeName);
             }
@@ -351,7 +351,10 @@ LOCAL void writer_simple_write(const MolochSession_t * const session, MolochPack
             LOGEXIT("ERROR - pcap open failed - Couldn't open file: '%s' with %s  (%d) -- You may need to check directory permissions or set pcapWriteMethod=simple-nodirect in config.ini file.  See https://molo.ch/settings#pcapwritemethod", name, strerror(errno), errno);
         }
         info->file->pos = currentInfo[thread]->bufpos = 24;
-        memcpy(info->buf, &pcapFileHeader, 24);
+
+        memcpy(info->buf, &pcapFileHeader, 20);
+        uint32_t linktype = moloch_packet_dlt_to_linktype(pcapFileHeader.dlt);
+        memcpy(info->buf+20, &linktype, 4);
         if (config.debug)
             LOG("opened %d %s %d", thread, name, info->file->fd);
         g_free(name);


### PR DESCRIPTION
Switch to using dlt everywhere instead of linktype, when writing a header ourselves do the dlt->linktype conversion with moloch code from information in https://github.com/aol/moloch/issues/1303#issuecomment-554684749