### PR TITLE
Fix typos/copypasta in common, parliament, and wiseService

### DIFF
--- a/common/notifier.js
+++ b/common/notifier.js
@@ -301,7 +301,7 @@ class Notifier {
    * Creates a new notifier (admin only).
    * @name /notifier
    * @param {string} name - The name of the new notifier.
-   * @param {type} type - The type of notifier.
+   * @param {string} type - The type of notifier.
    * @param {array} fields - The fields to configure the notifier.
    * @returns {boolean} success - Whether the create notifier operation was successful.
    * @returns {string} text - The success/error message to (optionally) display to the user.
@@ -344,8 +344,8 @@ class Notifier {
    *
    * Updates an existing notifier (admin only).
    * @name /notifier/:id
-   * @param {string} id - The new id of the notifier.
-   * @param {type} type - The new type of notifier.
+   * @param {string} id - The id of the notifier to update.
+   * @param {string} type - The new type of notifier.
    * @param {array} fields - The new field values to configure the notifier.
    * @returns {boolean} success - Whether the update notifier operation was successful.
    * @returns {string} text - The success/error message to (optionally) display to the user.

--- a/parliament/parliament.js
+++ b/parliament/parliament.js
@@ -1102,7 +1102,7 @@ function cleanUpIssues () {
   let len = issues.length;
   while (len--) {
     const issue = issues[len];
-    const timeSinceLastNoticed = Date.now() - issue.lastNoticed || issue.firstNoticed;
+    const timeSinceLastNoticed = Date.now() - (issue.lastNoticed || issue.firstNoticed);
     const removeIssuesAfter = Parliament.getGeneralSetting('removeIssuesAfter') * 1000 * 60;
     const removeAcknowledgedAfter = Parliament.getGeneralSetting('removeAcknowledgedAfter') * 1000 * 60;
 
@@ -1317,7 +1317,7 @@ async function getStats (cluster) {
 
         // look for no packets issue
         if (stat.deltaPacketsPerSec <= Parliament.getGeneralSetting('noPackets')) {
-          const id = cluster.title + stat.nodeName;
+          const id = cluster.title + ':' + stat.nodeName;
 
           // only set the noPackets issue if there is a record of this cluster/node
           // having noPackets and that issue has persisted for the set length of time
@@ -1484,7 +1484,7 @@ function removeIssue (issueType, clusterId, nodeId) {
       issues.splice(len, 1);
       if (issue.type === 'noPackets') {
         // also remove it from the no packets record
-        noPacketsMap.delete(issue.cluster + nodeId);
+        noPacketsMap.delete(issue.cluster + ':' + nodeId);
       }
     }
   }
@@ -1717,7 +1717,7 @@ app.get('/parliament/api/issues', (req, res, next) => {
         if (b[sortBy] !== undefined) { bVal = b[sortBy]; }
         if (a[sortBy] !== undefined) { aVal = a[sortBy]; }
 
-        return order === 'asc' ? bVal - aVal : aVal - bVal;
+        return order === 'asc' ? aVal - bVal : bVal - aVal;
       } else { // assume it's a string
         let aVal = '';
         let bVal = '';
@@ -1725,7 +1725,7 @@ app.get('/parliament/api/issues', (req, res, next) => {
         if (b[sortBy] !== undefined) { bVal = b[sortBy]; }
         if (a[sortBy] !== undefined) { aVal = a[sortBy]; }
 
-        return order === 'asc' ? bVal.localeCompare(aVal) : aVal.localeCompare(bVal);
+        return order === 'asc' ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal);
       }
     });
   }

--- a/parliament/vueapp/src/components/Parliament.vue
+++ b/parliament/vueapp/src/components/Parliament.vue
@@ -297,7 +297,7 @@ SPDX-License-Identifier: Apache-2.0
         <div v-if="isAdmin && groupAddingCluster === group.id && editMode">
           <div class="col-md-12">
             <hr>
-            <form @keyup.enter="createCluster">
+            <form @keyup.enter="createNewCluster(group)">
               <div class="form-group row mb-1">
                 <label
                   for="newClusterTitle"
@@ -1200,7 +1200,7 @@ export default {
       cluster.newLocalUrl = cluster.localUrl;
       cluster.newType = cluster.type;
     },
-    cancelEditCluster (cluster) {
+    cancelEditCluster () {
       this.focusClusterInput = false;
       this.clusterBeingEdited = undefined;
     },

--- a/wiseService/source.elasticsearch.js
+++ b/wiseService/source.elasticsearch.js
@@ -129,7 +129,7 @@ exports.initSource = function (api) {
     link: 'https://arkime.com/wise#elasticsearch',
     fields: [
       { name: 'type', required: true, help: 'The wise type of this source' },
-      { name: 'tag', required: true, help: 'The tags to set on matches' },
+      { name: 'tags', required: true, help: 'The tags to set on matches' },
       { name: 'esQueryField', required: true, help: 'The elasticsearch field in each document that is being queried' },
       { name: 'elasticsearch', required: true, help: 'Elasticsearch base url' },
       { name: 'esIndex', required: true, help: 'The index pattern to look at' },

--- a/wiseService/source.wiseproxy.js
+++ b/wiseService/source.wiseproxy.js
@@ -104,6 +104,7 @@ class WiseProxySource extends WISESource {
           for (let n = 0; n < num; n++) {
             const field = body[offset]; offset += 1;
             const len = body[offset]; offset += 1;
+            // len includes null terminator, exclude it from the string
             const str = body.toString('ascii', offset, offset + len - 1); offset += len;
             args.push(this.mapping[field], str);
           }

--- a/wiseService/vueapp/src/components/Config.vue
+++ b/wiseService/vueapp/src/components/Config.vue
@@ -187,7 +187,7 @@ SPDX-License-Identifier: Apache-2.0
 
         <div v-if="configViewSelected === 'edit'">
           <p class="wrapit">
-            {{ $t('wise.config.format') }} {{ currFormat ?? unknown }}
+            {{ $t('wise.config.format') }} {{ currFormat ?? 'unknown' }}
             <template v-if="currFormat === 'tagger'">
               -
               <a

--- a/wiseService/wiseService.js
+++ b/wiseService/wiseService.js
@@ -95,16 +95,16 @@ internals.type2Name = ['ip', 'domain', 'md5', 'email', 'url', 'tuple', 'ja3', 's
 // ----------------------------------------------------------------------------
 function processArgs (argv) {
   for (let i = 0, ilen = argv.length; i < ilen; i++) {
-    if (process.argv[i] === '-o') {
+    if (argv[i] === '-o') {
       i++;
-      const equal = process.argv[i].indexOf('=');
+      const equal = argv[i].indexOf('=');
       if (equal === -1) {
-        console.log('Missing equal sign in', process.argv[i]);
+        console.log('Missing equal sign in', argv[i]);
         process.exit(1);
       }
 
-      const key = process.argv[i].slice(0, equal);
-      const value = process.argv[i].slice(equal + 1);
+      const key = argv[i].slice(0, equal);
+      const value = argv[i].slice(equal + 1);
       if (key.includes('.')) {
         ArkimeConfig.setOverride(key, value);
       } else {
@@ -559,8 +559,8 @@ class WISESourceAPI {
 
   /**
    * Add a value action set
-   * @params {string} actionName - The globally unique name of this action, not shown to user
-   * @params {WISESourceAPI~ValueAction} action - The action
+   * @param {string} actionName - The globally unique name of this action, not shown to user
+   * @param {WISESourceAPI~ValueAction} action - The action
    */
   addValueAction (actionName, action) {
     internals.valueActions.set(actionName, action);
@@ -568,8 +568,8 @@ class WISESourceAPI {
 
   /**
    * Add a field action set
-   * @params {string} actionName - The globally unique name of this action, not shown to user
-   * @params {WISESourceAPI~ValueAction} action - The action
+   * @param {string} actionName - The globally unique name of this action, not shown to user
+   * @param {WISESourceAPI~ValueAction} action - The action
    */
   addFieldAction (actionName, action) {
     internals.fieldActions.set(actionName, action);


### PR DESCRIPTION
   common/notifier.js:
   - Fix JSDoc {type}→{string} for notifier type params
   - Fix JSDoc "new id"→"id of the notifier to update"

   parliament/parliament.js:
   - Fix operator precedence in timeSinceLastNoticed calculation
   - Fix swapped asc/desc sort order for issues (both number and string)
   - Add separator to noPacketsMap key to prevent collisions

   parliament/Parliament.vue:
   - Fix createCluster→createNewCluster(group) in enter handler
   - Remove unused cluster param from cancelEditCluster

   wiseService/wiseService.js:
   - Use argv param consistently instead of mixing with process.argv
   - Fix @params→@param in JSDoc (4 instances)

   wiseService/source.elasticsearch.js:
   - Fix config field name tag→tags to match tagsSetting() reader

   wiseService/Config.vue:
   - Fix undefined variable unknown→'unknown' string literal

   wiseService/source.wiseproxy.js:
   - Add comment explaining null terminator in buffer parse

   Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
