### PR TITLE
fix aws-managed opensearch cluster index refresh (requires 10s)

### DIFF
--- a/db/db.pl
+++ b/db/db.pl
@@ -4226,7 +4226,7 @@ my $template = qq(
           "limit": 10000
         }
       },
-      "refresh_interval": "5s"
+      "refresh_interval": "${REFRESH}s"
     }
   }
 }


### PR DESCRIPTION
## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
