### PR TITLE
Fix esProxy httpsAgent race condition with client certificates

### DIFF
--- a/viewer/esProxy.js
+++ b/viewer/esProxy.js
@@ -455,11 +455,14 @@ app.use(ArkimeUtil.expressErrorHandler);
 // ============================================================================
 // MAIN
 // ===========================================================================
-const httpAgent = new http.Agent({ keepAlive: true, keepAliveMsecs: 5000, maxSockets: 100 });
-const httpsAgent = new https.Agent(Object.assign({ keepAlive: true, keepAliveMsecs: 5000, maxSockets: 100 }, esSSLOptions));
+let httpAgent;
+let httpsAgent;
 
 async function main () {
   await Config.initialize();
+
+  httpAgent = new http.Agent({ keepAlive: true, keepAliveMsecs: 5000, maxSockets: 100 });
+  httpsAgent = new https.Agent(Object.assign({ keepAlive: true, keepAliveMsecs: 5000, maxSockets: 100 }, esSSLOptions));
 
   ArkimeUtil.createHttpServer(app, Config.get('esProxyHost'), Config.get('esProxyPort', '7200'));
 }


### PR DESCRIPTION
The httpsAgent was created at module load time before ArkimeConfig.loaded() populated esSSLOptions with client cert material (key, cert, ca, passphrase). This meant the [tee] feature silently failed with 401 when the tee target required mTLS client certificate authentication.

Move agent creation into main() after Config.initialize() so esSSLOptions is fully populated before the agents are constructed.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
