### PR TITLE
Replace hard-coded shebangs with portable shebangs

### DIFF
--- a/db/db.pl
+++ b/db/db.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # This script can initialize, upgrade or provide simple maintenance for the
 # Arkime OpenSearch/Elasticsearch db
 #

--- a/release/Configure
+++ b/release/Configure
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Simple capital C Configure script for rpm/deb, like the old days
 
 if [ "$1" == "--help" ]; then

--- a/release/Configure.moloch
+++ b/release/Configure.moloch
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "The moloch package is meant for folks who aren't ready for the Arkime name yet, and shouldn't be used for new installs. Please download the arkime package"


### PR DESCRIPTION
Change Shebang to portable shebang

Replace hard-coded shebangs (`/bin/bash` and `/usr/bin/perl`) with `/usr/bin/env`-based shebangs to improve portability across systems where interpreters may be installed in different locations.
This is e. g. mandatory for installation on FreeBSD.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
