### PR TITLE
Fix ArkimeTable not reacting to computed columns prop changes

### DIFF
--- a/viewer/vueapp/src/components/utils/Table.vue
+++ b/viewer/vueapp/src/components/utils/Table.vue
@@ -474,6 +474,25 @@ export default {
           }
         }
       }
+    },
+    // watch for columns prop changes (e.g. i18n locale change)
+    // and update computedColumns in place to preserve order, visibility, and width
+    columns: {
+      handler (newColumns) {
+        const columnMap = {};
+        for (const column of newColumns) {
+          columnMap[column.id] = column;
+        }
+        for (const computedCol of this.computedColumns) {
+          const sourceCol = columnMap[computedCol.id];
+          if (sourceCol) {
+            computedCol.name = sourceCol.name;
+            computedCol.help = sourceCol.help;
+            computedCol.dataFunction = sourceCol.dataFunction;
+            computedCol.avgTotFunction = sourceCol.avgTotFunction;
+          }
+        }
+      }
     }
   },
   mounted: function () {


### PR DESCRIPTION
Add a watcher on the columns prop so that when i18n locale changes, computedColumns are updated in place

fixes #3370

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
