### PR TITLE
fix "No parsers loaded, is parsersDir set correctly" always

### DIFF
--- a/capture/parsers.c
+++ b/capture/parsers.c
@@ -773,13 +773,15 @@ int arkime_parsers_load()
         ext->loaded = 1;
     }
 
+    int count = HASH_COUNT(s_, loaded);
+
     HASH_FORALL_POP_HEAD2(s_, loaded, hstring) {
         g_free(hstring->str);
         ARKIME_TYPE_FREE(ArkimeString_t, hstring);
     }
     g_free(disableParsers); // NOT, g_strfreev because using the pointers
 
-    return loaded.count;
+    return count;
 }
 /******************************************************************************/
 void arkime_parsers_register_load_extension(const char *extension, ArkimeParserLoadFunc loadFunc)


### PR DESCRIPTION
need to save count before freeing hash.
## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
