### PR TITLE
fix startup mem leaks, scheme later list was broken

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -43,6 +43,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #3706 - Don't close stdin after using "-" for filename
   - #3706 - Cert UTCTime/GneralizedTime offset parsing fixes
   - #3706 - Fix rules _dropBySession not working consistently
+  - #3709 - Fix scheme mode only queueing up to two files for later
 
 6.0.0-rc2 2026/02/10
 ## BREAKING

--- a/capture/config.c
+++ b/capture/config.c
@@ -934,6 +934,10 @@ LOCAL char *arkime_config_redis_get(const char *url)
     }
 
     int dataLen = atoi(line + 1);
+    if (dataLen < 0) {
+        close(fd);
+        CONFIGEXIT("Redis key not found or invalid response length: %d", dataLen);
+    }
     char *data = malloc(dataLen + 1);
 
     // Read exact data bytes
@@ -1868,7 +1872,7 @@ LOCAL void arkime_config_cmd_set(int argc, char **argv, gpointer cc)
             BSB_EXPORT_sprintf(bsb, "%s=%d\n", acv->name, *(int *)acv->var);
             break;
         case 8:
-            *(int64_t *)acv->var = atoi(argv[2]);
+            *(int64_t *)acv->var = strtoll(argv[2], NULL, 10);
             BSB_EXPORT_sprintf(bsb, "%s=%" PRId64 "\n", acv->name, *(int64_t *)acv->var);
             break;
         case ARKIME_CONFIG_CMD_VAR_STR_PTR:

--- a/capture/db.c
+++ b/capture/db.c
@@ -1572,8 +1572,8 @@ LOCAL uint64_t arkime_db_memory_size()
 
     buf[len] = 0;
 
-    uint64_t size;
-    sscanf(buf, "%lu", &size);
+    uint64_t size = 0;
+    sscanf(buf, "%" SCNu64, &size);
 
     if (size == 0) {
         LOG("/proc/self/statm size 0 - %d '%.*s'", len, len, buf);

--- a/capture/parsers/socks.c
+++ b/capture/parsers/socks.c
@@ -131,7 +131,7 @@ LOCAL int socks5_parser(ArkimeSession_t *session, void *uw, const uint8_t *data,
         arkime_field_string_add(userField, session, (char *)data + 2, data[1], TRUE);
         arkime_session_add_tag(session, "socks:password");
         socks->state5[which] = SOCKS5_STATE_CONN_REQUEST;
-        return data[1] + 1 + data[data[1] + 2];
+        return 2 + data[1] + 1 + data[data[1] + 2];
     case SOCKS5_STATE_USER_REPLY:
         socks->state5[which] = SOCKS5_STATE_CONN_REPLY;
         return 2;

--- a/capture/reader-scheme-file.c
+++ b/capture/reader-scheme-file.c
@@ -247,7 +247,7 @@ LOCAL int scheme_file_load(const char *uri, ArkimeSchemeFlags flags, ArkimeSchem
         if (bytesRead > 0) {
             if (arkime_reader_scheme_process(uri, buffer, bytesRead, NULL, actions)) {
                 close(fd);
-                if (config.ignoreErrors && flags & ARKIME_SCHEME_FLAG_DELETE) { // ALW - Maybe this should always delete?
+                if (config.ignoreErrors && (flags & ARKIME_SCHEME_FLAG_DELETE)) { // ALW - Maybe this should always delete?
                     if (config.debug)
                         LOG("Deleting %s", uri);
                     int rc = unlink(uri);

--- a/capture/reader-scheme.c
+++ b/capture/reader-scheme.c
@@ -192,6 +192,7 @@ void arkime_reader_scheme_load(const char *uri, ArkimeSchemeFlags flags, ArkimeS
     ARKIME_LOCK(laterLock);
     if (laterHead) {
         laterTail->next = item;
+        laterTail = item;
     } else {
         laterHead = laterTail = item;
     }

--- a/capture/readers.c
+++ b/capture/readers.c
@@ -89,6 +89,7 @@ void arkime_readers_start()
 
         char **opsstr = g_strsplit(interfaceOps[i], ",", 0);
         const char *error = arkime_field_ops_parse(&readerFieldOps[i], ARKIME_FIELD_OPS_FLAGS_COPY, opsstr);
+        g_strfreev(opsstr);
 
         if (error) {
             CONFIGEXIT("%s", error);


### PR DESCRIPTION
   - socks.c: Fix off-by-two in SOCKS5 username/password auth consumption
   - reader-scheme-file.c: Fix operator precedence in flags check
   - reader-scheme.c: Fix linked list append not advancing laterTail
   - config.c: Handle negative Redis reply length, use strtoll for int64_t
   - db.c: Initialize size variable and fix sscanf format specifier
   - readers.c: Fix memory leak from g_strsplit result

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
