### PR TITLE
Add AWS SigV4 request signing to esproxy

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -117,6 +117,11 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #3682 Added s7comm parser
   - #3686 Added websocket detection
   - #3687 Added c122 parser
+## esproxy
+  - Added AWS SigV4 request signing for OpenSearch IAM authentication
+  - Supports Athenz ZTS, STS AssumeRole, static, and default credential chain
+  - Automatic credential refresh before expiry
+  - SigV4 support for tee target
 
 6.0.0-rc1 2026/01/26
 ## BREAKING

--- a/docs/esproxy-sigv4-design.md
+++ b/docs/esproxy-sigv4-design.md
@@ -1,0 +1,221 @@
+# esproxy: AWS SigV4 Request Signing for OpenSearch
+
+## Summary
+
+Add AWS Signature v4 request signing to esproxy so that Arkime capture sensors
+can ship session metadata to a public-facing AWS OpenSearch domain using IAM
+authentication — without requiring AWS Direct Connect, VPN tunnels, or IP-based
+access policies.
+
+## Motivation
+
+Arkime sensors currently write session metadata to Elasticsearch/OpenSearch
+using Basic Auth or API keys. When migrating to AWS-managed OpenSearch, the
+standard approach is AWS IAM-based authentication via SigV4-signed HTTP
+requests.
+
+Today, getting sensors to talk to AWS OpenSearch requires one of:
+
+1. **AWS Direct Connect** — Requires data center hardware, network team
+   involvement, port-hour costs, and an IP-based access policy on the
+   OpenSearch domain. Does not provide per-request identity verification.
+
+2. **VPC-based OpenSearch + VPN** — Similar infrastructure overhead with the
+   OpenSearch domain locked to a VPC.
+
+3. **OpenSearch with FGAC + Basic Auth** — Works without code changes but
+   requires managing internal user credentials separately from your org's
+   identity system.
+
+None of these options align with a zero-trust architecture where each request
+is authenticated via cryptographic identity.
+
+### Proposed approach
+
+Modify esproxy to obtain temporary AWS credentials (via Athenz ZTS, STS
+AssumeRole, instance profile, or environment variables) and sign every outbound
+request to OpenSearch with SigV4. Sensors continue authenticating to esproxy
+using their existing Basic Auth credentials. esproxy acts as the trust boundary:
+
+```
+[Capture Sensor]
+  | Basic Auth over HTTPS
+  v
+[esproxy] — validates sensor identity, whitelists operations
+  | SigV4-signed HTTPS
+  v
+[AWS OpenSearch (public endpoint, IAM auth)]
+```
+
+This keeps all existing sensor-side configuration unchanged. Only esproxy needs
+new configuration for AWS credential sourcing.
+
+## Current State of esproxy
+
+`viewer/esProxy.js` (~468 lines) is a lightweight Express.js proxy that:
+
+- Accepts requests from sensors with Basic Auth + optional IP validation
+- Whitelists specific GET/POST/PUT/DELETE paths (sessions, fields, stats, bulk)
+- Validates bulk indexing payloads (only allows sessions/fields indices)
+- Forwards requests to Elasticsearch/OpenSearch via raw `http`/`https` modules
+- Supports optional "tee" to a secondary cluster
+- Auth to upstream ES: Basic Auth (`elasticsearchBasicAuth`) or API Key
+  (`elasticsearchAPIKey`) — set as a static `Authorization` header
+- Listens on port 7200 by default (`esProxyPort`)
+
+Key function: `doProxyFull()` (line 227) — single code path for all proxied
+requests. Constructs an `http.request()` with the upstream URL, sets the
+`Authorization` header, copies select headers from the original request, and
+pipes the body. This is the injection point for SigV4 signing.
+
+## Design
+
+### Credential Provider
+
+A module that obtains and caches AWS credentials. Supports multiple sources
+(checked in order):
+
+1. **Athenz ZTS** — Call ZTS with service identity cert to get temporary AWS
+   STS credentials. Requires config: `esProxySigV4AthenzZtsUrl`,
+   `esProxySigV4AthenzCert`, `esProxySigV4AthenzKey`, `esProxySigV4AthenzRole`.
+2. **STS AssumeRole** — Assume an IAM role using base credentials. Requires
+   config: `esProxySigV4RoleArn`.
+3. **Environment / instance profile** — Standard AWS SDK credential chain
+   (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, EC2/ECS metadata). No config
+   needed.
+
+Credentials are refreshed automatically before expiry (e.g., refresh at 75% of
+TTL, typically ~45 minutes for 1-hour tokens).
+
+### Request Signing
+
+Before forwarding each request in `doProxyFull()`:
+
+1. Read the request method, path, query string, headers, and body
+2. Compute SigV4 signature using the current cached credentials
+3. Set `Authorization`, `X-Amz-Date`, `X-Amz-Security-Token` (if using
+   session credentials), and `X-Amz-Content-Sha256` headers
+4. Remove any existing `Authorization` header (from sensor Basic Auth)
+5. Forward the signed request to OpenSearch
+
+Use `@aws-sdk/signature-v4` + `@smithy/hash-node` for signing. These are
+lightweight packages (~50KB) that don't require the full AWS SDK.
+
+### Configuration
+
+New config options in `config.ini` under the existing `[default]` or
+`[esproxy]` section:
+
+```ini
+# Enable SigV4 signing for upstream OpenSearch requests
+esProxySigV4=true
+
+# AWS region for the OpenSearch domain
+esProxySigV4Region=us-east-1
+
+# Service name (default: "es" for OpenSearch)
+esProxySigV4Service=es
+
+# --- Credential source options (pick one) ---
+
+# Option A: Athenz ZTS
+esProxySigV4AthenzZtsUrl=https://zts.example.com:4443/zts/v1
+esProxySigV4AthenzDomain=your.athenz.domain
+esProxySigV4AthenzRole=opensearch-writer
+esProxySigV4AthenzCert=/path/to/service.cert.pem
+esProxySigV4AthenzKey=/path/to/service.key.pem
+esProxySigV4AthenzAwsAccount=123456789012
+
+# Option B: STS AssumeRole (uses env/instance creds as base)
+esProxySigV4RoleArn=arn:aws:iam::123456789012:role/opensearch-writer
+
+# Option C: Static credentials (for testing only)
+esProxySigV4AccessKeyId=AKIA...
+esProxySigV4SecretAccessKey=...
+
+# Option D: Default AWS credential chain (no config needed, just set
+#           AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY env vars or use
+#           instance profile / ECS task role)
+```
+
+When `esProxySigV4=true`, the existing `elasticsearchBasicAuth` and
+`elasticsearchAPIKey` settings are ignored for upstream auth (sensor-side
+Basic Auth still works).
+
+### Tee Support
+
+The tee configuration already uses a separate `authHeader`. If the tee target
+also needs SigV4, it gets its own config section `[tee]` with the same
+`esProxySigV4*` keys.
+
+## Tasks
+
+- [x] **Add AWS signing dependencies** — Add `@aws-sdk/signature-v4`,
+      `@smithy/hash-node`, `@smithy/protocol-http` to package.json.
+- [x] **Implement credential provider** — Module that obtains, caches, and
+      refreshes AWS credentials from the configured source (env/instance
+      profile, AssumeRole, or Athenz ZTS).
+- [x] **Implement request signer** — Function that takes an HTTP request
+      (method, URL, headers, body) and returns SigV4-signed headers.
+- [x] **Integrate signing into doProxyFull()** — When SigV4 is enabled,
+      sign outbound requests before forwarding. Handle body hashing for
+      bulk payloads (possibly chunked/gzip-encoded).
+- [x] **Add configuration parsing** — Read `esProxySigV4*` config keys in
+      the `ArkimeConfig.loaded()` block.
+- [x] **Add Athenz ZTS credential source** — HTTPS call to ZTS to exchange
+      service identity for temporary AWS credentials.
+- [x] **Handle credential refresh** — Timer-based refresh before expiry.
+      Graceful handling if refresh fails (use cached creds until they expire,
+      log errors).
+- [x] **Add tee SigV4 support** — Separate credential provider for the tee
+      target if configured.
+- [ ] **Test with local OpenSearch** — Verify basic functionality with a
+      local OpenSearch instance + SigV4 auth (or mocked).
+- [ ] **Test with AWS OpenSearch** — End-to-end test with a real AWS
+      OpenSearch domain.
+- [ ] **Update documentation** — Document new config options on arkime.com
+      esproxy page.
+- [x] **Update CHANGELOG** — Add entry under the appropriate section.
+
+## Risks and Considerations
+
+**Body hashing with gzip** — SigV4 requires hashing the request body. esproxy
+already handles gzip-encoded bulk payloads (line 318-330). The body must be
+hashed *as sent* (compressed), not decompressed. This should work naturally
+since `req.body` contains the raw bytes.
+
+**Large bulk payloads** — Bulk requests can be up to 11MB (line 212). SHA-256
+hashing 11MB is fast (~20ms) but should be verified under load. For
+`UNSIGNED-PAYLOAD`, AWS OpenSearch would need to allow it — this may not work
+with IAM auth.
+
+**Credential refresh during requests** — If credentials expire mid-request,
+the request fails. The refresh timer should ensure credentials are always valid
+with comfortable margin.
+
+**Clock skew** — SigV4 requires timestamps within 5 minutes of AWS time. The
+esproxy host must have NTP configured. This is typically a non-issue but worth
+documenting.
+
+**No changes to sensors or capture** — This is purely an esproxy change.
+Sensors continue using Basic Auth to talk to esproxy. The capture binary and
+viewer are unaffected.
+
+## Infrastructure Dependencies (AWS Baselines)
+
+The target OpenSearch domain must satisfy AWS-6032, AWS-6033, and AWS-6095.
+SigV4 signing with a scoped IAM role is the cleanest path to compliance.
+
+- **IAM role** for esproxy with `es:ESHttp*` permissions on the domain
+  resource. Do not use `es:*` — that includes domain admin actions.
+- **Domain access policy** must list the esproxy role ARN as a trusted
+  principal (satisfies AWS-6032 trusted accounts + AWS-6033 resource-based
+  policy). Do not use `"Principal": "*"`.
+- **Athenz ZTS** must be configured to map the esproxy service identity to
+  the IAM role above.
+- **Encryption at rest** must be enabled on the domain (AWS-6095) — infra
+  team responsibility, no esproxy code impact.
+- **GACCO auto-remediation** — verify it won't overwrite the domain access
+  policy. Register the domain as manually managed if needed.
+- **Optional defense-in-depth** — add `aws:SourceIp` condition to the domain
+  policy if esproxy runs from known static IPs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1000.0",
+        "@aws-sdk/client-sts": "^3.1000.0",
+        "@aws-sdk/credential-providers": "^3.1000.0",
         "@clickhouse/client": "^1.12.1",
         "@databricks/sql": "^1.12.0",
         "@elastic/elasticsearch": "7.10.0",
