### PR TITLE
add capture process start time indication to sessions timeline graph

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,6 +21,11 @@ NOTICE: Restart wiseService before capture when upgrading
 2.4.2 2020/10/xx
   - NOTE - this is the last version to support ES 6
   - viewer - support utf8 chars in content-disposition
+  - viewer - add capture process restart to timeline graphs
+  - viewer - add "bookmarks"
+             apply a view's expression to the search input without issuing a query
+  - viewer - fix anonymous users settings not being saved
+  - viewer - share hunts between users
   - capture - QUIC version 5x detection
 
 2.4.1 2020/09/28

--- a/capture/db.c
+++ b/capture/db.c
@@ -1372,7 +1372,6 @@ LOCAL void moloch_db_update_stats(int n, gboolean sync)
         "\"deltaESDropped\": %" PRIu64 ","
         "\"esHealthMS\": %" PRIu64 ","
         "\"deltaMS\": %" PRIu64 ","
-        "\"runningTime\": %" PRIu64 ","
         "\"startTime\": %" PRIu64
         "}",
         VERSION,
@@ -1416,7 +1415,6 @@ LOCAL void moloch_db_update_stats(int n, gboolean sync)
         (esDropped - lastESDropped[n]),
         esHealthMS,
         diffms,
-        currentTime.tv_sec - startTime.tv_sec,
         startTime.tv_sec);
 
     lastTime[n]            = currentTime;

--- a/capture/db.c
+++ b/capture/db.c
@@ -1371,7 +1371,9 @@ LOCAL void moloch_db_update_stats(int n, gboolean sync)
         "\"deltaOverloadDropped\": %" PRIu64 ","
         "\"deltaESDropped\": %" PRIu64 ","
         "\"esHealthMS\": %" PRIu64 ","
-        "\"deltaMS\": %" PRIu64
+        "\"deltaMS\": %" PRIu64 ","
+        "\"runningTime\": %" PRIu64 ","
+        "\"startTime\": %" PRIu64
         "}",
         VERSION,
         config.nodeName,
@@ -1413,7 +1415,9 @@ LOCAL void moloch_db_update_stats(int n, gboolean sync)
         (overloadDropped - lastOverloadDropped[n]),
         (esDropped - lastESDropped[n]),
         esHealthMS,
