### PR TITLE
fix parliament highlight

### DIFF
--- a/parliament/vueapp/src/components/Parliament.vue
+++ b/parliament/vueapp/src/components/Parliament.vue
@@ -822,6 +822,7 @@ let interval;
 let draggableGroups;
 let draggableClusters;
 let highlightTimeout;
+let fallbackTimeout;
 
 export default {
   name: 'Parliament',
@@ -1013,9 +1014,12 @@ export default {
       // Find the cluster element and scroll to it
       const element = document.getElementById(`cluster-${clusterId}`);
       if (element) {
-        // Clear any existing highlight timeout
+        // Clear any existing highlight and fallback timeouts
         if (highlightTimeout) {
           clearTimeout(highlightTimeout);
+        }
+        if (fallbackTimeout) {
+          clearTimeout(fallbackTimeout);
         }
 
         // Clear highlight during scroll
@@ -1033,7 +1037,6 @@ export default {
 
         // Try to use scrollend event if supported
         const scrollContainer = element.closest('.parliament-content') || window;
-        let fallbackTimeout;
 
         const onScrollEnd = () => {
           scrollContainer.removeEventListener('scrollend', onScrollEnd);


### PR DESCRIPTION
parliament cluster highlight didn't wait for the cluster to scroll into view, causing the user to not see which cluster was being highlighted

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
