### PR TITLE
support quic salts for draft23, draft29, v2; more ssdp keywords

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -49,6 +49,8 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #3652 Added basic stun parser
   - #3653 Improve krb5 parser
   - #3654 Added turn support to stun parser
+  - #3655 Handle different quic salts for draft23, draft29, v2
+  - #3655 More ssdp keywords
 
 6.0.0-rc1 2026/01/26
 ## BREAKING


### PR DESCRIPTION
## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
