### PR TITLE
reliability improvements in common/ and parliament/

### DIFF
--- a/common/arkimeUtil.js
+++ b/common/arkimeUtil.js
@@ -476,11 +476,11 @@ class ArkimeUtil {
         }
       } catch (e) {
         console.log("ERROR - Couldn't find database version.  Have you run ./db.pl host:port upgrade?", e);
-        process.exit(0);
+        process.exit(1);
       }
     } catch (err) {
       console.log("ERROR - Couldn't retrieve database version, is OpenSearch/Elasticsearch running?  Have you run ./db.pl host:port init?", err);
-      process.exit(0);
+      process.exit(1);
     }
   }
 
@@ -555,7 +555,8 @@ class ArkimeUtil {
       })
       .on('listening', (e) => {
         console.log('%s listening on host %s port %d in %s mode', process.argv[1], server.address().address, server.address().port, app.settings.env);
-        console.log('Open your web browser to http://localhost:%d/', server.address().port);
+        const proto = ArkimeUtil.#httpsServer ? 'https' : 'http';
+        console.log('Open your web browser to %s://localhost:%d/', proto, server.address().port);
       })
       .listen({ port, host }, listenCb);
 

--- a/common/auth.js
+++ b/common/auth.js
@@ -1143,7 +1143,7 @@ class ESStore extends expressSession.Store {
       // If already exists ignore error
       if (err.meta.body?.error?.type !== 'resource_already_exists_exception') {
         console.log(err);
-        process.exit(0);
+        process.exit(1);
       }
     }
 

--- a/common/notifier.js
+++ b/common/notifier.js
@@ -39,7 +39,7 @@ class Notifier {
     };
 
     // look for all notifier providers and initialize them
