### PR TITLE
Fix multiple sanitizer and overflow issues

### DIFF
--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -1174,7 +1174,7 @@ int arkime_parsers_asn_get_sequence(ArkimeASNSeq_t *seqs, int maxSeq, const uint
 const char *arkime_parsers_asn_sequence_to_string(ArkimeASNSeq_t *seq, int *len);
 int arkime_parsers_asn_sequence_to_int(ArkimeASNSeq_t *seq);
 void arkime_parsers_asn_decode_oid(char *buf, int bufsz, const uint8_t *oid, int len);
-uint64_t arkime_parsers_asn_parse_time(ArkimeSession_t *session, int tag, uint8_t *value, int len);
+uint64_t arkime_parsers_asn_parse_time(ArkimeSession_t *session, uint32_t tag, uint8_t *value, uint32_t len);
 void arkime_parsers_classify_tcp(ArkimeSession_t *session, const uint8_t *data, int remaining, int which);
 void arkime_parsers_classify_udp(ArkimeSession_t *session, const uint8_t *data, int remaining, int which);
 void arkime_parsers_classify_sctp(ArkimeSession_t *session, uint32_t protocol, const uint8_t *data, int remaining, int which);

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -297,6 +297,7 @@ LOCAL void arkime_packet_process(ArkimePacket_t *packet, int thread)
         arkime_packet_free(packet);
         return;
     }
+    session->lastPacket = packet->ts;
 
     if (isNew) {
         arkime_parsers_initial_tag(session);
@@ -320,7 +321,6 @@ LOCAL void arkime_packet_process(ArkimePacket_t *packet, int thread)
 
     session->packets[packet->direction]++;
     session->bytes[packet->direction] += packet->pktlen;
-    session->lastPacket = packet->ts;
 
     uint32_t packets = session->packets[0] + session->packets[1];
 

--- a/capture/reader-tpacketv3.c
+++ b/capture/reader-tpacketv3.c
@@ -155,7 +155,7 @@ LOCAL void *reader_tpacketv3_thread(gpointer infov)
                     memmove(packet->pkt, packet->pkt + 4, 12);
 
                     // Build VLAN header (network byte order)
-                    vlanHeader = htonl((0x8100 << 16) | (th->hv1.tp_vlan_tci & 0xfff));
+                    vlanHeader = htonl((0x8100u << 16) | (th->hv1.tp_vlan_tci & 0xfff));
                     memcpy(packet->pkt + 12, &vlanHeader, 4);
                 }
             }

--- a/capture/session.c
+++ b/capture/session.c
@@ -1246,10 +1246,10 @@ int arkime_session_idle_seconds(int mProtocol)
 
     for (int t = 0; t < config.packetThreads; t++) {
         ArkimeSession_t *session = DLL_PEEK_HEAD(q_, &sessionThreadData[t].sessionsQ[mProtocol]);
-        if (!session)
+        if (!session || session->lastPacket.tv_sec == 0)
             continue;
 
-        tmp = arkimeThreadData[t].lastPacketSecs - (session->lastPacket.tv_sec + mProtocols[mProtocol].sessionTimeout);
+        tmp = (int)(arkimeThreadData[t].lastPacketSecs - session->lastPacket.tv_sec) - mProtocols[mProtocol].sessionTimeout;
         if (tmp > idle)
             idle = tmp;
     }


### PR DESCRIPTION
 - session.c: Fix arkime_session_idle_seconds overflow when session at head of queue has lastPacket.tv_sec=0 (race with session creation). Skip uninitialized sessions and reorder arithmetic to avoid overflow.
 - packet.c: Move lastPacket assignment earlier to reduce the window where a session exists in the queue with lastPacket unset.
 - reader-tpacketv3.c: Fix UB from signed integer overflow in VLAN header construction (0x8100 << 16 overflows int).
 - parsers.c: Fix ASN.1 integer overflows - widen OID decode value to uint64_t with overflow guard, add overflow check for extended tags, change asn_parse_time params to uint32_t to match callers.
 - arkime.h: Update arkime_parsers_asn_parse_time signature to match.
## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
