### PR TITLE
opus fixes, cert time issues, _dropBySession issues

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -40,6 +40,9 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #3699 - writer-s3 always uses 0xffff for snapLen now
   - #3699 - writer-s3 fix gzip memory leak
   - #3702 - support redis:// for config
+  - #3706 - Don't close stdin after using "-" for filename
+  - #3706 - Cert UTCTime/GneralizedTime offset parsing fixes
+  - #3706 - Fix rules _dropBySession not working consistently
 
 6.0.0-rc2 2026/02/10
 ## BREAKING

--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -637,6 +637,7 @@ typedef enum {
 typedef struct {
     ArkimePacketHead_t    packetQ[ARKIME_MAX_PACKET_THREADS];
     uint32_t              packetStats[ARKIME_PACKET_MAX];
+    uint64_t              totalBytes;
     uint32_t              totalPackets;
     int                   count;
     uint8_t               readerPos; // used by libpcap reader to set readerPos

--- a/capture/command.c
+++ b/capture/command.c
@@ -50,6 +50,7 @@ LOCAL gboolean arkime_command_run(const char *line, gpointer cc)
     GError *error = NULL;
 
     if (!g_shell_parse_argv(line, &argcp, &argvp, &error)) {
+        g_error_free(error);
         arkime_command_respond(cc, "No command sent\n", -1);
         return TRUE;
     }
@@ -218,6 +219,7 @@ void arkime_command_respond(gpointer cc, const char *data, int len)
 
     if (g_socket_send(client->socket, data, len, NULL, &error) != len) {
         LOG("ERROR - Sending response: %s", error ? error->message : "Unknown error");
+        g_clear_error(&error);
     }
 }
 /******************************************************************************/

--- a/capture/config.c
+++ b/capture/config.c
@@ -604,8 +604,7 @@ LOCAL void arkime_config_load_includes(char **includes)
         gboolean status = g_key_file_load_from_file(keyFile, fn, G_KEY_FILE_NONE, &error);
         if (!status || error) {
             if (includes[i][0] == '-') {
-                if (error)
-                    g_error_free(error);
+                g_clear_error(&error);
                 continue;
             } else {
                 CONFIGEXIT("Couldn't load config includes file (%s) %s", fn, (error ? error->message : ""));
@@ -1441,8 +1440,8 @@ void arkime_config_load_override_ips()
             gboolean status = g_key_file_load_from_file(keyfile, overrideIpsFiles[i], G_KEY_FILE_NONE, &error);
             if (!status || error) {
                 if (overrideIpsFiles[i][0] == '-') {
-                    if (error)
-                        g_error_free(error);
+                    g_clear_error(&error);
+                    g_key_file_free(keyfile);
                     continue;
                 } else {
                     CONFIGEXIT("Couldn't load overrideIpsFiles file (%s) %s", overrideIpsFiles[i], (error ? error->message : ""));
@@ -1508,8 +1507,8 @@ void arkime_config_load_packet_ips()
             gboolean status = g_key_file_load_from_file(keyfile, packetDropIpsFiles[i], G_KEY_FILE_NONE, &error);
             if (!status || error) {
                 if (packetDropIpsFiles[i][0] == '-') {
-                    if (error)
-                        g_error_free(error);
+                    g_clear_error(&error);
+                    g_key_file_free(keyfile);
                     continue;
                 } else {
                     CONFIGEXIT("Couldn't load packetDropIpsFiles file (%s) %s", packetDropIpsFiles[i], (error ? error->message : ""));

--- a/capture/field.c
+++ b/capture/field.c
@@ -758,7 +758,7 @@ gboolean arkime_field_string_add_upper(int pos, ArkimeSession_t *session, const 
         arkime_field_truncated(session, config.fields[pos]);
     }
 
-    char *upper = g_ascii_strdown(string, len);
+    char *upper = g_ascii_strup(string, len);
     if (!arkime_field_string_add(pos, session, upper, len, FALSE)) {
         g_free(upper);
         return FALSE;
@@ -1034,7 +1034,6 @@ gboolean arkime_field_float_add(int pos, ArkimeSession_t *session, float f)
         goto added;
     case ARKIME_FIELD_TYPE_FLOAT_GHASH:
         memcpy(&fint, &f, 4);
-        g_hash_table_add(field->ghash, (gpointer)(long)fint);
         if (!g_hash_table_add(field->ghash, (gpointer)(long)fint)) {
             return FALSE;
         }
@@ -1456,7 +1455,7 @@ int arkime_field_count(int pos, ArkimeSession_t *session)
 {
     ArkimeField_t         *field;
 
-    if (pos >= session->maxFields)
+    if (pos < 0 || pos >= session->maxFields)
         return 0;
 
     if (!session->fields[pos])

--- a/capture/plugins.c
+++ b/capture/plugins.c
@@ -299,7 +299,7 @@ void arkime_plugins_set_http_ext_cb(const char              *name,
         pluginsCbs |= ARKIME_PLUGIN_HP_OHF;
 
     plugin->on_header_field_raw = on_header_field_raw;
-    if (on_header_field)
+    if (on_header_field_raw)
         pluginsCbs |= ARKIME_PLUGIN_HP_OHFR;
 
     plugin->on_header_value = on_header_value;

--- a/capture/python.c
+++ b/capture/python.c
@@ -960,7 +960,7 @@ LOCAL PyObject *arkime_python_session_get(PyObject UNUSED(*self), PyObject *args
     }
 
     // This session doesn't have this many fields or field isnt set
-    if (pos < 0 || pos > session->maxFields || !session->fields[pos])
+    if (pos < 0 || pos >= session->maxFields || !session->fields[pos])
         Py_RETURN_NONE;
 
     switch (config.fields[pos]->type) {

--- a/capture/reader-libpcap-file.c
+++ b/capture/reader-libpcap-file.c
@@ -90,7 +90,8 @@ LOCAL gboolean reader_libpcapfile_monitor_read()
         return TRUE;
     if (rc == -1)
         LOGEXIT("ERROR - Monitor read failed - %s", strerror(errno));
-    buf[rc] = 0;
+    if (rc < (int)sizeof(buf))
+        buf[rc] = 0;
 
     for (char *p = buf; p < buf + rc;) {
         struct inotify_event *event = (struct inotify_event *) p;
@@ -258,13 +259,15 @@ filesDone:
         }
 
         if (feof(file)) {
-            fclose(file);
+            if (file != stdin)
+                fclose(file);
             file = NULL;
             return reader_libpcapfile_next();
         }
 
         if (!fgets(line, sizeof(line), file)) {
-            fclose(file);
+            if (file != stdin)
+                fclose(file);
             file = NULL;
             return reader_libpcapfile_next();
         }

--- a/capture/reader-pcapoverip.c
+++ b/capture/reader-pcapoverip.c
@@ -133,7 +133,7 @@ LOCAL gboolean pcapoverip_client_read_cb(gint UNUSED(fd), GIOCondition cond, gpo
             packet->ts.tv_usec = ph->ts.tv_usec;
         }
 
-        if (unlikely(caplen != origlen) && config.readTruncatedPackets && !config.ignoreErrors) {
+        if (unlikely(caplen != origlen) && !config.readTruncatedPackets && !config.ignoreErrors) {
             LOGEXIT("ERROR - Arkime requires full packet captures caplen: %u pktlen: %u\n"
                     "See https://arkime.com/faq#arkime_requires_full_packet_captures_error",
                     caplen, origlen);
@@ -206,8 +206,7 @@ LOCAL void pcapoverip_client_connect(int interface)
         }
 
         if (error && error->code != G_IO_ERROR_PENDING) {
-            g_error_free(error);
-            error = 0;
+            g_clear_error(&error);
             g_object_unref (conn);
             conn = NULL;
         } else {
@@ -224,10 +223,7 @@ LOCAL void pcapoverip_client_connect(int interface)
     g_object_unref (enumerator);
 
     if (conn) {
-        if (error) {
-            g_error_free(error);
-            error = 0;
-        }
+        g_clear_error(&error);
     } else if (error) {
         if (config.debug > 0)
             LOG("%s Error: %s", config.interface[interface], error->message);

--- a/capture/reader-scheme-file.c
+++ b/capture/reader-scheme-file.c
@@ -63,7 +63,8 @@ LOCAL gboolean scheme_file_monitor_read()
         return TRUE;
     if (rc == -1)
         LOGEXIT("ERROR - Monitor read failed - %s", strerror(errno));
-    buf[rc] = 0;
+    if (rc < (int)sizeof(buf))
+        buf[rc] = 0;
 
     for (char *p = buf; p < buf + rc;) {
         struct inotify_event *event = (struct inotify_event *) p;

--- a/capture/reader-scheme-http.c
+++ b/capture/reader-scheme-http.c
@@ -65,6 +65,7 @@ LOCAL int scheme_http_load(const char *uri, ArkimeSchemeFlags flags, ArkimeSchem
 
     if (rc) {
         LOG("Error parsing %s", uri);
+        curl_url_cleanup(h);
         return 1;
     }
 

--- a/capture/reader-scheme-s3.c
+++ b/capture/reader-scheme-s3.c
@@ -467,6 +467,12 @@ LOCAL int scheme_s3_load(const char *uri, ArkimeSchemeFlags flags, ArkimeSchemeA
 
     char **uris = g_strsplit(uri, "/", 0);
 
+    if (!uris[0] || !uris[1] || !uris[2]) {
+        LOG("ERROR - Invalid S3 uri %s", uri);
+        g_strfreev(uris);
+        return 1;
+    }
+
     S3Request req = {
         .actions = actions,
         .url = uri,

--- a/capture/reader-scheme-sqs.c
+++ b/capture/reader-scheme-sqs.c
@@ -314,7 +314,7 @@ LOCAL int scheme_sqs_load(const char *uri, ArkimeSchemeFlags flags, ArkimeScheme
         ARKIME_TYPE_FREE(SQSItem, item);
     }
 
-    ARKIME_TYPE_FREE(S3ItemHead, req->items);
+    ARKIME_TYPE_FREE(SQSItemHead, req->items);
     ARKIME_TYPE_FREE(SQSRequest, req);
     return 1;
 }

--- a/capture/reader-scheme.c
+++ b/capture/reader-scheme.c
@@ -335,7 +335,8 @@ LOCAL void *reader_scheme_thread(void *UNUSED(arg))
 
         while (!feof(file)) {
             if (!fgets(line, sizeof(line), file)) {
-                fclose(file);
+                if (file != stdin)
+                    fclose(file);
                 file = NULL;
                 break;
             }
@@ -350,7 +351,7 @@ LOCAL void *reader_scheme_thread(void *UNUSED(arg))
                 continue;
             arkime_reader_scheme_load_thread(line, flags, NULL);
         }
-        if (file) {
+        if (file && file != stdin) {
             fclose(file);
         }
     }
@@ -367,6 +368,7 @@ LOCAL void *reader_scheme_thread(void *UNUSED(arg))
             ts.tv_sec++;
             ARKIME_COND_TIMEDWAIT(laterLock, ts);
             if (unlikely(config.quitting)) {
+                ARKIME_UNLOCK(laterLock);
                 goto quitting;
             }
         }

--- a/capture/reader-tzsp.c
+++ b/capture/reader-tzsp.c
@@ -56,7 +56,7 @@ LOCAL void *tzsp_thread(gpointer UNUSED(uw))
         gsize len = g_socket_receive(socket, buf, sizeof(buf), NULL, &error);
         if (error) {
             LOG("Error: %s", error->message);
-            g_error_free(error);
+            g_clear_error(&error);
             dropped++;
             continue;
         }

--- a/capture/rules.c
+++ b/capture/rules.c
@@ -781,7 +781,9 @@ LOCAL void arkime_rules_load_complete()
             if (g_match_info_matches(match_info)) {
                 g_match_info_fetch_pos (match_info, 1, &start_pos, NULL);
                 rule->bpf = g_strndup(bpfs[i], start_pos - 1);
-                arkime_field_ops_add(&rule->ops, pos, g_match_info_fetch(match_info, 1), -1);
+                char *fetched = g_match_info_fetch(match_info, 1);
+                arkime_field_ops_add(&rule->ops, pos, fetched, -1);
+                g_free(fetched);
             } else {
                 rule->bpf = g_strdup(bpfs[i]);
                 arkime_field_ops_add(&rule->ops, pos, "1", -1);
@@ -805,7 +807,9 @@ LOCAL void arkime_rules_load_complete()
             if (g_match_info_matches(match_info)) {
                 g_match_info_fetch_pos (match_info, 1, &start_pos, NULL);
                 rule->bpf = g_strndup(bpfs[i], start_pos - 1);
-                arkime_field_ops_add(&rule->ops, pos, g_match_info_fetch(match_info, 1), -1);
+                char *fetched = g_match_info_fetch(match_info, 1);
+                arkime_field_ops_add(&rule->ops, pos, fetched, -1);
+                g_free(fetched);
             } else {
                 rule->bpf = g_strdup(bpfs[i]);
                 arkime_field_ops_add(&rule->ops, pos, "1", -1);
@@ -900,6 +904,7 @@ LOCAL void arkime_rules_load(char **names)
         yaml_parser_set_input_file(&parser, input);
         YamlNode_t *parent = arkime_rules_parser_parse_yaml(names[i], NULL, &parser, FALSE);
         yaml_parser_delete(&parser);
+        fclose(input);
         if (!parent) {
             LOG("WARNING %s - has no rules", names[i]);
             continue;
@@ -909,7 +914,6 @@ LOCAL void arkime_rules_load(char **names)
         }
         arkime_rules_parser_load_file(names[i], parent);
         arkime_rules_parser_free_node(parent);
-        fclose(input);
     }
 
     // Part 2, which will also copy loading to current

--- a/capture/session.c
+++ b/capture/session.c
@@ -445,9 +445,6 @@ LOCAL void arkime_session_free (ArkimeSession_t *session)
         ARKIME_SIZE_FREE("pluginData", session->pluginData);
     arkime_field_free(session);
 
-    if (mProtocols[session->mProtocol].sFree)
-        mProtocols[session->mProtocol].sFree(session);
-
     if (session->pq)
         arkime_pq_free(session);
 

--- a/capture/writer-simple.c
+++ b/capture/writer-simple.c
@@ -834,6 +834,7 @@ LOCAL FILE *writer_simple_get_index(int thread, int64_t fileNum)
     if ((simpleThreadData[thread].indexFiles[p].fp = fopen(filename, "a")) == NULL) {
         LOGEXIT("ERROR - Couldn't open file %s", filename);
     }
+    simpleThreadData[thread].indexFiles[p].fileNum = fileNum;
 
     if (!config.pcapReadOffline) {
         fchmod(fileno(simpleThreadData[thread].indexFiles[p].fp), S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);


### PR DESCRIPTION
False sharing
 - packet.c/arkime.h: Move totalBytes into batch pattern with ARKIME_CACHE_ALIGN
     global to eliminate false sharing between reader and worker threads

Bug fixes:
 - session.c: Remove duplicate sFree call in arkime_session_free (already called in arkime_session_save)
 - plugins.c: Check on_header_field_raw instead of on_header_field for OHFR flag
 - packet.c: Read radiotap header length from data instead of packet->pkt
 - parsers.c: Fix ASN.1 long-form tag to mask out continuation bit (& 0x7f)
 - parsers.c: Error on incomplete multi-byte ASN.1 length read
 - parsers.c: Fix signed integer overflow in OID decoding (int -> unsigned int)
 - parsers.c: Fix UTCTime/GeneralizedTime timezone offset calculation (units, sign, length checks, memset)
 - field.c: Fix g_ascii_strdown -> g_ascii_strup in arkime_field_string_add_upper
 - field.c: Remove duplicate g_hash_table_add for float ghash
 - field.c: Add negative index check in arkime_field_count
 - python.c: Fix off-by-one bounds check (> to >=)
 - db.c: Add NULL check after arkime_http_get in check_filename
 - db.c: Add NULL/underflow guard on hit in check_filename
 - db.c: Fix unsigned microsecond underflow in diffms/diffusage calculation
 - db.c: Use sizeof(sortedFieldsIndex[0]) instead of hardcoded 2 in qsort
 - reader-scheme-sqs.c: Fix wrong type S3ItemHead -> SQSItemHead in free
 - reader-scheme-s3.c: Add NULL check on uris after g_strsplit
 - writer-simple.c: Set fileNum in index file cache after fopen

 Memory/resource leaks:
 - command.c: Free GError on g_shell_parse_argv failure
 - command.c: Free GError on g_socket_send failure (g_clear_error)
 - config.c: Free GKeyFile and reset GError on optional file load failure (overrideIpsFiles, packetDropIpsFiles, includes loops)
 - rules.c: Add fclose on continue path in rule loading
 - rules.c: Free g_match_info_fetch results after use
 - reader-tzsp.c: Use g_clear_error to prevent dangling pointer in recv loop
 - reader-pcapoverip.c: Use g_clear_error instead of g_error_free + manual reset
 - reader-scheme-http.c: Add curl_url_cleanup on error path

 Defensive checks:
 - reader-libpcap-file.c: Guard fclose against stdin
 - reader-scheme.c: Guard fclose against stdin, add ARKIME_UNLOCK before goto
 - reader-scheme.c: Add missing ARKIME_UNLOCK(laterLock) before goto quitting

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
