### PR TITLE
Fix integer overflow

### DIFF
--- a/capture/parsers/tds.c
+++ b/capture/parsers/tds.c
@@ -27,9 +27,10 @@ LOCAL  int userField;
 LOCAL int tds_parser(MolochSession_t *session, void *uw, const unsigned char *data, int remaining, int which)
 {
     TDSInfo_t *tds = uw;
+    size_t count = remaining;
 
-    remaining = MIN(remaining, TDS_MAX_SIZE - tds->pos[which]);
-    memcpy(tds->data[which] + tds->pos[which], data, remaining);
+    count = MIN(count, TDS_MAX_SIZE - tds->pos[which]);
+    memcpy(tds->data[which] + tds->pos[which], data, count);
     tds->pos[which] += remaining;
 
     // Lots of info from http://www.freetds.org/tds.html


### PR DESCRIPTION
This fixes a potential integer overflow bug in a TDS parser, which arises due to the use of signed integer for both comparison and memcpy, allowing for an overflow with very large values.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