-        diffms);
+        diffms,
+        currentTime.tv_sec - startTime.tv_sec,
+        startTime.tv_sec);
 
     lastTime[n]            = currentTime;
     lastBytes[n]           = totalBytes;

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -4468,6 +4468,7 @@ app.get('/stats.json', [noCacheJson, recordResponseTime, checkPermissions(['hide
       fields.deltaOverloadDroppedPerSec = Math.floor(fields.deltaOverloadDropped * 1000.0 / fields.deltaMS);
       fields.deltaESDroppedPerSec = Math.floor(fields.deltaESDropped * 1000.0 / fields.deltaMS);
       fields.deltaTotalDroppedPerSec = Math.floor((fields.deltaDropped + fields.deltaOverloadDropped) * 1000.0 / fields.deltaMS);
+      fields.runningTime = fields.currentTime - fields.startTime;
       results.results.push(fields);
     }
 

--- a/viewer/vueapp/src/components/help/Help.vue
+++ b/viewer/vueapp/src/components/help/Help.vue
@@ -453,9 +453,37 @@
           Visualizations
         </h6>
         <p>
-          The section above the Sessions table contains a visualisation of the query's output. This quick glance visualization may be viewed by Session count, Packets count, or Databytes count.
-          Clicking and dragging over bars within the chart will drill into the selected time frame so only it is selected.
-          Additionally, a user can click the "+" or "-" magnifying glasses to quickly zoom out or zoom in the time window being observed.
+          The timeline graphs on the Sessions, SPIView, and SPIGraph pages
+          contain a visualisation of the query's output.
+          <ul>
+            <li>
+              View by Session count, Packets count, Bytes count, or Databytes count.
+              Packets, Bytes and Databytes show source and destination separated
+              by color.
+            </li>
+            <li>
+              Select between a line or bar chart.
+            </li>
+            <li>
+              Click and drag over sections of the chart to drill into the
+              selected time frame. Note: this issues a new query.
+            </li>
+            <li>
+              Click the + or - magnifying glass buttons to quickly zoom in or
+              out of the time window being observed. Note: this issues a new query.
+            </li>
+            <li>
+              Click the &lt; or &gt; buttons to move backwards or forwards in
+              time. Use the dropdown to select how far this shift is. Note: this
+              issues a new query.
+            </li>
+            <li>
+              View the last times capture nodes were started (shown by a vertical
+              line). Use this indicator to avoid incorrect assumptions about sessions.
+              When a capture process restarts there is a loss of protocol state
+              awareness and segment counts are restarted.
+            </li>
+          </ul>
         </p>
         <h6>
           <span class="fa fa-fw fa-exchange"></span>&nbsp;

--- a/viewer/vueapp/src/components/sessions/Sessions.vue
+++ b/viewer/vueapp/src/components/sessions/Sessions.vue
@@ -34,11 +34,11 @@
 
     <!-- visualizations -->
     <moloch-visualizations
-      v-if="mapData && graphData && capStartTime"
+      v-if="mapData && graphData && capStartTimes.length"
       :graph-data="graphData"
       :map-data="mapData"
       :primary="true"
-      :cap-start-time="capStartTime"
+      :cap-start-times="capStartTimes"
       :timezone="user.settings.timezone"
       :timelineDataFilters="timelineDataFilters"
       @fetchMapData="cancelAndLoad(true)">
@@ -600,7 +600,7 @@ export default {
       stickyHeader: false,
       tableHeaderOverflow: undefined,
       showFitButton: false,
-      capStartTime: undefined
+      capStartTimes: []
     };
   },
   created: function () {
@@ -1457,11 +1457,18 @@ export default {
     getCaptureStats: function () {
       this.$http.get('stats.json')
         .then((response) => {
-          // TODO ECR - which capture process?
-          this.capStartTime = response.data.data[0].startTime * 1000;
+          for (let data of response.data.data) {
+            this.capStartTimes.push({
+              nodeName: data.nodeName,
+              startTime: data.startTime * 1000
+            });
+          }
         })
         .catch((error) => {
-          this.capStartTime = 1;
+          this.capStartTimes = [{
+            nodeName: 'none',
+            startTime: 1
+          }];
         });
     },
     /**

--- a/viewer/vueapp/src/components/sessions/Sessions.vue
+++ b/viewer/vueapp/src/components/sessions/Sessions.vue
@@ -591,6 +591,7 @@ export default {
       fields: [],
       graphData: undefined,
       mapData: undefined,
+      capStartTimes: [],
       colQuery: '', // query for columns to toggle visibility
       newColConfigName: '', // name of new custom column config
       viewChanged: false,
@@ -599,8 +600,7 @@ export default {
       infoFieldVisMenuOpen: false,
       stickyHeader: false,
       tableHeaderOverflow: undefined,
-      showFitButton: false,
-      capStartTimes: []
+      showFitButton: false
     };
   },
   created: function () {
@@ -1454,6 +1454,7 @@ export default {
         this.loading = false;
       });
     },
+    /* Fetches capture stats to show the last time each capture node started */
     getCaptureStats: function () {
       this.$http.get('stats.json')
         .then((response) => {

--- a/viewer/vueapp/src/components/sessions/Sessions.vue
+++ b/viewer/vueapp/src/components/sessions/Sessions.vue
@@ -34,10 +34,11 @@
 
     <!-- visualizations -->
     <moloch-visualizations
-      v-if="mapData && graphData"
+      v-if="mapData && graphData && capStartTime"
       :graph-data="graphData"
       :map-data="mapData"
       :primary="true"
+      :cap-start-time="capStartTime"
       :timezone="user.settings.timezone"
       :timelineDataFilters="timelineDataFilters"
       @fetchMapData="cancelAndLoad(true)">
@@ -598,10 +599,12 @@ export default {
       infoFieldVisMenuOpen: false,
       stickyHeader: false,
       tableHeaderOverflow: undefined,
-      showFitButton: false
+      showFitButton: false,
+      capStartTime: undefined
     };
   },
   created: function () {
+    this.getCaptureStats();
     this.getColumnWidths();
     this.getTableState(); // IMPORTANT: kicks off the initial search query!
     this.getCustomColumnConfigurations();
@@ -1450,6 +1453,16 @@ export default {
         this.error = error.text || error;
         this.loading = false;
       });
+    },
+    getCaptureStats: function () {
+      this.$http.get('stats.json')
+        .then((response) => {
+          // TODO ECR - which capture process?
+          this.capStartTime = response.data.data[0].startTime * 1000;
+        })
+        .catch((error) => {
+          this.capStartTime = 1;
+        });
     },
     /**
      * Saves the table state

--- a/viewer/vueapp/src/components/spigraph/Spigraph.vue
+++ b/viewer/vueapp/src/components/spigraph/Spigraph.vue
@@ -146,12 +146,13 @@
     </MolochCollapsible>
 
     <!-- main visualization -->
-    <div v-if="spiGraphType === 'default' && mapData && graphData && fieldObj">
+    <div v-if="spiGraphType === 'default' && mapData && graphData && fieldObj && capStartTimes.length">
       <moloch-visualizations
         id="primary"
         :graph-data="graphData"
         :map-data="mapData"
         :primary="true"
+        :cap-start-times="capStartTimes"
         :timezone="user.settings.timezone"
         :timelineDataFilters="timelineDataFilters"
         @fetchMapData="cancelAndLoad(true)">
@@ -291,6 +292,7 @@ export default {
       filtered: 0,
       graphData: undefined,
       mapData: undefined,
+      capStartTimes: [],
       refresh: 0,
       recordsTotal: 0,
       recordsFiltered: 0,
@@ -369,6 +371,8 @@ export default {
       this.cancelAndLoad(true);
       this.changeRefreshInterval();
     });
+
+    this.getCaptureStats();
 
     FieldService.get(true)
       .then((result) => {
@@ -530,6 +534,24 @@ export default {
         this.loading = false;
         this.error = error.text || error;
       });
+    },
+    /* Fetches capture stats to show the last time each capture node started */
+    getCaptureStats: function () {
+      this.$http.get('stats.json')
+        .then((response) => {
+          for (let data of response.data.data) {
+            this.capStartTimes.push({
+              nodeName: data.nodeName,
+              startTime: data.startTime * 1000
+            });
+          }
+        })
+        .catch((error) => {
+          this.capStartTimes = [{
+            nodeName: 'none',
+            startTime: 1
+          }];
+        });
     }
   },
   beforeDestroy: function () {

--- a/viewer/vueapp/src/components/spiview/Spiview.vue
+++ b/viewer/vueapp/src/components/spiview/Spiview.vue
@@ -136,10 +136,11 @@
 
     <!-- visualizations -->
     <moloch-visualizations
-      v-if="mapData && graphData"
+      v-if="mapData && graphData && capStartTimes.length"
       :graph-data="graphData"
       :map-data="mapData"
       :primary="true"
+      :cap-start-times="capStartTimes"
       :timezone="user.settings.timezone"
       :timelineDataFilters="timelineDataFilters"
       @fetchMapData="fetchMapData">
@@ -416,6 +417,7 @@ export default {
       fieldConfigs: [],
       graphData: undefined,
       mapData: undefined,
+      capStartTimes: [],
       categoryList: [],
       categoryObjects: {},
       spiQuery: this.$route.query.spi,
@@ -447,6 +449,7 @@ export default {
     }
   },
   mounted: function () {
+    this.getCaptureStats();
     if (!this.spiQuery) {
       // get what's saved in the db
       UserService.getState('spiview')
@@ -1041,6 +1044,24 @@ export default {
         })
         .catch((error) => {
           this.fieldConfigError = error.text;
+        });
+    },
+    /* Fetches capture stats to show the last time each capture node started */
+    getCaptureStats: function () {
+      this.$http.get('stats.json')
+        .then((response) => {
+          for (let data of response.data.data) {
+            this.capStartTimes.push({
+              nodeName: data.nodeName,
+              startTime: data.startTime * 1000
+            });
+          }
+        })
+        .catch((error) => {
+          this.capStartTimes = [{
+            nodeName: 'none',
+            startTime: 1
+          }];
         });
     },
     /**

--- a/viewer/vueapp/src/components/stats/CaptureStats.vue
+++ b/viewer/vueapp/src/components/stats/CaptureStats.vue
@@ -133,7 +133,9 @@ export default {
         { id: 'deltaOverloadDropped', name: 'Overload Drops/s', sort: 'deltaOverloadDropped', width: 140, doStats: true, dataFunction: (item) => { return this.$options.filters.roundCommaString(item.deltaOverloadDropped); } },
         { id: 'deltaESDroppedPerSec', name: 'ES Drops/s', sort: 'deltaESDropped', width: 120, doStats: true, dataFunction: (item) => { return this.$options.filters.roundCommaString(item.deltaESDropped); } },
         { id: 'sessionSizePerSec', name: 'ES Session Size/Sec', sort: 'sessionSizePerSec', width: 100, doStats: true, dataFunction: (item) => { return this.$options.filters.roundCommaString(item.sessionSizePerSec); } },
-        { id: 'retention', name: 'Retention', sort: 'retention', width: 100, doStats: true, dataFunction: (item) => { return this.$options.filters.readableTimeCompact(item.retention * 1000); } }
+        { id: 'retention', name: 'Retention', sort: 'retention', width: 100, doStats: true, dataFunction: (item) => { return this.$options.filters.readableTimeCompact(item.retention * 1000); } },
+        { id: 'startTime', name: 'Start Time', sort: 'startTime', width: 200, doStats: false, dataFunction: (item) => { return this.$options.filters.timezoneDateString(item.startTime * 1000, this.user.settings.timezone, false); } },
+        { id: 'runningTime', name: 'Running Time', sort: 'runningTime', width: 200, doStats: false, dataFunction: (item) => { return this.$options.filters.readableTime(item.runningTime * 1000); } }
       ]
     };
   },

--- a/viewer/vueapp/src/components/visualizations/Visualizations.vue
+++ b/viewer/vueapp/src/components/visualizations/Visualizations.vue
@@ -595,36 +595,6 @@ export default {
       let previousPoint;
       // triggered when hovering over the graph
       $(this.plotArea).on('plothover', (event, pos, item) => {
-        // show capture process start time tooltip
-        // it is only 1px wide, but the hover displays if a user hovers over the
-        // surrounding line by half a bar width on either side (so it should
-        // still allow a user to see tooltips for data)
-        let capNode, capStartTime;
-        let isInCapTimeRange = false;
-        for (let cap of this.capStartTimes) {
-          if (cap.startTime) {
-            if (pos.x1 >= cap.startTime - (this.barWidth / 2) && pos.x1 < cap.startTime + (this.barWidth / 2)) {
-              capNode = cap.nodeName;
-              capStartTime = cap.startTime;
-              isInCapTimeRange = true;
-              break;
-            }
-          }
-        }
-        if (isInCapTimeRange) {
-          $(document.body).find('#tooltip').remove();
-          let tooltipHTML = `<div id="tooltip" class="graph-tooltip">
-                              Capture node ${capNode} started at ${this.$options.filters.timezoneDateString(capStartTime, this.timezone || 'local', false)}
-                            </div>`;
-
-          $(tooltipHTML).css({
-            top: pos.pageY - 30,
-            left: pos.pageX - 8
-          }).appendTo(document.body);
-
-          return;
-        }
-
         if (item) {
           if (!previousPoint ||
             previousPoint.dataIndex !== item.dataIndex ||
@@ -668,6 +638,32 @@ export default {
         } else {
           $(document.body).find('#tooltip').remove();
           previousPoint = null;
+          // show capture process start time tooltip
+          // it is only 1px wide, but the hover displays if a user hovers over the
+          // surrounding line by half a bar width on either side (so it should
+          // still allow a user to see tooltips for data)
+          let capNode, capStartTime;
+          let isInCapTimeRange = false;
+          for (let cap of this.capStartTimes) {
+            if (cap.startTime) {
+              if (pos.x1 >= cap.startTime - (this.barWidth / 2) && pos.x1 < cap.startTime + (this.barWidth / 2)) {
+                capNode = cap.nodeName;
+                capStartTime = cap.startTime;
+                isInCapTimeRange = true;
+                break;
+              }
+            }
+          }
+          if (isInCapTimeRange) {
+            let tooltipHTML = `<div id="tooltip" class="graph-tooltip">
+                                Capture node ${capNode} started at ${this.$options.filters.timezoneDateString(capStartTime, this.timezone || 'local', false)}
+                              </div>`;
+
+            $(tooltipHTML).css({
+              top: pos.pageY - 30,
+              left: pos.pageX - 8
+            }).appendTo(document.body);
+          }
         }
       });
     },

--- a/viewer/vueapp/src/components/visualizations/Visualizations.vue
+++ b/viewer/vueapp/src/components/visualizations/Visualizations.vue
@@ -270,7 +270,15 @@ export default {
       type: Array,
       required: true
     },
-    capStartTimes: Array
+    capStartTimes: {
+      type: Array,
+      default: () => {
+        return [{
+          nodeName: 'none',
+          startTime: 1
+        }];
+      }
+    }
   },
   data: function () {
     return {
@@ -749,7 +757,7 @@ export default {
 
       for (let capture of this.capStartTimes) {
         this.graphOptions.grid.markings.push({
-          color: '#666',
+          color: foregroundColor || '#666',
           xaxis: {
             from: capture.startTime,
             to: capture.startTime

--- a/viewer/vueapp/src/components/visualizations/Visualizations.vue
+++ b/viewer/vueapp/src/components/visualizations/Visualizations.vue
@@ -592,6 +592,9 @@ export default {
       // triggered when hovering over the graph
       $(this.plotArea).on('plothover', (event, pos, item) => {
         // show capture process start time tooltip
+        // it is only 1px wide, but the hover displays if a user hovers over the
+        // surrounding line by half a bar width on either side (so it should
+        // still allow a user to see tooltips for data)
         if (pos.x1 >= this.capStartTime - (this.barWidth / 2) && pos.x1 < this.capStartTime + (this.barWidth / 2)) {
           $(document.body).find('#tooltip').remove();
           let tooltipHTML = `<div id="tooltip" class="graph-tooltip">


### PR DESCRIPTION
only displayed on sessions page
can also view start time and running time fields on the capture stats page

<img width="694" alt="Screen Shot 2020-10-15 at 4 24 51 PM" src="https://user-images.githubusercontent.com/1235082/96182359-3c325600-0eea-11eb-8954-8a9b76ab6ff5.png">
<img width="804" alt="Screen Shot 2020-10-15 at 4 25 07 PM" src="https://user-images.githubusercontent.com/1235082/96182371-3f2d4680-0eea-11eb-99b0-6ec38a9b5eee.png">

fixes #271 