### PR TITLE
Various wiseui changes

### DIFF
--- a/wiseService/vueapp/src/components/Config.vue
+++ b/wiseService/vueapp/src/components/Config.vue
@@ -6,6 +6,6 @@
 
 <script>
 export default {
-  name: 'CreateINI'
+  name: 'Config'
 };
 </script>

--- a/wiseService/vueapp/src/components/Navbar.vue
+++ b/wiseService/vueapp/src/components/Navbar.vue
@@ -20,7 +20,7 @@
             active-class="active"
             class="nav-link"
             exact>
-            Wise
+            Query
           </router-link>
         </li>
         <li class="nav-item mr-2">
@@ -32,11 +32,11 @@
           </router-link>
         </li>
         <li class="nav-item mr-2">
-          <router-link to="create-config"
+          <router-link to="config"
             active-class="active"
             class="nav-link"
             exact>
-            Build Wise Config
+            Config
           </router-link>
         </li>
         <!-- <li class="nav-item mr-2"

--- a/wiseService/vueapp/src/components/Query.vue
+++ b/wiseService/vueapp/src/components/Query.vue
@@ -143,6 +143,8 @@ export default {
     this.loadTypeOptions();
 
     if (this.$route.query.searchTerm) {
+      this.chosenSource = this.$route.query.searchSource;
+      this.chosenType = this.$route.query.searchType;
       this.searchTerm = this.$route.query.searchTerm;
       this.debounceSearch();
     }
@@ -198,6 +200,17 @@ export default {
         this.error = 'Search term is empty';
         return;
       }
+
+      this.$router.push({
+        query: {
+          ...this.$route.query,
+          searchSource: this.chosenSource,
+          searchType: this.chosenType,
+          searchTerm: this.searchTerm
+        }
+      }).catch((err) => {
+        console.log(err);
+      });
 
       this.error = '';
       WiseService.search(this.chosenSource, this.chosenType, this.searchTerm)

--- a/wiseService/vueapp/src/components/Query.vue
+++ b/wiseService/vueapp/src/components/Query.vue
@@ -78,8 +78,17 @@
       </div> <!-- /search -->
     </div>
 
+    <!-- empty search -->
+    <div v-if="!hasMadeASearch">
+      <div class="vertical-center info-area">
+        <span class="fa fa-3x fa-search">
+        </span>
+        Try adding a search query!
+      </div>
+    </div> <!-- /empty search -->
+
     <!-- tabbed view options -->
-    <b-tabs content-class="mt-3" v-if="searchResult.length > 0">
+    <b-tabs content-class="mt-3" v-else-if="searchResult.length > 0">
       <b-tab title="Table View" active>
         <b-table striped hover :items="searchResult" :fields="tableFields"></b-table>
       </b-tab>
@@ -101,6 +110,7 @@
         No Results
       </div>
     </div> <!-- /no results -->
+
   </div>  <!-- /container -->
 
 </template>
@@ -119,6 +129,7 @@ export default {
   data: function () {
     return {
       error: '',
+      hasMadeASearch: false,
       searchTerm: '',
       searchResult: [],
       tableFields: [],
@@ -198,6 +209,9 @@ export default {
     sendSearchQuery: function () {
       if (!this.searchTerm) {
         this.error = 'Search term is empty';
+        this.searchResult = [];
+        this.tableFields = [];
+        this.hasMadeASearch = false;
         return;
       }
 
@@ -211,6 +225,8 @@ export default {
       }).catch((err) => {
         console.log(err);
       });
+
+      this.hasMadeASearch = true;
 
       this.error = '';
       WiseService.search(this.chosenSource, this.chosenType, this.searchTerm)

--- a/wiseService/vueapp/src/components/Query.vue
+++ b/wiseService/vueapp/src/components/Query.vue
@@ -135,7 +135,6 @@ export default {
   },
   watch: {
     chosenSource: function () {
-      this.chosenType = '';
       this.loadTypeOptions();
     }
   },
@@ -185,7 +184,7 @@ export default {
         .then((data) => {
           this.error = '';
           this.types = data;
-          if (data.length >= 1) {
+          if (data.length >= 1 && !data.includes(this.chosenType)) {
             this.chosenType = data[0];
           }
         })

--- a/wiseService/vueapp/src/components/Query.vue
+++ b/wiseService/vueapp/src/components/Query.vue
@@ -217,12 +217,17 @@ export default {
     },
     clear: function () {
       this.searchTerm = '';
-      this.$router.replace({
-        query: {
-          ...this.$route.query,
-          searchTerm: ''
-        }
-      });
+
+      if (this.$route.query.searchTerm !== '') {
+        this.$router.replace({
+          query: {
+            ...this.$route.query,
+            searchTerm: ''
+          }
+        }).catch((err) => {
+          console.log(err);
+        });
+      }
     }
   }
 };

--- a/wiseService/vueapp/src/components/Query.vue
+++ b/wiseService/vueapp/src/components/Query.vue
@@ -112,7 +112,7 @@ import Error from './Error';
 let timeout;
 
 export default {
-  name: 'Wise',
+  name: 'Query',
   components: {
     Error
   },

--- a/wiseService/vueapp/src/router/index.js
+++ b/wiseService/vueapp/src/router/index.js
@@ -10,11 +10,7 @@ Vue.use(VueRouter);
 const routes = [
   {
     path: '/',
-    name: 'Query',
-    component: Query
-  },
-  {
-    path: '/query',
+    alias: '/query',
     name: 'Query',
     component: Query
   },

--- a/wiseService/vueapp/src/router/index.js
+++ b/wiseService/vueapp/src/router/index.js
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 import VueRouter from 'vue-router';
-import Wise from '../components/Wise.vue';
-import CreateConfig from '../components/CreateConfig.vue';
+import Query from '../components/Query.vue';
+import Config from '../components/Config.vue';
 import Help from '../components/Help.vue';
 import Stats from '../components/Stats.vue';
 
@@ -10,8 +10,13 @@ Vue.use(VueRouter);
 const routes = [
   {
     path: '/',
-    name: 'Wise',
-    component: Wise
+    name: 'Query',
+    component: Query
+  },
+  {
+    path: '/query',
+    name: 'Query',
+    component: Query
   },
   {
     path: '/statistics',
@@ -19,9 +24,9 @@ const routes = [
     component: Stats
   },
   {
-    path: '/create-config',
-    name: 'Create config',
-    component: CreateConfig
+    path: '/config',
+    name: 'Config',
+    component: Config
   },
   {
     path: '/help',


### PR DESCRIPTION
Various changes made to wiseUI:

- Changed navigation names. "wise" => "query" & "create config" => "config".
- Added a /query alias for the root path. 
- Fixed an error clearing the search bar.
- Placed the search source and search type in the url 
- When the source changes, wise will check to see if the returned type options list already contains the chosen type. If it exists in it will not change to the first option in the list (saves previous chosen type). 
- Different message for empty searches. Will not show "no results" when a search has not happened yet/ empty searches 