### PR TITLE
more typos, use --flush with s3

### DIFF
--- a/tests/api-s3.t
+++ b/tests/api-s3.t
@@ -13,7 +13,7 @@ esPost("/tests2_sessions*/_delete_by_query?conflicts=proceed&refresh", '{ "query
 sub run {
 my ($tag, $compression, $extension, $gap) = @_;
 
-    my $cmd = "../capture/capture -o disablePython=true -o s3GapPacketPos=$gap -c config.test.ini -n s3-test --copy -R pcap --tag $tag -o s3Compression=$compression > /tmp/arkime.capture.$tag.log 2>&1";
+    my $cmd = "../capture/capture -o disablePython=true -o s3GapPacketPos=$gap -c config.test.ini -n s3-test --copy -R pcap --tag $tag -o s3Compression=$compression --flush > /tmp/arkime.capture.$tag.log 2>&1";
     system($cmd);
 
     # Test 1

--- a/viewer/apiConnections.js
+++ b/viewer/apiConnections.js
@@ -280,10 +280,10 @@ class ConnectionAPIs {
       if (ArkimeUtil.isPP(vsrc) || ArkimeUtil.isPP(vdst)) { return; }
       // ES 6 is returning formatted timestamps instead of ms like pre 6 did
       // https://github.com/elastic/elasticsearch/issues/27740
-      if (vsrc.length === 24 && vsrc[23] === 'Z' && vsrc.match(/^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d.\d\d\dZ$/)) {
+      if (vsrc.length === 24 && vsrc[23] === 'Z' && vsrc.match(/^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$/)) {
         vsrc = new Date(vsrc).getTime();
       }
-      if (vdst.length === 24 && vdst[23] === 'Z' && vdst.match(/^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d.\d\d\dZ$/)) {
+      if (vdst.length === 24 && vdst[23] === 'Z' && vdst.match(/^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$/)) {
         vdst = new Date(vdst).getTime();
       }
 

--- a/viewer/apiMisc.js
+++ b/viewer/apiMisc.js
@@ -137,7 +137,7 @@ class MiscAPIs {
           fields.locked = 0;
         }
         fields.cratio = fields.packetsSize ? Math.round(100 - (100 * fields.filesize / fields.packetsSize)) : 0;
-        fields.id = fields._id;
+        fields.id = file._id;
         results.results.push(fields);
       }
 
@@ -147,7 +147,7 @@ class MiscAPIs {
         data: results.results
       };
 
-      res.logCounts(r.data.length, r.recordsFiltered, r.total);
+      res.logCounts(r.data.length, r.recordsFiltered, r.recordsTotal);
       res.send(r);
     }).catch((err) => {
       console.log(`ERROR - ${req.method} /api/files`, util.inspect(err, false, 50));

--- a/viewer/apiViews.js
+++ b/viewer/apiViews.js
@@ -155,7 +155,7 @@ class ViewAPIs {
       const { body: { _source: view } } = await Db.getView(id);
 
       view.id = id;
-      view.users = view.users.join(',');
+      view.users = view.users?.join(',') ?? '';
 
       return res.json({
         success: true,
@@ -229,7 +229,7 @@ class ViewAPIs {
       try {
         await Db.setView(req.params.id, view);
         const { body: { _source: newView } } = await Db.getView(req.params.id);
-        newView.users = newView.users.join(',');
+        newView.users = newView.users?.join(',') ?? '';
         newView.id = dbView._id;
 
         return res.json({

--- a/viewer/buildQuery.js
+++ b/viewer/buildQuery.js
@@ -608,7 +608,7 @@ class BuildQuery {
       startTimeSec = (Math.floor(Date.now() / 1000) - 60 * 60 * parseFloat(queryDate));
       stopTimeSec = Date.now() / 1000;
 
-      interval = toInterval(60 * parseFloat(queryDate));
+      interval = toInterval(60 * 60 * parseFloat(queryDate));
     }
 
     switch (reqQuery.interval) {

--- a/viewer/esProxy.js
+++ b/viewer/esProxy.js
@@ -35,6 +35,7 @@ let authHeader;
 ArkimeConfig.loaded(() => {
   elasticsearch = Config.get('elasticsearch');
   sensors = Config.configMap('esproxy-sensors');
+  prefix = ArkimeUtil.formatPrefix(Config.get('prefix', 'arkime_'));
   oldprefix = prefix === 'arkime_' ? '' : prefix;
   console.log('sensors', sensors);
 
@@ -44,7 +45,6 @@ ArkimeConfig.loaded(() => {
       sensors[sensor].ip = sensors[sensor].ip.split(',');
     }
   }
-  prefix = ArkimeUtil.formatPrefix(Config.get('prefix', 'arkime_'));
   console.log(`PREFIX: ${prefix} OLDPREFIX: ${oldprefix}`);
 
   const esClientKey = Config.get('esClientKey');

--- a/viewer/pcap.js
+++ b/viewer/pcap.js
@@ -836,11 +836,11 @@ class Pcap {
 
   // --------------------------------------------------------------------------
   ppp (buffer, obj, pos) {
-    obj.pppoe = {
+    obj.ppp = {
       type: buffer.readUInt16BE(2)
     };
 
-    switch (obj.pppoe.type) {
+    switch (obj.ppp.type) {
     case 0x21:
       this.ip4(buffer.slice(4), obj, pos + 4);
       return;

--- a/viewer/viewerUtils.js
+++ b/viewer/viewerUtils.js
@@ -209,7 +209,7 @@ class ViewerUtils {
       return {
         fieldsMap: JSON.stringify(Config.getFieldsMap()),
         fieldsArr: Config.getFields().sort((a, b) => {
-          return a.exp - b.exp;
+          return a.exp.localeCompare(b.exp);
         })
       };
     } catch (err) {

--- a/viewer/views/mixins.pug
+++ b/viewer/views/mixins.pug
@@ -241,4 +241,4 @@ mixin ipArrayListDNS(container, field, title, expr, max)
         +ipPrint(container, container[field + "Ip"][i], undefined, (container[field + "GEO"]?container[field + "GEO"][i]:null), (container[field+"ASN"]?container[field + "ASN"][i]:null), (container[field + "RIR"]?container[field + "RIR"][i]:null), expr, false)
       if (container[field + "Ip"].length > max)
         |</span>
-        a.cursor-pointer.show-more-items &hellip
+        a.cursor-pointer.show-more-items &hellip;

--- a/viewer/views/sessionDetail.pug
+++ b/viewer/views/sessionDetail.pug
@@ -69,7 +69,7 @@ dl
         +clickableLabelBody('bytes.dst', 'Dst Bytes')
         +clickableFieldActions('bytes.dst', false)
         b-dropdown-divider
-        +clickableLabelBody('databytes.dst', 'Dst DataBytes')
+        +clickableLabelBody('databytes.dst', 'Dst Databytes')
         +clickableFieldActions('databytes.dst', false)
     dd
       span.no-wrap
@@ -104,7 +104,7 @@ dl
         +clickableLabelBody('mac.dst', 'Dst Mac')
         +clickableFieldActions('mac.dst', false)
         b-dropdown-divider
-        +clickableLabelBody('out.dst', 'Dst OUI')
+        +clickableLabelBody('oui.dst', 'Dst OUI')
         +clickableFieldActions('oui.dst', false)
     dd
       strong.ms-1 Mac
@@ -174,7 +174,7 @@ dl
       b-dropdown.clickable-label(text="Dst Outer Layer", size="sm", variant="default")
         if (session.dstOuterMac)
           +clickableLabelBody('outermac.dst', 'Outer Dst Mac')
-          +clickableFieldActions('outeroui.dst', false)
+          +clickableFieldActions('outermac.dst', false)
           b-dropdown-divider
         if (session.dstOuterIp)
           +clickableLabelBody('outerip.dst', 'Outer Dst IP')

--- a/viewer/vueapp/src/components/hunt/HuntData.vue
+++ b/viewer/vueapp/src/components/hunt/HuntData.vue
@@ -352,7 +352,7 @@ export default {
       this.localJob.roles = roles;
       this.$emit('updateHunt', this.localJob);
     },
-    updateJobDescription: function (roles) {
+    updateJobDescription: function () {
       this.localJob.description = this.newDescription;
       this.$emit('updateHunt', this.localJob);
       this.editDescription = false;

--- a/viewer/vueapp/src/components/hunt/HuntService.js
+++ b/viewer/vueapp/src/components/hunt/HuntService.js
@@ -60,7 +60,7 @@ export default {
   /**
    * Plays a hunt
    * @param {string} id The id of the hunt item to play
-   * @param {string} cluster The cluster name string of the cluster to plays the hunt from
+   * @param {string} cluster The cluster name string of the cluster to play the hunt from
    * @returns {Promise} Promise A promise object that signals the completion
    *                            or rejection of the request.
    */
@@ -73,7 +73,7 @@ export default {
    * @param {string} id The id of the hunt
    * @param {object} data The updated description & roles:
                           { description: 'text', roles: ['one', 'two'] }
-   * @param {string} cluster The cluster name string of the cluster to updates the hunt from
+   * @param {string} cluster The cluster name string of the cluster to update the hunt from
    * @returns {Promise} Promise A promise object that signals the completion
    *                            or rejection of the request.
    */
@@ -85,7 +85,7 @@ export default {
    * Removes a user from a hunt
    * @param {string} id The id of the hunt
    * @param {string} userid The id of the user to remove
-   * @param {string} cluster The cluster name string of the cluster to removes the hunt from
+   * @param {string} cluster The cluster name string of the cluster to remove the hunt from
    * @returns {Promise} Promise A promise object that signals the completion
    *                            or rejection of the request.
    */
@@ -112,7 +112,7 @@ export default {
    * @returns {Promise} Promise A promise object that signals the completion
    *                            or rejection of the request.
    */
-  async cleanup (id, users, cluster) {
+  async cleanup (id, cluster) {
     return await fetchWrapper({ url: `api/hunt/${id}/removefromsessions`, method: 'PUT', params: { cluster } });
   },
 

--- a/viewer/vueapp/src/components/search/Search.vue
+++ b/viewer/vueapp/src/components/search/Search.vue
@@ -830,7 +830,7 @@ export default {
 .multies-menu-dropdown .dropdown-menu {
   /* max-height: 300px; */
   /* overflow: auto; */
-  width: 300px
+  width: 300px;
 }
 
 .multies-menu-dropdown .dropdown-header {

--- a/viewer/vueapp/src/components/sessions/SessionsService.js
+++ b/viewer/vueapp/src/components/sessions/SessionsService.js
@@ -86,8 +86,7 @@ export default {
    * Gets a list of sessions from the server
    * @param {object} query        Parameters to query the server
    * @param {boolean} calculateFacets Whether to calculate facets (true) or not (false)
-   * @returns {AbortController} The AbortController used to cancel the request.
-   * @returns {Promise<Object>} The response data parsed as JSON.
+   * @returns {Object} Object with controller (AbortController) and fetcher (Promise).
    */
   get: function (query, calculateFacets = true) {
     const params = this.buildSessionParams(query, {

--- a/viewer/vueapp/src/components/spiview/SpiviewService.js
+++ b/viewer/vueapp/src/components/spiview/SpiviewService.js
@@ -5,7 +5,7 @@ export default {
 
   /* service methods ------------------------------------------------------- */
   /**
-   * Gets spigraph data from the server
+   * Gets spiview data from the server
    * @param {object} params        Parameters to query the server
    * @param {object} cancelToken  Token to cancel the request
    * @returns {Promise} Promise   A promise object that signals the completion

--- a/viewer/vueapp/src/components/stats/EsAdmin.vue
+++ b/viewer/vueapp/src/components/stats/EsAdmin.vue
@@ -227,7 +227,7 @@ export default {
       await this.save(setting);
     },
     async cancel (setting) {
-      const selection = Utils.checkClusterSelection(this.query.cluster, this.$store.state.esCluster.availableCluster.active);
+      const selection = Utils.checkClusterSelection(this.query.cluster, this.$store.state.esCluster.availableCluster.active, this);
       if (!selection.valid) {
         setting.error = selection.error;
         return;

--- a/viewer/vueapp/src/components/utils/Navbar.vue
+++ b/viewer/vueapp/src/components/utils/Navbar.vue
@@ -108,7 +108,7 @@ export default {
   },
   computed: {
     userLogo: function () {
-      if (this.user && this.user.settings.logo && this.user.settings.logo) {
+      if (this.user && this.user.settings.logo) {
         return this.user.settings.logo;
       }
       return 'assets/Arkime_Logo_Mark_White.png';


### PR DESCRIPTION
   - apiConnections.js: Escape dot in ISO timestamp regex patterns
   - apiMisc.js: Use file._id instead of fields._id for file list id
   - apiMisc.js: Use r.recordsTotal instead of nonexistent r.total in logCounts
   - apiViews.js: Guard users.join() with optional chaining in create/update
   - buildQuery.js: Fix interval calculation (queryDate is hours, not minutes)
   - esProxy.js: Move prefix assignment before oldprefix depends on it
   - pcap.js: Use obj.ppp instead of obj.pppoe in ppp() function
   - viewerUtils.js: Use localeCompare instead of subtraction for string sort
   - sessionDetail.pug: Fix field names (oui.dst, outermac.dst, Databytes)
   - mixins.pug: Add missing semicolon to &hellip HTML entity
   - Navbar.vue: Remove duplicate conditional in userLogo check
   - Search.vue: Add missing CSS semicolon
   - EsAdmin.vue: Pass missing 'this' arg to checkClusterSelection
   - HuntService.js: Remove unused param, fix JSDoc verb tense
   - HuntData.vue: Remove unused 'roles' parameter from updateJobDescription
   - SpiviewService.js: Fix JSDoc comment (spigraph -> spiview)
   - SessionsService.js: Merge duplicate @returns JSDoc into single tag

   Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
