### PR TITLE
move summaryChunkDelay to testuser section to not slow down tests

### DIFF
--- a/tests/config.test.ini
+++ b/tests/config.test.ini
@@ -1,6 +1,4 @@
 [default]
-# Development-only: delay between summary chunks for testing progressive display (milliseconds)
-summaryChunkDelay=2000
 getSessionBySearch=true
 #aes256Encryption=true
 elasticsearch= , , http://127.0.0.1:9200,
@@ -97,6 +95,9 @@ viewUrl=http://localhost:8123
 gapPacketPos=true
 
 [testuser]
+# Development-only: delay between summary chunks for testing progressive display (milliseconds)
+summaryChunkDelay=1000
+
 pcapWriteMethod=simple
 interface=eth1
 prefix=tests


### PR DESCRIPTION
## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
