### PR TITLE
capture/erspan: fix VLAN parsing for Type III - mask out version bits

### DIFF
--- a/capture/parsers/erspan.c
+++ b/capture/parsers/erspan.c
@@ -46,6 +46,7 @@ LOCAL ArkimePacketRC erspan_packet_enqueue3(ArkimePacketBatch_t *UNUSED(batch), 
     BSB_INIT(bsb, data, len);
 
     BSB_IMPORT_u16(bsb, packet->vlan);
+    packet->vlan &= 0xfff; // clear the version bits (top 4 bits)
     BSB_IMPORT_skip(bsb, 8);
 
     uint16_t subheader = 0;


### PR DESCRIPTION
Type III ERSPAN header encodes Ver(4)|VLAN(12) in the first 2 bytes. The original code imported the raw 16-bit value without masking, so the top 4 version bits were included in packet->vlan. Type II already had the correct mask; apply the same fix to Type III.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
