### PR TITLE
Fix summary page missing response time and timeline graph

### DIFF
--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -1743,7 +1743,7 @@ app.post( // remove tags endpoint
 
 app.getpost(
   ['/api/sessions/summary'],
-  [ArkimeUtil.noCacheJson, fillQueryFromBody, checkHeaderToken, logAction('summary')],
+  [ArkimeUtil.noCacheJson, recordResponseTime, fillQueryFromBody, checkHeaderToken, logAction('summary')],
   SessionAPIs.summary
 );
 

--- a/viewer/vueapp/src/components/summary/Summary.vue
+++ b/viewer/vueapp/src/components/summary/Summary.vue
@@ -317,6 +317,7 @@ const generateSummary = async () => {
     // Build request body with fields and other params
     const body = {
       cancelId,
+      facets: 1, // default to requesting facets for timeline graph (setFacetsQuery can override to 0)
       fields: props.summaryFields.join(',')
     };
 
@@ -362,6 +363,12 @@ const generateSummary = async () => {
 
     if (!fetchResponse.ok) {
       throw new Error(fetchResponse.statusText);
+    }
+
+    // Extract and commit response time to store (matches fetchWrapper pattern)
+    const responseTime = fetchResponse.headers.get('x-arkime-response-time');
+    if (responseTime) {
+      store.commit('setResponseTime', responseTime);
     }
 
     // Stream the response using newline-delimited JSON


### PR DESCRIPTION
- Add recordResponseTime middleware to summary endpoint (viewer.js)
- Extract x-arkime-response-time header in Summary.vue for footer display
- Add facets: 1 default to enable timeline graph data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
