### PR TITLE
Improve delete-old-snapshots workflow

### DIFF
--- a/.github/workflows/delete-old-snapshots.yml
+++ b/.github/workflows/delete-old-snapshots.yml
@@ -3,7 +3,16 @@ name: Delete Old Snapshot Packages
 on:
 #  schedule:
 #    - cron: '0 0 * * *'  # Run daily at midnight UTC
-  workflow_dispatch:  # Allow manual triggering
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run mode (true = no deletions)'
+        required: false
+        default: 'true'
+      days:
+        description: 'Delete snapshots older than this many days'
+        required: false
+        default: '90'
 
 jobs:
   delete-old-packages:
@@ -15,41 +24,51 @@ jobs:
         run: |
           #!/bin/bash
           
+          DRY_RUN=${{ inputs.dry_run }}
+          DAYS=${{ inputs.days }}
+          
           page=1
           while true; do
-            result=$(gh api \
+            response=$(gh api \
               -H "Accept: application/vnd.github+json" \
-              "/orgs/arkime/packages/container/arkime%2Farkime/versions?per_page=100&page=$page" | \
-            jq -c '.[] | select(.metadata.container.tags[] | startswith("snapshot-v6")) | 
-                {id: .id, tag: .metadata.container.tags[0], created_at: .created_at, 
-                 days_old: ((now - (.created_at | fromdateiso8601)) / 86400 | floor)}' | \
-            jq -c 'select(.days_old > 10)')
+              "/orgs/arkime/packages/container/arkime%2Farkime/versions?per_page=100&page=$page")
 
-            if [ -z "$result" ]; then
+            # Exit if no more packages returned from API
+            if [ "$(echo "$response" | jq 'length')" -eq 0 ]; then
               break
             fi
 
-            echo "$result" | while read -r package; do
-              id=$(echo $package | jq -r '.id')
-              tag=$(echo $package | jq -r '.tag')
-              created_at=$(echo $package | jq -r '.created_at')
-              days_old=$(echo $package | jq -r '.days_old')
+            result=$(echo "$response" | \
+            jq -c '.[] | select(.metadata.container.tags[] | startswith("snapshot-")) | 
+                {id: .id, tag: .metadata.container.tags[0], created_at: .created_at, 
+                 days_old: ((now - (.created_at | fromdateiso8601)) / 86400 | floor)}' | \
+            jq -c "select(.days_old > $DAYS)")
 
-              echo "Deleting package version: $tag (Created: $created_at, Age: $days_old days)"
-              
-              continue
+            if [ -n "$result" ]; then
+              echo "$result" | while read -r package; do
+                id=$(echo "$package" | jq -r '.id')
+                tag=$(echo "$package" | jq -r '.tag')
+                created_at=$(echo "$package" | jq -r '.created_at')
+                days_old=$(echo "$package" | jq -r '.days_old')
 
-              gh api \
-                --method DELETE \
-                -H "Accept: application/vnd.github+json" \
-                "/orgs/arkime/packages/container/arkime%2Farkime/versions/$id"
-              
-              if [ $? -eq 0 ]; then
-                echo "Successfully deleted package version: $tag"
-              else
-                echo "Failed to delete package version: $tag"
-              fi
-            done
+                echo "Deleting package version: $tag (Created: $created_at, Age: $days_old days)"
+
+                if [ "$DRY_RUN" != "false" ]; then
+                  echo "[DRY RUN] Would delete package version: $tag"
+                else
+                  gh api \
+                    --method DELETE \
+                    -H "Accept: application/vnd.github+json" \
+                    "/orgs/arkime/packages/container/arkime%2Farkime/versions/$id"
+                  
+                  if [ $? -eq 0 ]; then
+                    echo "Successfully deleted package version: $tag"
+                  else
+                    echo "Failed to delete package version: $tag"
+                  fi
+                fi
+              done
+            fi
 
             ((page++))
           done


### PR DESCRIPTION
- Add dry_run and days inputs with safe defaults
- Fix pagination to check API response instead of filtered results
- Fix variable quoting and indentation
- Delete snapshots starting with 'snapshot-' older than configurable days
## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
