### PR TITLE
Fix multiple bugs and typos across cont3xt

### DIFF
--- a/cont3xt/audit.js
+++ b/cont3xt/audit.js
@@ -82,7 +82,7 @@ class Audit {
         } else {
           resolve(results);
         }
-      }).catch((err) => reject('ES Error', err));
+      }).catch((err) => reject('ES Error: ' + err));
     });
   }
 

--- a/cont3xt/integration.js
+++ b/cont3xt/integration.js
@@ -868,7 +868,7 @@ class Integration {
    */
   static async apiPutSettings (req, res, next) {
     if (typeof req.body.settings !== 'object') {
-      res.send({ success: false, text: 'Missing settings' });
+      return res.send({ success: false, text: 'Missing settings' });
     }
     req.user.setCont3xtKeys(req.body.settings);
     res.send({ success: true, text: 'Saved' });
@@ -942,7 +942,7 @@ class Integration {
   }
 
   userAgent () {
-    this.getConfig('userAgent', ArkimeConfig.get('userAgent', 'cont3xt'));
+    return this.getConfig('userAgent', ArkimeConfig.get('userAgent', 'cont3xt'));
   }
 
   normalizeCard () {
@@ -1008,7 +1008,7 @@ function updateTime (stats, istats, diff, prefix) {
   const lookup = Math.min(stats[prefix + 'Lookup'], 100);
   stats[prefix + 'RecentAvgMS'] = (stats[prefix + 'RecentAvgMS'] * (lookup - 1) + diff) / lookup;
 
-  const ilookup = Math.min(stats[prefix + 'Lookup'], 100);
+  const ilookup = Math.min(istats[prefix + 'Lookup'], 100);
   istats[prefix + 'RecentAvgMS'] = (istats[prefix + 'RecentAvgMS'] * (ilookup - 1) + diff) / ilookup;
 }
 

--- a/cont3xt/integrations/alienvaultotx/index.js
+++ b/cont3xt/integrations/alienvaultotx/index.js
@@ -52,7 +52,7 @@ class AlienVaultOTXIntegration extends Integration {
     }, {
       url: 'https://otx.alienvault.com/indicator/file/%{query}',
       itypes: ['hash'],
-      name: 'Search AlienVault OTX for URL: %{query}'
+      name: 'Search AlienVault OTX for File: %{query}'
     }],
     fields: [
       {

--- a/cont3xt/integrations/arkime/index.js
+++ b/cont3xt/integrations/arkime/index.js
@@ -253,12 +253,9 @@ class ArkimeIntegration extends Integration {
     return this.doFetch(user, item, [
       'dhcp.host',
       'dns.host',
-      'dns.host',
       'dns.mailserverHost',
       'dns.nameserverHost',
       'dns.hostTokens',
-      'dns.mailserverHost',
-      'dns.nameserverHost',
       'http.host',
       'quic.host',
       'smb.host',

--- a/cont3xt/integrations/csvjson/index.js
+++ b/cont3xt/integrations/csvjson/index.js
@@ -278,7 +278,7 @@ class CsvJsonIntegration extends Integration {
       return;
     }
 
-    // Proess the file
+    // Process the file
     this.#process(fs.readFileSync(this.#url));
 
     // Watch for file changes, debounce over 500ms
@@ -312,7 +312,7 @@ class CsvJsonIntegration extends Integration {
 
   // ----------------------------------------------------------------------------
   #loadHttp () {
-    axios.get(this.url)
+    axios.get(this.#url)
       .then((response) => {
         return this.#process(response.data);
       })

--- a/cont3xt/integrations/dns/index.js
+++ b/cont3xt/integrations/dns/index.js
@@ -15,7 +15,7 @@ class DNSIntegration extends Integration {
   };
 
   // Default cacheTimeout 10 minutes
-  cacheTimeout = 10 * 1000;
+  cacheTimeout = 10 * 60 * 1000;
 
   card = {
     title: 'DNS for %{query}',

--- a/cont3xt/integrations/emailrep/index.js
+++ b/cont3xt/integrations/emailrep/index.js
@@ -112,7 +112,7 @@ class EmailReputationIntegration extends Integration {
       result._cont3xt = { count: 0 };
       // count all of these fields that are true
       const fields = ['blacklisted', 'malicious_activity', 'malicious_activity_recent', 'credentials_leaked', 'credentials_leaked_recent', 'data_breach', 'new_domain', 'suspicious_tld', 'spam', 'accept_all', 'spoofable'];
-      for (const field in fields) {
+      for (const field of fields) {
         if (result.details[field]) {
           result._cont3xt.count++;
         }

--- a/cont3xt/integrations/redis/index.js
+++ b/cont3xt/integrations/redis/index.js
@@ -61,7 +61,7 @@ class RedisIntegration extends Integration {
   // ----------------------------------------------------------------------------
   async #fetch (user, item, type) {
     if (this.#keyTemplate !== undefined) {
-      item = this.#keyTemplate.replace('%key%', item).replace('%type%', this.type);
+      item = this.#keyTemplate.replace('%key%', item).replace('%type%', type);
     }
     try {
       const result = await this.#redisClient[this.#redisMethod](item);

--- a/cont3xt/integrations/spur/index.js
+++ b/cont3xt/integrations/spur/index.js
@@ -152,7 +152,7 @@ class SpurIntegration extends Integration {
       });
 
       for (const rkey in response.data) {
-        if (typeof (response.data) === 'object') {
+        if (typeof (response.data[rkey]) === 'object') {
           if (response.data[rkey].exists === false) {
             delete response.data[rkey];
           } else {

--- a/cont3xt/integrations/wise/index.js
+++ b/cont3xt/integrations/wise/index.js
@@ -77,7 +77,7 @@ class WiseIntegration extends Integration {
   }
 
   // ----------------------------------------------------------------------------
-  async fetchDomain (user, item, ip) {
+  async fetchDomain (user, item) {
     return this.doFetch(user, item, 'domain');
   }
 

--- a/cont3xt/linkGroup.js
+++ b/cont3xt/linkGroup.js
@@ -256,7 +256,7 @@ class LinkGroup {
       return res.send({ success: false, text: 'LinkGroup not found' });
     }
 
-    const results = await Db.deleteLinkGroup(req.params.id, req.body);
+    const results = await Db.deleteLinkGroup(req.params.id);
     if (!results) {
       return res.send({ success: false, text: 'ES Error' });
     }

--- a/cont3xt/overview.js
+++ b/cont3xt/overview.js
@@ -306,7 +306,7 @@ class Overview {
         return res.send({ success: false, text: 'Can not change iType of a default overview' });
       }
 
-      if (overview.viewRoles?.length !== 1 || reqOverview.viewRoles[0] !== 'cont3xtUser') {
+      if (overview.viewRoles?.length !== 1 || overview.viewRoles[0] !== 'cont3xtUser') {
         return res.send({ success: false, text: 'Can not change viewRoles of a default overview' });
       }
     }
@@ -376,7 +376,7 @@ class Overview {
       return res.send({ success: false, text: 'Overview not found' });
     }
 
-    const results = await Db.deleteOverview(req.params.id, req.body);
+    const results = await Db.deleteOverview(req.params.id);
     if (!results) {
       return res.send({ success: false, text: 'ES Error' });
     }
@@ -570,31 +570,37 @@ const defaultOverviewPropertiesForIType = {
     title: 'Phone Overview for %{query}',
     fields: [
       {
+        from: 'Twilio',
         field: 'line_type_intelligence.carrier_name',
         alias: 'Carrier',
         type: 'linked'
       },
       {
+        from: 'Twilio',
         field: 'line_type_intelligence.type',
         alias: 'Line Type',
         type: 'linked'
       },
       {
+        from: 'Twilio',
         field: 'caller_name_object.caller_name',
         alias: 'Caller Name',
         type: 'linked'
       },
       {
+        from: 'Twilio',
         field: 'caller_name_object.caller_type',
         alias: 'Caller Type',
         type: 'linked'
       },
       {
+        from: 'Twilio',
         alias: 'Country Code',
         field: 'country_code',
         type: 'linked'
       },
       {
+        from: 'Twilio',
         alias: 'Phone Number',
         field: 'phone_number',
         type: 'linked'

--- a/cont3xt/view.js
+++ b/cont3xt/view.js
@@ -108,7 +108,7 @@ class View {
    *
    * Creates a new view
    * @name /view
-   * @param {Cont3xtView} views - The view to create
+   * @param {Cont3xtView} view - The view to create
    * @returns {boolean} success - True if the request was successful, false otherwise
    * @returns {string} text - The success/error message to (optionally) display to the user
    */
@@ -138,7 +138,7 @@ class View {
    *
    * Updates a view
    * @name /view/:id
-   * @param {Cont3xtView} views - The view to update
+   * @param {Cont3xtView} view - The view to update
    * @returns {boolean} success - True if the request was successful, false otherwise
    * @returns {string} text - The success/error message to (optionally) display to the user
    */
@@ -176,7 +176,7 @@ class View {
    *
    * Deletes a view
    * @name /view/:id
-   * @param {Cont3xtView} views - The view to delete
+   * @param {Cont3xtView} view - The view to delete
    * @returns {boolean} success - True if the request was successful, false otherwise
    * @returns {string} text - The success/error message to (optionally) display to the user
    */
@@ -186,7 +186,7 @@ class View {
       return res.send({ success: false, text: 'View not found' });
     }
 
-    const results = await Db.deleteView(req.params.id, req.body);
+    const results = await Db.deleteView(req.params.id);
     if (!results) {
       return res.send({ success: false, text: 'ES Error' });
     }

--- a/cont3xt/vueapp/src/utils/applyTemplate.js
+++ b/cont3xt/vueapp/src/utils/applyTemplate.js
@@ -27,7 +27,7 @@ export const applyTemplate = (templateStr, accessibleVars) => {
     }
 
     if (stop < start) { // invalid -- opener ('<') must always come before closer ('>')
-      console.warn(`Invalid template: ${templateStr} -- template opener ('<') must precede template opener ('>')`);
+      console.warn(`Invalid template: ${templateStr} -- template opener ('<') must precede template closer ('>')`);
       return invalidResult;
     }
 

--- a/cont3xt/vueapp/src/utils/paramStr.js
+++ b/cont3xt/vueapp/src/utils/paramStr.js
@@ -5,7 +5,7 @@
  */
 export const paramStr = (queryParamObj) => {
   // no parameters, return empty
-  if (!Object.keys(queryParamObj)) { return ''; }
+  if (!Object.keys(queryParamObj).length) { return ''; }
   // form query param string
   return '?' + Object.entries(queryParamObj)
     .filter(([_, value]) => typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean')


### PR DESCRIPTION
   Bug fixes:
   - integration.js: Add missing return in userAgent(), causing all integrations to send undefined User-Agent headers
   - integration.js: Add missing return after error response in apiPutSettings, preventing fall-through to setCont3xtKeys with invalid data
   - integration.js: Fix updateTime using stats instead of istats for per-integration rolling average calculation
   - emailrep: Fix for...in on array (iterates indices not values), causing _cont3xt.count to always be 0
   - spur: Fix typeof check on response.data instead of response.data[rkey], making the condition always true
   - csvjson: Fix this.url to this.#url in #loadHttp, causing HTTP fetch to fail with undefined URL
   - paramStr.js: Fix !Object.keys() check that never triggers since arrays are always truthy, add .length check
   - redis: Fix this.type to type parameter in key template replacement
   - dns: Fix cacheTimeout from 10 seconds to 10 minutes (10*60*1000)
   - overview.js: Fix mixed overview/reqOverview in viewRoles check
   - overview.js: Add missing 'from' field to all phone overview defaults

   Cleanup:
   - alienvaultotx: Fix search label "URL" to "File" for hash type
   - arkime: Remove 3 duplicate entries in fetchDomain search fields
   - audit.js: Fix reject() to include error in message string
   - linkGroup/view/overview: Remove unused req.body arg from delete calls
   - view.js: Fix JSDoc @param 'views' to 'view' (3 occurrences)
   - csvjson: Fix "Proess" typo in comment
   - applyTemplate.js: Fix "opener" to "closer" in warning message
   - wise: Remove unused ip parameter from fetchDomain

   Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
