### PR TITLE
handle nodes being down better

### DIFF
--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -7692,12 +7692,14 @@ function continueHuntSkipSession (hunt, huntId, session, sessionId, searchedSess
   if (!hunt.failedSessionIds) {
     hunt.failedSessionIds = [ sessionId ];
   } else {
-    if (hunt.failedSessionIds.length > 10000) { // TODO ECR - is this a good limit? ES doesn't specifically have an array size limit, but it does get costly to update a document if there is a large field
+    // pause the hunt if there are more than 10k failed sessions
+    if (hunt.failedSessionIds.length > 10000) {
       return pauseHuntJobWithError(huntId, hunt, {
         value: 'Error hunting: Too many sessions are unreachable. Please contact your administrator.'
       });
     }
     // make sure the session id is not already in the array
+    // if it's not the first pass and a node is still down, this could be a duplicate
     if (hunt.failedSessionIds.indexOf(sessionId) < 0) {
       hunt.failedSessionIds.push(sessionId);
     }

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -7707,7 +7707,7 @@ function continueHuntSkipSession (hunt, huntId, session, sessionId, searchedSess
 // if there are still failed sessions, but no new sessions coudl be searched, pause the job with an error
 function huntFailedSessions (hunt, huntId, options, searchedSessions, user) {
   let changesSearchingFailedSessions = false;
-  if (!options.searchingFailedSessions && hunt.failedSessionIds && hunt.failedSessionIds.length) {
+  if (hunt.failedSessionIds && hunt.failedSessionIds.length) {
     options.searchingFailedSessions = true;
     // copy the failed session ids so we can remove them from the hunt
     // but still loop through them iteratively
@@ -7761,6 +7761,8 @@ function huntFailedSessions (hunt, huntId, options, searchedSessions, user) {
       } else if (hunt.failedSessionIds && hunt.failedSessionIds.length > 0 && changesSearchingFailedSessions) {
         // there are still failed sessions, but there were also changes,
         // so keep going
+        // uninitialize hunts so that the running job with failed sessions will kick off again
+        internals.proccessHuntJobsInitialized = false;
         return continueProcess();
       } else if (!changesSearchingFailedSessions) {
         options.searchingFailedSessions = false; // no longer searching failed sessions
@@ -7780,7 +7782,7 @@ function runHuntJob (huntId, hunt, query, user) {
   let searchedSessions;
 
   // look for failed sessions if we're done searching sessions normally
-  if (hunt.searchedSessions === hunt.totalSessions && hunt.failedSessionIds && hunt.failedSessionIds.length) {
+  if (!options.searchingFailedSessions && hunt.searchedSessions === hunt.totalSessions && hunt.failedSessionIds && hunt.failedSessionIds.length) {
     options.searchingFailedSessions = true;
     return huntFailedSessions(hunt, huntId, options, searchedSessions, user);
   }

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -7807,7 +7807,6 @@ function runHuntJob (huntId, hunt, query, user) {
     }
 
     async.forEachLimit(hits, 3, function (hit, cb) {
-      setTimeout(() => {
       searchedSessions++;
       let session = hit._source;
       let sessionId = Db.session2Sid(hit);
@@ -7848,7 +7847,6 @@ function runHuntJob (huntId, hunt, query, user) {
           return updateHuntStats(hunt, huntId, session, searchedSessions, cb);
         });
       });
-      }, 500);
     }, function (err) { // done running this section of hunt job
       // Some kind of error, stop now
       if (err === 'paused' || err === 'undefined') {

--- a/viewer/vueapp/src/components/hunt/Hunt.vue
+++ b/viewer/vueapp/src/components/hunt/Hunt.vue
@@ -538,6 +538,12 @@
                 </hunt-status>
                 &nbsp;
                 <span class="badge badge-secondary cursor-help"
+                  v-if="job.failedSessionIds && job.failedSessionIds.length"
+                  :id="`jobmatches${job.id}`">
+                  {{ (((job.searchedSessions - job.failedSessionIds.length) / job.totalSessions) * 100) | round(1) }}%
+                </span>
+                <span v-else
+                  class="badge badge-secondary cursor-help"
                   :id="`jobmatches${job.id}`">
                   {{ ((job.searchedSessions / job.totalSessions) * 100) | round(1) }}%
                 </span>
@@ -1341,7 +1347,7 @@ export default {
           this.$set(this.runningJob, 'expanded', runningJobExpanded);
           let searchedSessions = this.runningJob.searchedSessions;
           if (this.runningJob.failedSessionIds && this.runningJob.failedSessionIds.length) {
-            searchedSessions = searchedSessions - this.runningJob.failedSessionIds;
+            searchedSessions = searchedSessions - this.runningJob.failedSessionIds.length;
           }
           this.$set(
             this.runningJob,

--- a/viewer/vueapp/src/components/hunt/Hunt.vue
+++ b/viewer/vueapp/src/components/hunt/Hunt.vue
@@ -1377,12 +1377,10 @@ export default {
           if (this.runningJob.failedSessionIds && this.runningJob.failedSessionIds.length) {
             searchedSessions = searchedSessions - this.runningJob.failedSessionIds.length;
           }
-          let progress = (searchedSessions / this.runningJob.totalSessions) * 100;
-          console.log('running job progress', progress); // TODO ECR remvoe
           this.$set(
             this.runningJob,
             'progress',
-            progress
+            (searchedSessions / this.runningJob.totalSessions) * 100
           );
         }
         this.calculateQueue();

--- a/viewer/vueapp/src/components/hunt/Hunt.vue
+++ b/viewer/vueapp/src/components/hunt/Hunt.vue
@@ -452,47 +452,6 @@
               <transition name="grow">
                 <div v-if="runningJob.expanded"
                   class="mt-3">
-                  <div class="mt-2">
-                    <span class="fa fa-eye">
-                    </span>&nbsp;
-                    Found <strong>{{ runningJob.matchedSessions | commaString }}</strong> sessions
-                    matching <strong>{{ runningJob.search }}</strong> ({{ runningJob.searchType }})
-                    out of <strong>{{ runningJob.searchedSessions | commaString }}</strong>
-                    sessions searched.
-                    (Still need to search
-                    <strong>{{ (runningJob.totalSessions - runningJob.searchedSessions) | commaString }}</strong>
-                    of <strong>{{ runningJob.totalSessions }}</strong>
-                    total sessions.)
-                  </div>
-                  <div class="row">
-                    <div class="col-12">
-                      <span class="fa fa-clock-o fa-fw">
-                      </span>&nbsp;
-                      Created:
-                      <strong>
-                        {{ runningJob.created * 1000 | timezoneDateString(user.settings.timezone, false) }}
-                      </strong>
-                    </div>
-                  </div>
-                  <div v-if="runningJob.lastUpdated"
-                    class="row">
-                    <div class="col-12">
-                      <span class="fa fa-clock-o fa-fw">
-                      </span>&nbsp;
-                      Last Updated:
-                      <strong>
-                        {{ runningJob.lastUpdated * 1000 | timezoneDateString(user.settings.timezone, false) }}
-                      </strong>
-                    </div>
-                  </div>
-                  <div class="row"
-                    v-if="runningJob.notifier">
-                    <div class="col-12">
-                      <span class="fa fa-bell fa-fw">
-                      </span>&nbsp;
-                      Notifying: {{ runningJob.notifier }}
-                    </div>
-                  </div>
                   <div class="row">
                     <div class="col-12">
                       <span class="fa fa-id-card fa-fw">
@@ -500,70 +459,10 @@
                       Hunt Job ID: {{ runningJob.id }}
                     </div>
                   </div>
-                  <div class="row">
-                    <div class="col-12">
-                      <span class="fa fa-search fa-fw">
-                      </span>&nbsp;
-                      Examining
-                      <strong v-if="runningJob.size > 0">{{ runningJob.size }}</strong>
-                      <strong v-else>all</strong>
-                      <strong>{{ runningJob.type }}</strong>
-                      <strong v-if="runningJob.src">source</strong>
-                      <span v-if="runningJob.src && runningJob.dst">
-                        and
-                      </span>
-                      <strong v-if="runningJob.dst">destination</strong>
-                      packets per session
-                    </div>
-                  </div>
-                  <div v-if="runningJob.query.expression"
-                    class="row">
-                    <div class="col-12">
-                      <span class="fa fa-search fa-fw">
-                      </span>&nbsp;
-                      The sessions query expression was:
-                      <strong>{{ runningJob.query.expression }}</strong>
-                    </div>
-                  </div>
-                  <div v-if="runningJob.query.view"
-                    class="row">
-                    <div class="col-12">
-                      <span class="fa fa-search fa-fw">
-                      </span>&nbsp;
-                      The sessions query view was:
-                      <strong>{{ runningJob.query.view }}</strong>
-                    </div>
-                  </div>
-                  <div class="row">
-                    <div class="col-12">
-                      <span class="fa fa-clock-o fa-fw">
-                      </span>&nbsp;
-                      The sessions query time range was from
-                      <strong>{{ runningJob.query.startTime * 1000 | timezoneDateString(user.settings.timezone, false) }}</strong>
-                      to
-                      <strong>{{ runningJob.query.stopTime * 1000 | timezoneDateString(user.settings.timezone, false) }}</strong>
-                    </div>
-                  </div>
-                  <template v-if="runningJob.errors">
-                    <div v-for="(error, index) in runningJob.errors"
-                      :key="index"
-                      class="row text-danger">
-                      <div class="col-12">
-                        <span class="fa fa-exclamation-triangle">
-                        </span>&nbsp;
-                        <span v-if="error.time">
-                          {{ error.time * 1000 | timezoneDateString(user.settings.timezone, false) }}
-                        </span>
-                        <span v-if="error.node">
-                          ({{ error.node }} node)
-                        </span>
-                        <span v-if="error.time || error.node">
-                          -
-                        </span>
-                        {{ error.value }}
-                      </div>
-                    </div>
-                  </template>
+                  <hunt-data :job="runningJob"
+                    :user="user"
+                    :queue-count="runningJob.queueCount">
+                  </hunt-data>
                 </div>
               </transition>
             </div>
@@ -633,26 +532,10 @@
                 </toggle-btn>
               </td>
               <td>
-                <span v-if="job.status === 'running'"
-                  v-b-tooltip.hover
-                  title="Starting"
-                  class="fa fa-play-circle fa-fw cursor-help">
-                </span>
-                <span v-else-if="job.status === 'paused'"
-                  v-b-tooltip.hover
-                  title="Paused"
-                  class="fa fa-pause fa-fw cursor-help">
-                </span>
-                <span v-else-if="job.status === 'queued'"
-                  v-b-tooltip.hover
-                  :title="`Queued (#${job.queueCount} in the queue)`"
-                  class="fa fa-clock-o fa-fw cursor-help">
-                </span>
-                <span v-else-if="job.status === 'finished'"
-                  v-b-tooltip.hover
-                  title="Finished"
-                  class="fa fa-check fa-fw cursor-help">
-                </span>
+                <hunt-status :status="job.status"
+                  :queue-count="job.queueCount"
+                  :hide-text="true">
+                </hunt-status>
                 &nbsp;
                 <span class="badge badge-secondary cursor-help"
                   :id="`jobmatches${job.id}`">
@@ -762,87 +645,10 @@
             <tr :key="`${job.id}-detail`"
               v-if="job.expanded">
               <td colspan="10">
-                <div class="row">
-                  <div class="col-12">
-                    This hunt is
-                    <strong>{{ job.status }}</strong>
-                  </div>
-                </div>
-                <div v-if="job.lastUpdated"
-                  class="row">
-                  <div class="col-12">
-                    This hunt was last updated at:
-                    <strong>
-                      {{ job.lastUpdated * 1000 | timezoneDateString(user.settings.timezone, false) }}
-                    </strong>
-                  </div>
-                </div>
-                <div class="row">
-                  <div class="col-12">
-                    Examining
-                    <strong v-if="job.size > 0">{{ job.size }}</strong>
-                    <strong v-else>all</strong>
-                    <strong>{{ job.type }}</strong>
-                    <strong v-if="job.src">source</strong>
-                    <span v-if="job.src && job.dst">
-                      and
-                    </span>
-                    <strong v-if="job.dst">destination</strong>
-                    packets per session
-                  </div>
-                </div>
-                <div class="row">
-                  <div class="col-12">
-                    Found
-                    <strong>{{ job.matchedSessions | commaString }}</strong> of
-                    <strong>{{ job.searchedSessions | commaString }}</strong>
-                    searched sessions out of
-                    <strong>{{ job.totalSessions }}</strong>
-                    total sessions to search
-                  </div>
-                </div>
-                <div v-if="job.query.expression"
-                  class="row">
-                  <div class="col-12">
-                    The sessions query expression was:
-                    <strong>{{ job.query.expression }}</strong>
-                  </div>
-                </div>
-                <div v-if="job.query.view"
-                  class="row">
-                  <div class="col-12">
-                    The sessions query view was:
-                    <strong>{{ job.query.view }}</strong>
-                  </div>
-                </div>
-                <div class="row">
-                  <div class="col-12">
-                    The sessions query time range was from
-                    <strong>{{ job.query.startTime * 1000 | timezoneDateString(user.settings.timezone, false) }}</strong>
-                    to
-                    <strong>{{ job.query.stopTime * 1000 | timezoneDateString(user.settings.timezone, false) }}</strong>
-                  </div>
-                </div>
-                <template v-if="job.errors">
-                  <div v-for="(error, index) in job.errors"
-                    :key="index"
-                    class="row text-danger">
-                    <div class="col-12">
-                      <span class="fa fa-exclamation-triangle">
-                      </span>&nbsp;
-                      <span v-if="error.time">
-                        {{ error.time * 1000 | timezoneDateString(user.settings.timezone, false) }}
-                      </span>
-                      <span v-if="error.node">
-                        ({{ error.node }} node)
-                      </span>
-                      <span v-if="error.time || error.node">
-                        -
-                      </span>
-                      {{ error.value }}
-                    </div>
-                  </div>
-                </template>
+                <hunt-data :job="job"
+                  :user="user"
+                  :queue-count="job.queueCount">
+                </hunt-data>
               </td>
             </tr>
           </template> <!-- /packet search jobs -->
@@ -963,26 +769,10 @@
                 </toggle-btn>
               </td>
               <td>
-                <span v-if="job.status === 'running'"
-                  v-b-tooltip.hover
-                  title="Running"
-                  class="fa fa-spinner fa-spin fa-fw cursor-help">
-                </span>
-                <span v-else-if="job.status === 'paused'"
-                  v-b-tooltip.hover
-                  title="Paused"
-                  class="fa fa-pause fa-fw cursor-help">
-                </span>
-                <span v-else-if="job.status === 'queued'"
-                  v-b-tooltip.hover
-                  title="Queued"
-                  class="fa fa-clock-o fa-fw cursor-help">
-                </span>
-                <span v-else-if="job.status === 'finished'"
-                  v-b-tooltip.hover
-                  title="Finished"
-                  class="fa fa-check fa-fw cursor-help">
-                </span>
+                <hunt-status :status="job.status"
+                  :queue-count="job.queueCount"
+                  :hide-text="true">
+                </hunt-status>
                 &nbsp;
                 <span class="badge badge-secondary cursor-help"
                   :id="`jobmatches${job.id}`">
@@ -1088,124 +878,11 @@
             <tr :key="`${job.id}-detail`"
               v-if="job.expanded">
               <td colspan="10">
-                <div class="row">
-                  <div class="col-12">
-                    This hunt is
-                    <strong>{{ job.status }}</strong>
-                  </div>
-                </div>
-                <div v-if="job.lastUpdated"
-                  class="row">
-                  <div class="col-12">
-                    This hunt was last updated at:
-                    <strong>
-                      {{ job.lastUpdated * 1000 | timezoneDateString(user.settings.timezone, false) }}
-                    </strong>
-                  </div>
-                </div>
-                <div class="row">
-                  <div class="col-12">
-                    Examining
-                    <strong v-if="job.size > 0">{{ job.size }}</strong>
-                    <strong v-else>all</strong>
-                    <strong>{{ job.type }}</strong>
-                    <strong v-if="job.src">source</strong>
-                    <span v-if="job.src && job.dst">
-                      and
-                    </span>
-                    <strong v-if="job.dst">destination</strong>
-                    packets per session
-                  </div>
-                </div>
-                <div class="row">
-                  <div class="col-12">
-                    Found
-                    <strong>{{ job.matchedSessions | commaString }}</strong> of
-                    <strong>{{ job.searchedSessions | commaString }}</strong>
-                    searched sessions out of
-                    <strong>{{ job.totalSessions | commaString }}</strong>
-                    total sessions to search
-                  </div>
-                </div>
-                <div v-if="job.query.expression"
-                  class="row">
-                  <div class="col-12">
-                    The sessions query expression was:
-                    <strong>{{ job.query.expression }}</strong>
-                  </div>
-                </div>
-                <div v-if="job.query.view"
-                  class="row">
-                  <div class="col-12">
-                    The sessions query view was:
-                    <strong>{{ job.query.view }}</strong>
-                  </div>
-                </div>
-                <div class="row">
-                  <div class="col-12">
-                    The sessions query time range was from
-                    <strong>{{ job.query.startTime * 1000 | timezoneDateString(user.settings.timezone, false) }}</strong>
-                    to
-                    <strong>{{ job.query.stopTime * 1000 | timezoneDateString(user.settings.timezone, false) }}</strong>
-                  </div>
-                </div>
-                <template v-if="job.errors">
-                  <div v-for="(error, index) in job.errors"
-                    :key="index"
-                    class="row text-danger">
-                    <div class="col-12">
-                      <span class="fa fa-exclamation-triangle">
-                      </span>&nbsp;
-                      <span v-if="error.time">
-                        {{ error.time * 1000 | timezoneDateString(user.settings.timezone, false) }}
-                      </span>
-                      <span v-if="error.node">
-                        ({{ error.node }} node)
-                      </span>
-                      <span v-if="error.time || error.node">
-                        -
-                      </span>
-                      {{ error.value }}
-                    </div>
-                  </div>
-                </template>
-                <div v-if="job.unrunnable"
-                  class="row mt-2">
-                  <div class="col-12">
-                    <div class="alert alert-danger">
-                      <h5 class="alert-heading">
-                        <span class="fa fa-ban">
-                        </span>&nbsp;
-                        Unrunnable Hunt
-                      </h5>
-                      <p class="mb-0">
-                        This hunt has encountered a fatal error.
-                        It cannot be rerun or replayed. References the error(s) above to diagnose the issue.
-                      </p>
-                      <p class="mb-0">
-                        Try again with a new hunt after fixing the error(s) listed above.
-                      </p>
-                      <button
-                        @click="removeJob(job, 'historyResults')"
-                        :disabled="job.loading"
-                        type="button"
-                        v-b-tooltip.hover.right
-                        title="Remove this job from history"
-                        class="mt-2 btn btn-sm btn-danger">
-                        <span v-if="!job.loading">
-                          <span class="fa fa-trash-o fa-fw">
-                          </span>
-                          Delete this hunt
-                        </span>
-                        <span v-else>
-                          <span class="fa fa-spinner fa-spin fa-fw">
-                          </span>
-                          Deleteing this hunt
-                        </span>
-                      </button>
-                    </div>
-                  </div>
-                </div>
+                <hunt-data :job="job"
+                  @removeJob="removeJob"
+                  :user="user"
+                  :queue-count="job.queueCount">
+                </hunt-data>
               </td>
             </tr>
           </template> <!-- /packet search jobs -->
@@ -1252,6 +929,8 @@ import MolochLoading from '../utils/Loading';
 import MolochPaging from '../utils/Pagination';
 import MolochCollapsible from '../utils/CollapsibleWrapper';
 import FocusInput from '../utils/FocusInput';
+import HuntData from './HuntData';
+import HuntStatus from './HuntStatus';
 // import utils
 import Utils from '../utils/utils';
 
@@ -1267,7 +946,9 @@ export default {
     MolochSearch,
     MolochLoading,
     MolochCollapsible,
-    MolochPaging
+    MolochPaging,
+    HuntData,
+    HuntStatus
   },
   directives: { FocusInput },
   data: function () {
@@ -1658,10 +1339,14 @@ export default {
         if (this.runningJob) {
           this.$set(this.runningJob, 'loading', runningJobLoading);
           this.$set(this.runningJob, 'expanded', runningJobExpanded);
+          let searchedSessions = this.runningJob.searchedSessions;
+          if (this.runningJob.failedSessionIds && this.runningJob.failedSessionIds.length) {
+            searchedSessions = searchedSessions - this.runningJob.failedSessionIds;
+          }
           this.$set(
             this.runningJob,
             'progress',
-            this.runningJob.searchedSessions / this.runningJob.totalSessions * 100
+            searchedSessions / this.runningJob.totalSessions * 100
           );
         }
         this.calculateQueue();

--- a/viewer/vueapp/src/components/hunt/HuntData.vue
+++ b/viewer/vueapp/src/components/hunt/HuntData.vue
@@ -1,0 +1,156 @@
+<template>
+  <div>
+    <div class="row">
+      <div class="col-12">
+        <hunt-status :status="job.status"
+          :queue-count="queueCount">
+        </hunt-status>
+      </div>
+    </div>
+    <div>
+      <span class="fa fa-fw fa-eye">
+      </span>&nbsp;
+      Found <strong>{{ job.matchedSessions | commaString }}</strong> sessions
+      matching <strong>{{ job.search }}</strong> ({{ job.searchType }})
+      of
+      <span v-if="job.failedSessionIds && job.failedSessionIds.length">
+        <strong>{{ job.searchedSessions - job.failedSessionIds.length | commaString }}</strong>
+      </span>
+      <span v-else>
+        <strong>{{ job.searchedSessions | commaString }}</strong>
+      </span>
+      sessions searched
+      <span v-if="job.failedSessionIds && job.failedSessionIds.length">
+        <br>
+        <span class="fa fa-fw fa-search-plus">
+        </span>&nbsp;
+        Still need to search
+        <strong>{{ (job.totalSessions - job.searchedSessions + job.failedSessionIds.length) | commaString }}</strong>
+        of <strong>{{ job.totalSessions }}</strong>
+        total sessions
+        <br>
+        <span class="fa fa-exclamation-triangle fa-fw">
+        </span>&nbsp;
+        <strong>{{ job.failedSessionIds.length | commaString }}</strong>
+        sessions failed to load and were not searched yet
+      </span>
+      <span v-else-if="job.totalSessions !== job.searchedSessions">
+        <br>
+        <span class="fa fa-fw fa-search-plus">
+        </span>&nbsp;
+        Still need to search
+        <strong>{{ (job.totalSessions - job.searchedSessions) | commaString }}</strong>
+        of <strong>{{ job.totalSessions }}</strong>
+        total sessions
+      </span>
+    </div>
+    <div class="row">
+      <div class="col-12">
+        <span class="fa fa-fw fa-clock-o fa-fw">
+        </span>&nbsp;
+        Created:
+        <strong>
+          {{ job.created * 1000 | timezoneDateString(user.settings.timezone, false) }}
+        </strong>
+      </div>
+    </div>
+    <div v-if="job.lastUpdated"
+      class="row">
+      <div class="col-12">
+        <span class="fa fa-fw fa-clock-o fa-fw">
+        </span>&nbsp;
+        Last Updated:
+        <strong>
+          {{ job.lastUpdated * 1000 | timezoneDateString(user.settings.timezone, false) }}
+        </strong>
+      </div>
+    </div>
+    <div class="row"
+      v-if="job.notifier">
+      <div class="col-12">
+        <span class="fa fa-fw fa-bell fa-fw">
+        </span>&nbsp;
+        Notifying: {{ job.notifier }}
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-12">
+        <span class="fa fa-fw fa-search fa-fw">
+        </span>&nbsp;
+        Examining
+        <strong v-if="job.size > 0">{{ job.size }}</strong>
+        <strong v-else>all</strong>
+        <strong>{{ job.type }}</strong>
+        <strong v-if="job.src">source</strong>
+        <span v-if="job.src && job.dst">
+          and
+        </span>
+        <strong v-if="job.dst">destination</strong>
+        packets per session
+      </div>
+    </div>
+    <div v-if="job.query.expression"
+      class="row">
+      <div class="col-12">
+        <span class="fa fa-fw fa-search fa-fw">
+        </span>&nbsp;
+        The sessions query expression was:
+        <strong>{{ job.query.expression }}</strong>
+      </div>
+    </div>
+    <div v-if="job.query.view"
+      class="row">
+      <div class="col-12">
+        <span class="fa fa-fw fa-search fa-fw">
+        </span>&nbsp;
+        The sessions query view was:
+        <strong>{{ job.query.view }}</strong>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-12">
+        <span class="fa fa-fw fa-clock-o fa-fw">
+        </span>&nbsp;
+        The sessions query time range was from
+        <strong>{{ job.query.startTime * 1000 | timezoneDateString(user.settings.timezone, false) }}</strong>
+        to
+        <strong>{{ job.query.stopTime * 1000 | timezoneDateString(user.settings.timezone, false) }}</strong>
+      </div>
+    </div>
+    <template v-if="job.errors">
+      <div v-for="(error, index) in job.errors"
+        :key="index"
+        class="row text-danger">
+        <div class="col-12">
+          <span class="fa fa-fw fa-exclamation-triangle">
+          </span>&nbsp;
+          <span v-if="error.time">
+            {{ error.time * 1000 | timezoneDateString(user.settings.timezone, false) }}
+          </span>
+          <span v-if="error.node">
+            ({{ error.node }} node)
+          </span>
+          <span v-if="error.time || error.node">
+            -
+          </span>
+          {{ error.value }}
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script>
+import HuntStatus from './HuntStatus';
+
+export default {
+  name: 'HuntData',
+  props: [ 'job', 'user', 'queueCount' ],
+  components: { HuntStatus },
+  methods: {
+    removeJob: function (job, list) {
+      this.$emit('removeJob', job, list);
+    }
+  }
+};
+</script>

--- a/viewer/vueapp/src/components/hunt/HuntStatus.vue
+++ b/viewer/vueapp/src/components/hunt/HuntStatus.vue
@@ -1,0 +1,36 @@
+<template>
+  <span>
+    <span v-if="status === 'running'"
+      v-b-tooltip.hover
+      title="Starting"
+      class="fa fa-play-circle fa-fw cursor-help">
+    </span>
+    <span v-else-if="status === 'paused'"
+      v-b-tooltip.hover
+      title="Paused"
+      class="fa fa-pause fa-fw cursor-help">
+    </span>
+    <span v-else-if="status === 'queued'"
+      v-b-tooltip.hover
+      :title="`Queued (#${queueCount} in the queue)`"
+      class="fa fa-clock-o fa-fw cursor-help">
+    </span>
+    <span v-else-if="status === 'finished'"
+      v-b-tooltip.hover
+      title="Finished"
+      class="fa fa-check fa-fw cursor-help">
+    </span>
+    &nbsp;
+    <span v-if="!hideText">
+      This hunt is
+      <strong>{{ status }}</strong>
+    </span>
+  </span>
+</template>
+
+<script>
+export default {
+  name: 'HuntStatus',
+  props: [ 'status', 'queueCount', 'hideText' ]
+};
+</script>


### PR DESCRIPTION
if remote node is down, skip the session and go back through skipped sessions later
consolidate redundant ui components for status and hunt details
don't display skipped hunts in progress bar
indicate number of skipped hunts in hunt details
if failed sessions exceed 10k, pause with an error

fixes #1512