### PR TITLE
fix missing time params when navigating to /sessions

### DIFF
--- a/viewer/vueapp/src/components/sessions/SessionsService.js
+++ b/viewer/vueapp/src/components/sessions/SessionsService.js
@@ -434,6 +434,16 @@ export default {
       ...routeParams
     };
 
+    // fallback to store time values if not in route query (can happen when navigating directly to /sessions)
+    if (!combinedParams.date && !combinedParams.startTime && !combinedParams.stopTime) {
+      if (parseInt(store.state.timeRange, 10) === -1) {
+        combinedParams.date = store.state.timeRange;
+      } else {
+        combinedParams.startTime = store.state.time.startTime;
+        combinedParams.stopTime = store.state.time.stopTime;
+      }
+    }
+
     if (!combinedParams.applyTo || combinedParams.applyTo === 'open') {
       // specific sessions that have been opened
       data.ids = [];


### PR DESCRIPTION
Added a fallback in getReqOptions() that checks if time parameters are missing gets them from the Vuex store

time params are missing when the router gets default date added to it

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
