### PR TITLE
Esnode filtered count

### DIFF
--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -4227,7 +4227,7 @@ app.get('/esstats.json', [noCacheJson, recordResponseTime, checkPermissions(['hi
 
       r = {
         health: health,
-        recordsTotal: nodeKeys.length,
+        recordsTotal: (nodeKeys.includes('timestamp')) ? nodeKeys.length - 1 : nodeKeys.length,
         recordsFiltered: stats.length,
         data: stats
       };

--- a/viewer/vueapp/src/components/stats/EsNodes.vue
+++ b/viewer/vueapp/src/components/stats/EsNodes.vue
@@ -15,7 +15,7 @@
         class="mt-1 ml-2"
         :info-only="true"
         :records-total="recordsTotal"
-        :records-filtered="recordsFiltered">
+        :records-filtered="filteredStats.length">
       </moloch-paging>
 
       <moloch-table
@@ -113,7 +113,6 @@ export default {
       initialLoading: true,
       stats: null,
       recordsTotal: null,
-      recordsFiltered: null,
       query: {
         filter: this.searchTerm || undefined,
         sortField: 'nodeName',
@@ -244,7 +243,6 @@ export default {
           this.initialLoading = false;
           this.stats = response.data.data;
           this.recordsTotal = response.data.recordsTotal;
-          this.recordsFiltered = response.data.recordsFiltered;
         }, (error) => {
           respondedAt = undefined;
           this.loading = false;

--- a/viewer/vueapp/src/components/stats/Stats.vue
+++ b/viewer/vueapp/src/components/stats/Stats.vue
@@ -594,7 +594,7 @@ export default {
     onOffFocus: function () {
       this.focusInput = false;
     },
-    debounceSearchInput () {
+    debounceSearchInput: function () {
       if (searchInputTimeout) { clearTimeout(searchInputTimeout); }
       // debounce the input so it only issues a request after keyups cease for 400ms
       searchInputTimeout = setTimeout(() => {


### PR DESCRIPTION
Two fixes for pagination count. 
1) Ignore 'timestamp' that adds +1 occasionally for 'filtered from * total entries'
2) Correctly updates when 'data-nodes-only' checkbox is ticked. 

<img width="384" alt="Screen Shot 2020-07-28 at 4 18 02 PM" src="https://user-images.githubusercontent.com/9063864/88737697-ebcb0980-d0ed-11ea-8851-7a5fca5e13f4.png">