@@ -308,6 +310,56 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-cognito-identity": {
+      "version": "3.1000.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.1000.0.tgz",
+      "integrity": "sha512-7PtY49oxAo0rzkXZ1ulumtRL4QYi30Q5AMJtqJhYCHc1VZr0I2f0LHxiwovzquqUPzmTArgY6LjcPB7bkB/54w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.15",
+        "@aws-sdk/credential-provider-node": "^3.972.14",
+        "@aws-sdk/middleware-host-header": "^3.972.6",
+        "@aws-sdk/middleware-logger": "^3.972.6",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.6",
+        "@aws-sdk/middleware-user-agent": "^3.972.15",
+        "@aws-sdk/region-config-resolver": "^3.972.6",
+        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/util-endpoints": "^3.996.3",
+        "@aws-sdk/util-user-agent-browser": "^3.972.6",
+        "@aws-sdk/util-user-agent-node": "^3.973.0",
+        "@smithy/config-resolver": "^4.4.9",
+        "@smithy/core": "^3.23.6",
+        "@smithy/fetch-http-handler": "^5.3.11",
+        "@smithy/hash-node": "^4.2.10",
+        "@smithy/invalid-dependency": "^4.2.10",
+        "@smithy/middleware-content-length": "^4.2.10",
+        "@smithy/middleware-endpoint": "^4.4.20",
+        "@smithy/middleware-retry": "^4.4.37",
+        "@smithy/middleware-serde": "^4.2.11",
+        "@smithy/middleware-stack": "^4.2.10",
+        "@smithy/node-config-provider": "^4.3.10",
+        "@smithy/node-http-handler": "^4.4.12",
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/smithy-client": "^4.12.0",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.10",
+        "@smithy/util-base64": "^4.3.1",
+        "@smithy/util-body-length-browser": "^4.2.1",
+        "@smithy/util-body-length-node": "^4.2.2",
+        "@smithy/util-defaults-mode-browser": "^4.3.36",
+        "@smithy/util-defaults-mode-node": "^4.2.39",
+        "@smithy/util-endpoints": "^3.3.1",
+        "@smithy/util-middleware": "^4.2.10",
+        "@smithy/util-retry": "^4.2.10",
+        "@smithy/util-utf8": "^4.2.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-s3": {
       "version": "3.1000.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1000.0.tgz",
@@ -374,6 +426,56 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.1000.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.1000.0.tgz",
+      "integrity": "sha512-PMUloaoajk/YxLWh4OFC5H8wauISkeG5/OS/I0ZeptMVq36hKQmJgYFhOqcCWAm6u/88JX9XztmKCTX8CyFPVg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.15",
+        "@aws-sdk/credential-provider-node": "^3.972.14",
+        "@aws-sdk/middleware-host-header": "^3.972.6",
+        "@aws-sdk/middleware-logger": "^3.972.6",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.6",
+        "@aws-sdk/middleware-user-agent": "^3.972.15",
+        "@aws-sdk/region-config-resolver": "^3.972.6",
+        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/util-endpoints": "^3.996.3",
+        "@aws-sdk/util-user-agent-browser": "^3.972.6",
+        "@aws-sdk/util-user-agent-node": "^3.973.0",
+        "@smithy/config-resolver": "^4.4.9",
+        "@smithy/core": "^3.23.6",
+        "@smithy/fetch-http-handler": "^5.3.11",
+        "@smithy/hash-node": "^4.2.10",
+        "@smithy/invalid-dependency": "^4.2.10",
+        "@smithy/middleware-content-length": "^4.2.10",
+        "@smithy/middleware-endpoint": "^4.4.20",
+        "@smithy/middleware-retry": "^4.4.37",
+        "@smithy/middleware-serde": "^4.2.11",
+        "@smithy/middleware-stack": "^4.2.10",
+        "@smithy/node-config-provider": "^4.3.10",
+        "@smithy/node-http-handler": "^4.4.12",
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/smithy-client": "^4.12.0",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.10",
+        "@smithy/util-base64": "^4.3.1",
+        "@smithy/util-body-length-browser": "^4.2.1",
+        "@smithy/util-body-length-node": "^4.2.2",
+        "@smithy/util-defaults-mode-browser": "^4.3.36",
+        "@smithy/util-defaults-mode-node": "^4.2.39",
+        "@smithy/util-endpoints": "^3.3.1",
+        "@smithy/util-middleware": "^4.2.10",
+        "@smithy/util-retry": "^4.2.10",
+        "@smithy/util-utf8": "^4.2.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/core": {
       "version": "3.973.15",
       "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.15.tgz",
@@ -404,6 +506,22 @@
       "integrity": "sha512-UExeK+EFiq5LAcbHm96CQLSia+5pvpUVSAsVApscBzayb7/6dJBJKwV4/onsk4VbWSmqxDMcfuTD+pC4RxgZHg==",
       "license": "Apache-2.0",
       "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity": {
+      "version": "3.972.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.972.6.tgz",
+      "integrity": "sha512-RJqEZYFoXkBTVCwSJuYFd311qc/Q/cBJ8BH08+ggX/rUTWw47TUEyZlxzyTlKfP7DoXG4Khu/TX+pzU6godEGQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/nested-clients": "^3.996.3",
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/property-provider": "^4.2.10",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
@@ -562,6 +680,37 @@
         "@aws-sdk/types": "^3.973.4",
         "@smithy/property-provider": "^4.2.10",
         "@smithy/shared-ini-file-loader": "^4.4.5",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers": {
+      "version": "3.1000.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.1000.0.tgz",
+      "integrity": "sha512-J0pBgTZ2b3UCnj+NQTPtWYjrEUne2aGwq1Xuuw8P2cIMpPBYJc39e59oYoRGpNseUXqcjkh0nLtWqZREEeMvkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.1000.0",
+        "@aws-sdk/core": "^3.973.15",
+        "@aws-sdk/credential-provider-cognito-identity": "^3.972.6",
+        "@aws-sdk/credential-provider-env": "^3.972.13",
+        "@aws-sdk/credential-provider-http": "^3.972.15",
+        "@aws-sdk/credential-provider-ini": "^3.972.13",
+        "@aws-sdk/credential-provider-login": "^3.972.13",
+        "@aws-sdk/credential-provider-node": "^3.972.14",
+        "@aws-sdk/credential-provider-process": "^3.972.13",
+        "@aws-sdk/credential-provider-sso": "^3.972.13",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.13",
+        "@aws-sdk/nested-clients": "^3.996.3",
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/config-resolver": "^4.4.9",
+        "@smithy/core": "^3.23.6",
+        "@smithy/credential-provider-imds": "^4.2.10",
+        "@smithy/node-config-provider": "^4.3.10",
+        "@smithy/property-provider": "^4.2.10",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1000.0",
+    "@aws-sdk/client-sts": "^3.1000.0",
+    "@aws-sdk/credential-providers": "^3.1000.0",
     "@clickhouse/client": "^1.12.1",
     "@databricks/sql": "^1.12.0",
     "@elastic/elasticsearch": "7.10.0",

--- a/viewer/esProxy.js
+++ b/viewer/esProxy.js
@@ -17,6 +17,10 @@ const basicAuth = require('basic-auth');
 const zlib = require('zlib');
 const ArkimeUtil = require('../common/arkimeUtil');
 const ArkimeConfig = require('../common/arkimeConfig');
+const { SignatureV4 } = require('@smithy/signature-v4');
+const { Hash } = require('@smithy/hash-node');
+const { HttpRequest } = require('@smithy/protocol-http');
+const EsProxyCredentials = require('./esProxyCredentials');
 
 // express app
 const app = express();
@@ -31,6 +35,11 @@ let oldprefix;
 let prefix;
 const esSSLOptions = { rejectUnauthorized: !ArkimeConfig.insecure };
 let authHeader;
+let sigV4Enabled = false;
+let sigV4Signer = null;
+let sigV4Credentials = null;
+let sigV4SignerTee = null;
+let sigV4CredentialsTee = null;
 
 ArkimeConfig.loaded(() => {
   elasticsearch = Config.get('elasticsearch');
@@ -72,6 +81,34 @@ ArkimeConfig.loaded(() => {
       authHeader = `Basic ${Buffer.from(esBasicAuth).toString('base64')}`;
     }
   }
+
+  sigV4Enabled = Config.get('esProxySigV4', false) === 'true' || Config.get('esProxySigV4', false) === true;
+  if (sigV4Enabled) {
+    const region = Config.get('esProxySigV4Region');
+    const service = Config.get('esProxySigV4Service', 'es');
+
+    sigV4Credentials = new EsProxyCredentials({
+      athenzZtsUrl: Config.get('esProxySigV4AthenzZtsUrl'),
+      athenzDomain: Config.get('esProxySigV4AthenzDomain'),
+      athenzRole: Config.get('esProxySigV4AthenzRole'),
+      athenzCert: Config.get('esProxySigV4AthenzCert'),
+      athenzKey: Config.get('esProxySigV4AthenzKey'),
+      athenzAwsAccount: Config.get('esProxySigV4AthenzAwsAccount'),
+      roleArn: Config.get('esProxySigV4RoleArn'),
+      accessKeyId: Config.get('esProxySigV4AccessKeyId'),
+      secretAccessKey: Config.get('esProxySigV4SecretAccessKey')
+    });
+
+    sigV4Signer = new SignatureV4({
+      credentials: () => sigV4Credentials.getCredentials(),
+      region: region,
+      service: service,
+      sha256: Hash.bind(null, 'sha256')
+    });
+
+    authHeader = null;
+    console.log('SigV4 signing enabled for region:', region);
+  }
 });
 
 // ============================================================================
@@ -92,6 +129,34 @@ ArkimeConfig.loaded(() => {
     } else {
       authHeaderTee = `Basic ${Buffer.from(esBasicAuthTee).toString('base64')}`;
     }
+  }
+
+  const teeSigV4Enabled = Config.sectionGet('tee', 'esProxySigV4', false) === 'true' || Config.sectionGet('tee', 'esProxySigV4', false) === true;
+  if (teeSigV4Enabled) {
+    const teeRegion = Config.sectionGet('tee', 'esProxySigV4Region');
+    const teeService = Config.sectionGet('tee', 'esProxySigV4Service', 'es');
+
+    sigV4CredentialsTee = new EsProxyCredentials({
+      athenzZtsUrl: Config.sectionGet('tee', 'esProxySigV4AthenzZtsUrl'),
+      athenzDomain: Config.sectionGet('tee', 'esProxySigV4AthenzDomain'),
+      athenzRole: Config.sectionGet('tee', 'esProxySigV4AthenzRole'),
+      athenzCert: Config.sectionGet('tee', 'esProxySigV4AthenzCert'),
+      athenzKey: Config.sectionGet('tee', 'esProxySigV4AthenzKey'),
+      athenzAwsAccount: Config.sectionGet('tee', 'esProxySigV4AthenzAwsAccount'),
+      roleArn: Config.sectionGet('tee', 'esProxySigV4RoleArn'),
+      accessKeyId: Config.sectionGet('tee', 'esProxySigV4AccessKeyId'),
+      secretAccessKey: Config.sectionGet('tee', 'esProxySigV4SecretAccessKey')
+    });
+
+    sigV4SignerTee = new SignatureV4({
+      credentials: () => sigV4CredentialsTee.getCredentials(),
+      region: teeRegion,
+      service: teeService,
+      sha256: Hash.bind(null, 'sha256')
+    });
+
+    authHeaderTee = null;
+    console.log('SigV4 signing enabled for tee, region:', teeRegion);
   }
 });
 
@@ -224,7 +289,7 @@ function saveBody (req, res, next) {
 
 // Proxy
 
-function doProxyFull (config, req, res) {
+async function doProxyFull (config, req, res) {
   let result = '';
   const esUrl = config.elasticsearch + req.url;
   console.log(`URL ${req.method} "%s"`, ArkimeUtil.sanitizeStr(esUrl));
@@ -239,7 +304,27 @@ function doProxyFull (config, req, res) {
     client = http;
   }
 
-  if (config.authHeader) {
+  if (config.sigV4Signer && config.sigV4Credentials) {
+    await config.sigV4Credentials.getCredentials();
+    const httpRequest = new HttpRequest({
+      method: req.method,
+      protocol: url.protocol,
+      hostname: url.hostname,
+      port: url.port ? Number(url.port) : undefined,
+      path: url.pathname + (url.search || ''),
+      headers: {
+        host: url.host,
+        'content-type': req.headers['content-type'] || 'application/json'
+      }
+    });
+    if (req._body) {
+      httpRequest.body = req.body;
+    }
+    const signed = await config.sigV4Signer.sign(httpRequest, {
+      signingDate: new Date()
+    });
+    options.headers = signed.headers;
+  } else if (config.authHeader) {
     options.headers = {
       Authorization: config.authHeader
     };
@@ -273,10 +358,10 @@ function doProxyFull (config, req, res) {
   }
 }
 
-function doProxy (req, res) {
-  doProxyFull({ elasticsearch, authHeader }, req, res);
+async function doProxy (req, res) {
+  await doProxyFull({ elasticsearch, authHeader, sigV4Signer, sigV4Credentials }, req, res);
   if (elasticsearchTee) {
-    doProxyFull({ elasticsearch: elasticsearchTee, authHeader: authHeaderTee }, req, {
+    doProxyFull({ elasticsearch: elasticsearchTee, authHeader: authHeaderTee, sigV4Signer: sigV4SignerTee, sigV4Credentials: sigV4CredentialsTee }, req, {
       setHeader: () => {},
       send: () => {}
     });
@@ -305,7 +390,10 @@ app.get('*', (req, res) => {
     console.log(`GET failed node: ${req.sensor.node} path:>%s<:`, ArkimeUtil.sanitizeStr(path));
     return res.status(400).send('Not authorized for API');
   }
-  doProxy(req, res);
+  doProxy(req, res).catch(e => {
+    console.log('Proxy error', e);
+    res.status(500).send('Internal proxy error');
+  });
 });
 
 // Validate Bulk
@@ -420,7 +508,10 @@ app.post('*', saveBody, (req, res) => {
     console.log(req.body.toString('utf8'));
     return res.status(400).send('Not authorized for API');
   }
-  doProxy(req, res);
+  doProxy(req, res).catch(e => {
+    console.log('Proxy error', e);
+    res.status(500).send('Internal proxy error');
+  });
 });
 
 // Delete requests
@@ -433,7 +524,10 @@ app.delete('*', (req, res) => {
     console.log(`DELETE failed node: ${req.sensor.node} path:>%s<:`, ArkimeUtil.sanitizeStr(path));
     return res.status(400).send('Not authorized for API');
   }
-  doProxy(req, res);
+  doProxy(req, res).catch(e => {
+    console.log('Proxy error', e);
+    res.status(500).send('Internal proxy error');
+  });
 });
 
 // Put requests
@@ -446,7 +540,10 @@ app.put('*', (req, res) => {
     console.log(`PUT failed node: ${req.sensor.node} path:>%s<:`, ArkimeUtil.sanitizeStr(path));
     return res.status(400).send('Not authorized for API');
   }
-  doProxy(req, res);
+  doProxy(req, res).catch(e => {
+    console.log('Proxy error', e);
+    res.status(500).send('Internal proxy error');
+  });
 });
 
 // Replace the default express error handler
@@ -463,6 +560,13 @@ async function main () {
 
   httpAgent = new http.Agent({ keepAlive: true, keepAliveMsecs: 5000, maxSockets: 100 });
   httpsAgent = new https.Agent(Object.assign({ keepAlive: true, keepAliveMsecs: 5000, maxSockets: 100 }, esSSLOptions));
+
+  if (sigV4Credentials) {
+    await sigV4Credentials.initialize();
+  }
+  if (sigV4CredentialsTee) {
+    await sigV4CredentialsTee.initialize();
+  }
 
   ArkimeUtil.createHttpServer(app, Config.get('esProxyHost'), Config.get('esProxyPort', '7200'));
 }

--- a/viewer/esProxyCredentials.js
+++ b/viewer/esProxyCredentials.js
@@ -1,0 +1,233 @@
+/******************************************************************************/
+/* esProxyCredentials.js -- AWS credential provider for esproxy SigV4 signing.
+ *                          Supports Athenz ZTS, STS AssumeRole, static creds,
+ *                          and the default AWS credential chain.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict';
+
+const https = require('https');
+const fs = require('fs');
+
+// ============================================================================
+// EsProxyCredentials
+// ============================================================================
+
+class EsProxyCredentials {
+  #config;
+  #credentials;
+  #refreshTimer;
+  #source;
+
+  // --------------------------------------------------------------------------
+  constructor (config) {
+    this.#config = config || {};
+    this.#credentials = null;
+    this.#refreshTimer = null;
+    this.#source = this.#determineSource();
+  }
+
+  // --------------------------------------------------------------------------
+  #determineSource () {
+    if (this.#config.athenzZtsUrl) {
+      return 'athenz';
+    }
+    if (this.#config.roleArn) {
+      return 'sts';
+    }
+    if (this.#config.accessKeyId && this.#config.secretAccessKey) {
+      return 'static';
+    }
+    return 'default';
+  }
+
+  // --------------------------------------------------------------------------
+  async getCredentials () {
+    if (this.#credentials) {
+      return this.#credentials;
+    }
+    return this.#fetchCredentials();
+  }
+
+  // --------------------------------------------------------------------------
+  async initialize () {
+    console.log(`esProxyCredentials: initializing with source=${this.#source}`);
+    await this.#fetchCredentials();
+    console.log('esProxyCredentials: initial credentials obtained');
+  }
+
+  // --------------------------------------------------------------------------
+  stop () {
+    if (this.#refreshTimer) {
+      clearTimeout(this.#refreshTimer);
+      this.#refreshTimer = null;
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  async #fetchCredentials () {
+    switch (this.#source) {
+    case 'athenz':
+      return this.#fetchAthenz();
+    case 'sts':
+      return this.#fetchSts();
+    case 'static':
+      return this.#fetchStatic();
+    case 'default':
+      return this.#fetchDefault();
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  async #fetchAthenz () {
+    const { athenzZtsUrl, athenzDomain, athenzRole, athenzCert, athenzKey, athenzAwsAccount } = this.#config;
+
+    const certData = fs.readFileSync(athenzCert);
+    const keyData = fs.readFileSync(athenzKey);
+
+    const urlStr = `${athenzZtsUrl}/domain/${athenzDomain}/role/${athenzRole}/creds` +
+      `?durationSeconds=3600&externalId=${athenzAwsAccount}`;
+    const url = new URL(urlStr);
+
+    const options = {
+      method: 'POST',
+      hostname: url.hostname,
+      port: url.port || 443,
+      path: url.pathname + url.search,
+      cert: certData,
+      key: keyData,
+      rejectUnauthorized: true
+    };
+
+    const body = await new Promise((resolve, reject) => {
+      const req = https.request(options, (res) => {
+        let data = '';
+        res.on('data', (chunk) => { data += chunk; });
+        res.on('end', () => {
+          if (res.statusCode < 200 || res.statusCode >= 300) {
+            reject(new Error(`Athenz ZTS returned status ${res.statusCode}: ${data}`));
+            return;
+          }
+          resolve(data);
+        });
+      });
+      req.on('error', reject);
+      req.end();
+    });
+
+    const json = JSON.parse(body);
+    const creds = json.Credentials || json.credentials;
+    if (!creds) {
+      throw new Error('Athenz ZTS response missing Credentials field');
+    }
+
+    this.#credentials = {
+      accessKeyId: creds.AccessKeyId,
+      secretAccessKey: creds.SecretAccessKey,
+      sessionToken: creds.SessionToken
+    };
+
+    const expiration = creds.Expiration;
+    if (expiration) {
+      this.#scheduleRefresh(new Date(expiration));
+    }
+
+    console.log('esProxyCredentials: refreshed credentials from Athenz ZTS');
+    return this.#credentials;
+  }
+
+  // --------------------------------------------------------------------------
+  async #fetchSts () {
+    const { STSClient, AssumeRoleCommand } = require('@aws-sdk/client-sts');
+
+    const client = new STSClient({});
+    const command = new AssumeRoleCommand({
+      RoleArn: this.#config.roleArn,
+      RoleSessionName: 'arkime-esproxy'
+    });
+
+    const response = await client.send(command);
+    const creds = response.Credentials;
+
+    this.#credentials = {
+      accessKeyId: creds.AccessKeyId,
+      secretAccessKey: creds.SecretAccessKey,
+      sessionToken: creds.SessionToken
+    };
+
+    if (creds.Expiration) {
+      this.#scheduleRefresh(new Date(creds.Expiration));
+    }
+
+    console.log('esProxyCredentials: refreshed credentials from STS AssumeRole');
+    return this.#credentials;
+  }
+
+  // --------------------------------------------------------------------------
+  async #fetchStatic () {
+    this.#credentials = {
+      accessKeyId: this.#config.accessKeyId,
+      secretAccessKey: this.#config.secretAccessKey,
+      sessionToken: undefined
+    };
+    console.log('esProxyCredentials: using static credentials');
+    return this.#credentials;
+  }
+
+  // --------------------------------------------------------------------------
+  async #fetchDefault () {
+    const { fromNodeProviderChain } = require('@aws-sdk/credential-providers');
+
+    const provider = fromNodeProviderChain();
+    const creds = await provider();
+
+    this.#credentials = {
+      accessKeyId: creds.accessKeyId,
+      secretAccessKey: creds.secretAccessKey,
+      sessionToken: creds.sessionToken
+    };
+
+    if (creds.expiration) {
+      this.#scheduleRefresh(new Date(creds.expiration));
+    }
+
+    console.log('esProxyCredentials: refreshed credentials from default provider chain');
+    return this.#credentials;
+  }
+
+  // --------------------------------------------------------------------------
+  #scheduleRefresh (expiration) {
+    if (this.#refreshTimer) {
+      clearTimeout(this.#refreshTimer);
+    }
+
+    const now = Date.now();
+    const expiresAt = expiration.getTime();
+    const ttl = expiresAt - now;
+    const delay = Math.max(ttl * 0.75, 30000); // refresh at 75% of TTL, min 30s
+
+    console.log(`esProxyCredentials: scheduling refresh in ${Math.round(delay / 1000)}s (expires in ${Math.round(ttl / 1000)}s)`);
+
+    this.#refreshTimer = setTimeout(async () => {
+      try {
+        await this.#fetchCredentials();
+      } catch (err) {
+        console.log('esProxyCredentials: failed to refresh credentials, will keep using cached:', err.message);
+        // Retry again at half the remaining TTL
+        const remaining = expiresAt - Date.now();
+        if (remaining > 60000) {
+          this.#scheduleRefresh(expiration);
+        }
+      }
+    }, delay);
+
+    // Allow the process to exit even if the timer is pending
+    if (this.#refreshTimer.unref) {
+      this.#refreshTimer.unref();
+    }
+  }
+}
+
+module.exports = EsProxyCredentials;


### PR DESCRIPTION
## Summary

- Adds AWS SigV4 request signing to esproxy, enabling IAM-authenticated access to AWS OpenSearch without Direct Connect or VPN
- New `esProxyCredentials.js` module supporting Athenz ZTS, STS AssumeRole, static credentials, and the default AWS credential chain with automatic refresh
- Signs outbound requests in `doProxyFull()` when `esProxySigV4=true` is configured
- Tee target gets independent SigV4 support
- Fully backward compatible — no behavior changes when SigV4 is not enabled

## Architecture

```
[Capture Sensor] --Basic Auth/HTTPS--> [esproxy] --SigV4/HTTPS--> [AWS OpenSearch]
```

Sensors continue authenticating to esproxy with existing Basic Auth. esproxy obtains temporary AWS credentials, signs each outbound request, and forwards to OpenSearch. Request whitelisting and sensor validation are unchanged.

## New config keys

```ini
esProxySigV4=true
esProxySigV4Region=us-east-1
esProxySigV4Service=es

# Credential source (pick one):
esProxySigV4AthenzZtsUrl=...    # Athenz ZTS
esProxySigV4RoleArn=...         # STS AssumeRole
esProxySigV4AccessKeyId=...     # Static (testing)
# Or: default AWS credential chain (no config needed)
```

## Test plan

- [ ] Verify non-SigV4 mode works identically to current behavior (no config changes)
- [ ] Test with static AWS credentials against a local OpenSearch instance
- [ ] Test with STS AssumeRole against an AWS OpenSearch domain
- [ ] Test with Athenz ZTS credential source
- [ ] Verify credential refresh works (observe logs across token expiry boundary)
- [ ] Test bulk indexing with gzip-compressed payloads
- [ ] Verify tee target SigV4 signing works independently
- [ ] Run `npm run lint` — passes clean