-    const files = fs.globSync(path.join(__dirname, '/../common/notifier.*.js'));
+    const files = fs.globSync(path.join(__dirname, 'notifier.*.js'));
     for (const file of files) {
       const notifier = require(file);
       notifier.init(api);

--- a/common/user.js
+++ b/common/user.js
@@ -990,7 +990,7 @@ class User {
 
         if (err) {
           console.log(`ERROR - ${req.method} /api/user/%s`, userId, util.inspect(err, false, 50), user, info);
-          return res.serverError(500, 'Error updating user:' + err);
+          return res.serverError(500, 'Error updating user');
         }
 
         return res.json({
@@ -1059,7 +1059,7 @@ class User {
 
         if (err) {
           console.log(`ERROR - ${req.method} /api/user/%s/assignment`, userId, util.inspect(err, false, 50), user, info);
-          return res.serverError(500, 'Error updating user role:' + err);
+          return res.serverError(500, 'Error updating user role');
         }
 
         return res.json({

--- a/common/vueapp/UserService.js
+++ b/common/vueapp/UserService.js
@@ -196,6 +196,8 @@ export default {
         } else {
           return reject(response.text);
         }
+      }).catch((err) => {
+        reject(err.message || err);
       });
     });
   },

--- a/parliament/parliament.js
+++ b/parliament/parliament.js
@@ -534,8 +534,7 @@ class Parliament {
       return res.serverError(422, 'A group must have a string description.');
     }
 
-    const newGroup = { title: req.body.title, id: uuid(), clusters: [] };
-    newGroup.description ??= req.body.description;
+    const newGroup = { title: req.body.title, description: req.body.description, id: uuid(), clusters: [] };
 
     try {
       const { body: { _source: parliament } } = await Parliament.getParliament();
@@ -839,15 +838,6 @@ class Parliament {
 // ----------------------------------------------------------------------------
 // MIDDLEWARE
 // ----------------------------------------------------------------------------
-// Replace the default express error handler
-app.use((err, req, res, next) => {
-  console.log(ArkimeUtil.sanitizeStr(err.stack));
-  res.status(err.httpStatusCode ?? 500).json({
-    success: false,
-    text: err.message ?? 'Error'
-  });
-});
-
 app.use((req, res, next) => {
   res.serverError = ArkimeUtil.serverError;
   return next();
@@ -883,17 +873,19 @@ let alerts = [];
 // sends alerts in the alerts list
 async function sendAlerts () {
   const hostname = Parliament.getGeneralSetting('hostname');
+  const toSend = alerts;
+  alerts = [];
   const promise = new Promise((resolve, reject) => {
-    for (let index = 0, len = alerts.length; index < len; index++) {
+    for (let index = 0, len = toSend.length; index < len; index++) {
       (function (i) {
         // timeout so that alerts are alerted in order
         setTimeout(() => {
-          const alertToSend = alerts[i];
+          const alertToSend = toSend[i];
           const links = [];
           if (Parliament.getGeneralSetting('includeUrl')) {
             links.push({
               text: 'Parliament Dashboard',
-              url: `${hostname}?searchTerm=${alertToSend.cluster}`
+              url: `${hostname}?searchTerm=${encodeURIComponent(alertToSend.cluster)}`
             });
           }
           alertToSend.notifier.sendAlert(alertToSend.config, alertToSend.message, links);
@@ -906,9 +898,7 @@ async function sendAlerts () {
     }
   });
 
-  promise.then(() => {
-    alerts = []; // clear the queue
-  });
+  await promise;
 }
 
 // sorts the list of alerts by cluster title then sends them
@@ -1026,8 +1016,13 @@ async function initializeParliament () {
 
   // fetch parliament file if it exists
   try {
-    parliamentFile = require(`${ArkimeConfig.get('file')}`);
-  } catch (err) {}
+    parliamentFile = JSON.parse(fs.readFileSync(ArkimeConfig.get('file'), 'utf8'));
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      console.log('Error reading parliament file:', err.message);
+      process.exit(1);
+    }
+  }
 
   // if there's a parliament file, check that it is the correct version
   if (parliamentFile && (parliamentFile.version === undefined || parliamentFile.version < MIN_PARLIAMENT_VERSION)) {
@@ -1522,9 +1517,8 @@ function writeIssues (req, res, next, successObj, errorText, sendIssues) {
       }
 
       if (err) {
-        const errorMsg = `Unable to write issue data: ${err.message ?? err}`;
-        console.log(errorMsg);
-        return res.serverError(500, errorMsg);
+        console.log(`Unable to write issue data: ${err.message ?? err}`);
+        return res.serverError(500, 'Unable to write issue data');
       }
 
       // send the updated issues with the response
@@ -1950,6 +1944,15 @@ app.put('/parliament/api/removeSelectedAcknowledgedIssues', [isUser, checkCookie
   writeIssues(req, res, next, successObj, errorText);
 });
 
+// Replace the default express error handler
+app.use((err, req, res, next) => {
+  console.log(ArkimeUtil.sanitizeStr(err.stack));
+  res.status(err.httpStatusCode ?? 500).json({
+    success: false,
+    text: err.message ?? 'Error'
+  });
+});
+
 // ----------------------------------------------------------------------------
 // INITIALIZE
 // ----------------------------------------------------------------------------
@@ -2040,7 +2043,7 @@ async function main () {
     internals.webBasePath = ArkimeConfig.get('webBasePath', '/');
   } catch (err) {
     console.log(err);
-    process.exit();
+    process.exit(1);
   }
 
   // ERROR OUT if there's no parliament config
@@ -2051,15 +2054,15 @@ async function main () {
 
   // construct the issues file name
   let issuesFilename = 'issues.json';
-  if (ArkimeConfig.get('file')?.indexOf('.json') > -1) {
-    const filename = ArkimeConfig.get('file').replace(/\.json/g, '');
-    issuesFilename = `${filename}.issues.json`;
+  const configFile = ArkimeConfig.get('file');
+  if (configFile?.endsWith('.json')) {
+    issuesFilename = `${configFile.slice(0, -5)}.issues.json`;
   }
   app.set('issuesfile', issuesFilename);
 
   // get the issues file or create it if it doesn't exist
   try {
-    issues = require(issuesFilename);
+    issues = JSON.parse(fs.readFileSync(issuesFilename, 'utf8'));
   } catch (err) {
     issues = [];
   }


### PR DESCRIPTION
   common/arkimeUtil.js:
   - Use process.exit(1) instead of exit(0) in checkArkimeSchemaVersion
   - Log correct protocol (https/http) in createHttpServer startup message

   common/auth.js:
   - Use process.exit(1) instead of exit(0) in ESStore.start()

   common/notifier.js:
   - Fix fragile glob path from '/../common/notifier.*.js' to 'notifier.*.js'

   common/user.js:
   - Remove raw error object from apiUpdateUser/apiUpdateUserRole responses

   common/vueapp/UserService.js:
   - Add missing .catch() handler in changePassword promise chain

   parliament/parliament.js:
   - Replace require() with JSON.parse(fs.readFileSync()) for data files
   - Exit with code 1 when parliament file exists but is unreadable
   - Use process.exit(1) instead of exit() on config initialization failure
   - Move Express error handler after route registrations so it actually works
   - Fix sendAlerts race condition by copying alerts array before clearing
   - URL-encode cluster title in alert notification links
   - Stop leaking file system paths in writeIssues error response
   - Fix .replace(/\.json/g) removing .json from directory names in path
   - Simplify newGroup creation, remove misleading ??= assignment

<!-- Provide a clear and descriptive title -->

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
