### PR TITLE
Add session parse error display to summary, spiview, and hunt pages

### DIFF
--- a/viewer/vueapp/src/components/hunt/Hunt.vue
+++ b/viewer/vueapp/src/components/hunt/Hunt.vue
@@ -56,10 +56,18 @@ SPDX-License-Identifier: Apache-2.0
             <BButton
               size="sm"
               variant="theme-tertiary"
-              :disabled="loadingSessions || !!loadingSessionsError"
+              :disabled="loadingSessions"
               v-if="!createFormOpened"
               @click="createFormOpened = true">
               {{ $t('hunts.createJob') }}
+            </BButton>
+            <BButton
+              size="sm"
+              variant="warning"
+              v-if="createFormOpened && loadingSessionsDetailError"
+              @click="createFormOpened = false">
+              <span class="fa fa-ban" />&nbsp;
+              {{ $t('common.cancel') }}
             </BButton>
           </BCol>
         </BRow> <!-- /hunt create navbar -->
@@ -69,6 +77,12 @@ SPDX-License-Identifier: Apache-2.0
     <!-- loading overlay -->
     <arkime-loading
       v-if="loading" /> <!-- /loading overlay -->
+
+    <!-- page error -->
+    <arkime-error
+      v-if="loadingSessionsDetailError && createFormOpened"
+      :message="loadingSessionsDetailError"
+      class="mt-2 mb-2" /> <!-- /page error -->
 
     <!-- configuration error -->
     <div
@@ -106,7 +120,7 @@ SPDX-License-Identifier: Apache-2.0
       <div class="mb-3">
         <transition name="slide">
           <div
-            v-if="createFormOpened"
+            v-if="createFormOpened && !loadingSessionsDetailError"
             class="card">
             <form
               class="card-body"
@@ -835,6 +849,7 @@ import HuntService from './HuntService';
 // import components
 import ToggleBtn from '@common/ToggleBtn.vue';
 import ArkimeSearch from '../search/Search.vue';
+import ArkimeError from '../utils/Error.vue';
 import ArkimeLoading from '../utils/Loading.vue';
 import ArkimePaging from '../utils/Pagination.vue';
 import ArkimeCollapsible from '../utils/CollapsibleWrapper.vue';
@@ -856,6 +871,7 @@ export default {
   name: 'PacketSearch',
   components: {
     ToggleBtn,
+    ArkimeError,
     ArkimeSearch,
     ArkimeLoading,
     ArkimeCollapsible,
@@ -886,6 +902,7 @@ export default {
       runningJob: undefined, // the currently running hunt job obj
       sessions: {}, // sessions a new job applies to
       loadingSessionsError: '',
+      loadingSessionsDetailError: '',
       loadingSessions: false,
       // new job search form
       createFormError: '',
@@ -1396,6 +1413,7 @@ export default {
     async loadSessions () {
       this.loadingSessions = true;
       this.loadingSessionsError = '';
+      this.loadingSessionsDetailError = '';
 
       // create unique cancel id to make cancel req for corresponding es task
       const cancelId = Utils.createRandomString();
@@ -1418,6 +1436,7 @@ export default {
         this.sessions = {};
         this.loadingSessions = false;
         this.loadingSessionsError = this.$t('hunts.problemLoading');
+        this.loadingSessionsDetailError = error.text || error.message || '';
       }
     }
   },

--- a/viewer/vueapp/src/components/spiview/Spiview.vue
+++ b/viewer/vueapp/src/components/spiview/Spiview.vue
@@ -177,7 +177,7 @@ SPDX-License-Identifier: Apache-2.0
       <arkime-error
         v-if="error"
         :message="error"
-        class="mt-5 mb-5" /> <!-- /page error -->
+        class="mt-2 mb-2" /> <!-- /page error -->
 
       <!-- spiview panels -->
       <div role="tablist">
@@ -401,7 +401,7 @@ SPDX-License-Identifier: Apache-2.0
                         class="fa fa-spinner fa-spin" /> <!-- /spiview field loading -->
                       <!-- spiview field error -->
                       <span
-                        v-if="value.error"
+                        v-if="value.error && !error"
                         class="text-danger ms-2">
                         <span class="fa fa-exclamation-triangle" />&nbsp;
                         {{ value.error }}
@@ -906,7 +906,7 @@ export default {
           pendingPromises.splice(index, 1);
         }
 
-        this.error = error.text;
+        this.error = error.text || error.message;
 
         // Check if all requests are done (for viz data requests)
         if (pendingPromises.length === 0 && this.dataLoading) {
@@ -1119,7 +1119,10 @@ export default {
 
         this.countCategoryFieldsLoading(category, false);
 
-        if (response.error) { spiData.error = response.error; }
+        if (response.error) {
+          spiData.error = response.error;
+          if (!this.error) { this.error = response.error; }
+        }
 
         // only update the requested spi data
         spiData.loading = false;
@@ -1155,7 +1158,9 @@ export default {
 
         // display error for the requested spi data
         spiData.loading = false;
-        spiData.error = error.text;
+        const errMsg = error.text || error.message;
+        spiData.error = errMsg;
+        if (!this.error && errMsg) { this.error = errMsg; }
         this.loadingVisualizations = false;
 
         // Check if all requests are done

--- a/viewer/vueapp/src/components/summary/Summary.vue
+++ b/viewer/vueapp/src/components/summary/Summary.vue
@@ -1,11 +1,10 @@
 <template>
   <div>
     <!-- Error message -->
-    <div
+    <arkime-error
       v-if="error"
-      class="alert alert-danger m-3">
-      {{ error }}
-    </div>
+      :message="error"
+      class="mt-5 mb-5" />
 
     <!-- Skeleton stats (shown while loading, before first chunk) -->
     <div
@@ -201,6 +200,7 @@ import { useI18n } from 'vue-i18n';
 import Sortable from 'sortablejs';
 // internal dependencies
 import setReqHeaders from '@common/setReqHeaders';
+import ArkimeError from '../utils/Error.vue';
 import SummaryWidget from './SummaryWidget.vue';
 import SummaryChartTooltip from './SummaryChartTooltip.vue';
 import FieldService from '../search/FieldService';


### PR DESCRIPTION
- Summary: Replace bootstrap alert with ArkimeError component for proper newline rendering via white-space: pre-line
- SpiView: Propagate field-level errors to page-level error, fix error.text vs error.message mismatch from fetchWrapper, suppress per-field errors when page-level error is shown
- Hunt: Show detailed parse error when user clicks "Create a packet search job", with cancel button to dismiss; keep generic message in sub navbar

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
