### PR TITLE
Fix tooltip clipping by setting global BTooltip defaults

### DIFF
--- a/parliament/vueapp/src/main.js
+++ b/parliament/vueapp/src/main.js
@@ -31,7 +31,14 @@ async function initializeApp() {
   app.use(store);
   app.use(router);
   app.use(i18n);
-  app.use(createBootstrap());
+  app.use(createBootstrap({
+    components: {
+      BTooltip: {
+        boundary: 'viewport',
+        teleportTo: 'body'
+      }
+    }
+  }));
 
   // these globals are injected into index.ejs.html, by parliament.js
   /* eslint-disable no-undef */

--- a/viewer/vueapp/src/components/history/History.vue
+++ b/viewer/vueapp/src/components/history/History.vue
@@ -113,9 +113,7 @@ SPDX-License-Identifier: Apache-2.0
             <BTooltip
               target="seeAll"
               noninteractive
-              placement="bottom"
-              boundary="viewport"
-              teleport-to="body">
+              placement="bottom">
               <span v-html="$t('history.seeAllTipHtml')" />
             </BTooltip>
             <input

--- a/viewer/vueapp/src/components/search/Search.vue
+++ b/viewer/vueapp/src/components/search/Search.vue
@@ -12,7 +12,6 @@ SPDX-License-Identifier: Apache-2.0
         target="hideViz"
         :delay="{show: 0, hide: 0}"
         noninteractive
-        boundary="viewport"
         placement="left"
         v-if="basePath !== 'spigraph'">
         {{ $t(!hideViz ? 'search.speedUpTip' : 'search.showGraphTip') }}
@@ -22,7 +21,6 @@ SPDX-License-Identifier: Apache-2.0
           target="fetchVizQuery"
           :delay="{show: 0, hide: 0}"
           noninteractive
-          boundary="viewport"
           placement="left">
           {{ $t('search.fetchVizQueryTip') }}
         </BTooltip>
@@ -30,7 +28,6 @@ SPDX-License-Identifier: Apache-2.0
           target="fetchVizSession"
           :delay="{show: 0, hide: 0}"
           noninteractive
-          boundary="viewport"
           placement="left">
           {{ $t('search.fetchVizSessionTip') }}
         </BTooltip>
@@ -38,7 +35,6 @@ SPDX-License-Identifier: Apache-2.0
           target="fetchVizBrowser"
           :delay="{show: 0, hide: 0}"
           noninteractive
-          boundary="viewport"
           placement="left">
           {{ $t('search.fetchVizBrowserTip') }}
         </BTooltip>

--- a/viewer/vueapp/src/components/sessions/PacketOptions.vue
+++ b/viewer/vueapp/src/components/sessions/PacketOptions.vue
@@ -74,9 +74,7 @@ SPDX-License-Identifier: Apache-2.0
           <BTooltip
             :target="getTarget('toggleCompression')"
             noninteractive
-            boundary="viewport"
-            placement="right"
-            teleport-to="body">
+            placement="right">
             {{ $t(params.gzip ? 'sessions.packetOptions.disableUncompressing' : 'sessions.packetOptions.enableUncompressingTip') }}
           </BTooltip>
         </b-dropdown-item>
@@ -88,9 +86,7 @@ SPDX-License-Identifier: Apache-2.0
           <BTooltip
             :target="getTarget('toggleImages')"
             noninteractive
-            boundary="viewport"
-            placement="right"
-            teleport-to="body">
+            placement="right">
             {{ $t(params.image ? 'sessions.packetOptions.hideFiles' : 'sessions.packetOptions.showFilesTip') }}
           </BTooltip>
         </b-dropdown-item>
@@ -120,7 +116,6 @@ SPDX-License-Identifier: Apache-2.0
           <BTooltip
             :target="getTarget('toggleSrc')"
             noninteractive
-            boundary="viewport"
             placement="bottom">
             {{ $t('sessions.packetOptions.srcVisTip') }}
           </BTooltip>
@@ -135,7 +130,6 @@ SPDX-License-Identifier: Apache-2.0
           <BTooltip
             :target="getTarget('toggleDst')"
             noninteractive
-            boundary="viewport"
             placement="bottom">
             {{ $t('sessions.packetOptions.dstVisTip') }}
           </BTooltip>
@@ -161,7 +155,6 @@ SPDX-License-Identifier: Apache-2.0
           <BTooltip
             :target="`decodings${key}`"
             noninteractive
-            boundary="viewport"
             placement="bottom">
             {{ $t('sessions.packetOptions.toggleDecodingTip', value.name) }}
           </BTooltip>

--- a/viewer/vueapp/src/components/sessions/Sessions.vue
+++ b/viewer/vueapp/src/components/sessions/Sessions.vue
@@ -87,9 +87,7 @@ SPDX-License-Identifier: Apache-2.0
                       <BTooltip
                         target="openAllSessions"
                         noninteractive
-                        placement="right"
-                        boundary="viewport"
-                        teleport-to="body">
+                        placement="right">
                         {{ $t('sessions.sessions.openAll') }}
                       </BTooltip>
                     </button>
@@ -103,9 +101,7 @@ SPDX-License-Identifier: Apache-2.0
                     <BTooltip
                       target="closeAllSessions"
                       noninteractive
-                      placement="right"
-                      boundary="viewport"
-                      teleport-to="body">
+                      placement="right">
                       {{ $t('sessions.sessions.closeAll') }}
                     </BTooltip>
                   </button>
@@ -119,9 +115,7 @@ SPDX-License-Identifier: Apache-2.0
                     <BTooltip
                       target="fitTable"
                       noninteractive
-                      placement="right"
-                      boundary="viewport"
-                      teleport-to="body">
+                      placement="right">
                       {{ $t('sessions.sessions.fitTable') }}
                     </BTooltip>
                   </button>
@@ -144,7 +138,6 @@ SPDX-License-Identifier: Apache-2.0
                   no-caret
                   size="sm"
                   teleport-to="body"
-                  boundary="viewport"
                   menu-class="col-dropdown-menu"
                   class="col-dropdown d-inline-block"
                   variant="theme-secondary">
@@ -155,9 +148,7 @@ SPDX-License-Identifier: Apache-2.0
                       <BTooltip
                         target="colConfigMenu"
                         noninteractive
-                        placement="right"
-                        boundary="viewport"
-                        teleport-to="body">{{ $t('sessions.sessions.customColumnMsg') }}</BTooltip>
+                        placement="right">{{ $t('sessions.sessions.customColumnMsg') }}</BTooltip>
                     </span>
                   </template>
                   <b-dropdown-header header-class="p-1">
@@ -191,9 +182,7 @@ SPDX-License-Identifier: Apache-2.0
                       <BTooltip
                         target="colConfigDefault"
                         noninteractive
-                        placement="right"
-                        boundary="viewport"
-                        teleport-to="body">
+                        placement="right">
                         {{ $t('sessions.sessions.customColumnReset') }}
                       </BTooltip>
                     </b-dropdown-item>
@@ -216,9 +205,7 @@ SPDX-License-Identifier: Apache-2.0
                         <BTooltip
                           target="updateColumnConfiguration"
                           noninteractive
-                          placement="right"
-                          boundary="viewport"
-                          teleport-to="body">
+                          placement="right">
                           {{ $t('sessions.sessions.customColumnUpdate') }}
                         </BTooltip>
                       </button>
@@ -269,7 +256,6 @@ SPDX-License-Identifier: Apache-2.0
                       no-caret
                       size="sm"
                       teleport-to="body"
-                      boundary="viewport"
                       variant="theme-secondary"
                       menu-class="col-dropdown-menu"
                       class="info-vis-menu pull-right col-dropdown">
@@ -280,9 +266,7 @@ SPDX-License-Identifier: Apache-2.0
                           <BTooltip
                             target="infoConfigMenuSave"
                             noninteractive
-                            placement="right"
-                            boundary="viewport"
-                            teleport-to="body">{{ $t('sessions.sessions.customInfoMsg') }}</BTooltip>
+                            placement="right">{{ $t('sessions.sessions.customInfoMsg') }}</BTooltip>
                         </span>
                       </template>
                       <b-dropdown-header header-class="p-1">
@@ -313,9 +297,7 @@ SPDX-License-Identifier: Apache-2.0
                         <BTooltip
                           target="infodefault"
                           noninteractive
-                          placement="right"
-                          boundary="viewport"
-                          teleport-to="body">
+                          placement="right">
                           {{ $t('sessions.sessions.customInfoReset') }}
                         </BTooltip>
                       </b-dropdown-item>
@@ -344,9 +326,7 @@ SPDX-License-Identifier: Apache-2.0
                             <BTooltip
                               target="updateInfoFieldConfiguration"
                               noninteractive
-                              placement="right"
-                              boundary="viewport"
-                              teleport-to="body">
+                              placement="right">
                               {{ $t('sessions.sessions.customInfoUpdate') }}
                             </BTooltip>
                           </button>
@@ -378,7 +358,6 @@ SPDX-License-Identifier: Apache-2.0
                       no-caret
                       size="sm"
                       teleport-to="body"
-                      boundary="viewport"
                       menu-class="col-dropdown-menu"
                       class="info-vis-menu pull-right col-dropdown me-1"
                       variant="theme-primary"
@@ -391,9 +370,7 @@ SPDX-License-Identifier: Apache-2.0
                           <BTooltip
                             target="infoConfigMenu"
                             noninteractive
-                            placement="right"
-                            boundary="viewport"
-                            teleport-to="body">
+                            placement="right">
                             {{ $t('sessions.sessions.toggleInfoFields') }}
                           </BTooltip>
                         </span>
@@ -434,9 +411,7 @@ SPDX-License-Identifier: Apache-2.0
                                 v-if="field.help"
                                 :target="key + k + 'infoitem'"
                                 noninteractive
-                                placement="right"
-                                boundary="viewport"
-                                teleport-to="body">{{ field.help }}</BTooltip>
+                                placement="right">{{ field.help }}</BTooltip>
                             </b-dropdown-item>
                           </template>
                         </template>
@@ -457,7 +432,6 @@ SPDX-License-Identifier: Apache-2.0
                     no-flip
                     size="sm"
                     teleport-to="body"
-                    boundary="viewport"
                     menu-class="col-dropdown-menu"
                     class="pull-right col-dropdown">
                     <b-dropdown-item

--- a/viewer/vueapp/src/components/spiview/Spiview.vue
+++ b/viewer/vueapp/src/components/spiview/Spiview.vue
@@ -61,9 +61,7 @@ SPDX-License-Identifier: Apache-2.0
                     <BTooltip
                       target="spiViewFieldConfigSave"
                       placement="right"
-                      noninteractive
-                      teleport-to="body"
-                      boundary="viewport"><span v-i18n-btip="'spiview.'" /></BTooltip>
+                      noninteractive><span v-i18n-btip="'spiview.'" /></BTooltip>
                   </button>
                 </div>
               </b-dropdown-header>
@@ -79,9 +77,7 @@ SPDX-License-Identifier: Apache-2.0
                   <BTooltip
                     target="spiViewConfigDefault"
                     noninteractive
-                    placement="right"
-                    boundary="viewport"
-                    teleport-to="body">
+                    placement="right">
                     {{ $t('spiview.spiViewConfigDefaultTip') }}
                   </BTooltip>
                 </b-dropdown-item>
@@ -283,7 +279,6 @@ SPDX-License-Identifier: Apache-2.0
                           class="me-1 mb-1 field-dropdown"
                           :text="field.friendlyName"
                           :id="`spiViewField-${field.dbField}`"
-                          boundary="viewport"
                           @split-click="toggleSpiData(field, true, true)"
                           :class="{'active':categoryObjects[category].spi[field.dbField] && categoryObjects[category].spi[field.dbField].active}">
                           <b-dropdown-item

--- a/viewer/vueapp/src/components/stats/EsAdmin.vue
+++ b/viewer/vueapp/src/components/stats/EsAdmin.vue
@@ -119,8 +119,7 @@ SPDX-License-Identifier: Apache-2.0
               class="btn btn-warning">
               <span class="fa fa-undo" />
               <BTooltip
-                :target="`restore-${setting.key}`"
-                teleport-to="body">
+                :target="`restore-${setting.key}`">
                 {{ $t('stats.esAdmin.restoreAllocationTip') }}
               </BTooltip>
             </button>

--- a/viewer/vueapp/src/components/stats/EsShards.vue
+++ b/viewer/vueapp/src/components/stats/EsShards.vue
@@ -104,7 +104,6 @@ SPDX-License-Identifier: Apache-2.0
                     <span class="fa fa-trash fa-fw" />
                     <BTooltip
                       :target="`deleteUnassignedShards${index}`"
-                      teleport-to="body"
                       placement="right">
                       {{ $t('stats.esShards.deleteUnassignedTip') }}
                     </BTooltip>
@@ -118,7 +117,6 @@ SPDX-License-Identifier: Apache-2.0
                     <span class="fa fa-check fa-fw" />
                     <BTooltip
                       :target="`confirmDeleteUnassignedShards${index}`"
-                      teleport-to="body"
                       placement="right">
                       {{ $t('stats.esShards.confirmDeleteUnassignedTip') }}
                     </BTooltip>

--- a/viewer/vueapp/src/components/summary/SummaryConfigDropdown.vue
+++ b/viewer/vueapp/src/components/summary/SummaryConfigDropdown.vue
@@ -16,9 +16,7 @@ SPDX-License-Identifier: Apache-2.0
           <BTooltip
             target="summary-config-dropdown-btn"
             noninteractive
-            placement="right"
-            boundary="viewport"
-            teleport-to="body">{{ $t('sessions.summary.config.configurations') }}</BTooltip>
+            placement="right">{{ $t('sessions.summary.config.configurations') }}</BTooltip>
         </span>
       </template>
       <!-- Loading indicator -->

--- a/viewer/vueapp/src/components/utils/FieldSelectDropdown.vue
+++ b/viewer/vueapp/src/components/utils/FieldSelectDropdown.vue
@@ -5,7 +5,6 @@
     no-caret
     size="sm"
     teleport-to="body"
-    boundary="viewport"
     menu-class="field-dropdown-menu"
     class="field-dropdown d-inline-block"
     :variant="buttonVariant"
@@ -18,9 +17,7 @@
         <BTooltip
           :target="dropdownId"
           noninteractive
-          placement="right"
-          boundary="viewport"
-          teleport-to="body">{{ tooltipText }}</BTooltip>
+          placement="right">{{ tooltipText }}</BTooltip>
       </span>
     </template>
     <b-dropdown-header header-class="p-1">

--- a/viewer/vueapp/src/main.js
+++ b/viewer/vueapp/src/main.js
@@ -46,7 +46,14 @@ async function initializeApp() {
   app.use(store);
   app.use(router);
   app.use(i18n);
-  app.use(createBootstrap());
+  app.use(createBootstrap({
+    components: {
+      BTooltip: {
+        boundary: 'viewport',
+        teleportTo: 'body'
+      }
+    }
+  }));
 
   app.directive('has-role', HasRole);
   app.directive('has-permission', HasPermission);

--- a/wiseService/vueapp/src/main.js
+++ b/wiseService/vueapp/src/main.js
@@ -31,7 +31,14 @@ async function initializeApp() {
   app.use(store);
   app.use(router);
   app.use(i18n);
-  app.use(createBootstrap());
+  app.use(createBootstrap({
+    components: {
+      BTooltip: {
+        boundary: 'viewport',
+        teleportTo: 'body'
+      }
+    }
+  }));
 
   // these globals are injected into index.ejs.html, by wiseService.js
   /* eslint-disable no-undef */


### PR DESCRIPTION
Configure boundary='viewport' and teleportTo='body' globally via createBootstrap() in viewer, parliament, and wiseService. Remove now-redundant per-component boundary and teleport-to attributes.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
