### PR TITLE
The bpf setting was reversed for scheme, pcapoverip and tzsp readers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -41,6 +41,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #3786 Dedup packets including VLAN/VNI by default, set dedupVlanVni=false to disable
   - #3792 The setting uploadFileSizeLimit now defaults to 2G instead of unlimited
   - #3792 Link group urls in cont3xt must start with http(s):// now
+  - #3794 Previously the bpf filter setting was reversed for scheme, pcapoverip, and tzsp readers
 ## All
   - #3782 sqlite support added for user database and cont3xt/parliament databases
   - #3782 many fixes for lmdb and redis database implementation
@@ -48,6 +49,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
 ## Capture
   - #3786 add VLAN/VNI deduplication support (thanks @waynieack)
   - #3790 fix VLAN parsing for Type III ERSPAN (thanks @waynieack)
+  - #3794 Fixed bpf filter setting reversed for scheme, pcapoverip, and tzsp readers
 ## ES Proxy
   - #3789 Add AWS SigV4 signing support for managed OpenSearch
 ## Parliament

--- a/capture/reader-pcapoverip.c
+++ b/capture/reader-pcapoverip.c
@@ -159,7 +159,7 @@ LOCAL gboolean pcapoverip_client_read_cb(gint UNUSED(fd), GIOCondition cond, gpo
         packet->pkt           = (u_char *)poic->data + pos + 16;
         packet->readerPos     = poic->interface;
 
-        if (config.bpf && bpf_filter(bpfp.bf_insns, packet->pkt, packet->pktlen, packet->pktlen)) {
+        if (config.bpf && !bpf_filter(bpfp.bf_insns, packet->pkt, packet->pktlen, packet->pktlen)) {
             arkime_packet_free(packet);
         } else {
             arkime_packet_batch(&batch, packet);

--- a/capture/reader-scheme.c
+++ b/capture/reader-scheme.c
@@ -754,7 +754,7 @@ LOCAL int arkime_reader_scheme_processNG(const char *uri, uint8_t *data, int len
             packets++;
             offlineInfo[readerState.readerPos].lastPackets++;
             offlineInfo[readerState.readerPos].lastPacketTime = readerState.packet->ts;
-            if (deadPcap && bpf_filter(bpf.bf_insns, readerState.packet->pkt, readerState.pktlen, readerState.pktlen)) {
+            if (deadPcap && !bpf_filter(bpf.bf_insns, readerState.packet->pkt, readerState.pktlen, readerState.pktlen)) {
                 arkime_packet_free(readerState.packet);
             } else {
                 arkime_packet_batch(&batch, readerState.packet);
@@ -934,7 +934,7 @@ int arkime_reader_scheme_process(const char *uri, uint8_t *data, int len, const 
             packets++;
             offlineInfo[readerState.readerPos].lastPackets++;
             offlineInfo[readerState.readerPos].lastPacketTime = readerState.packet->ts;
-            if (deadPcap && bpf_filter(bpf.bf_insns, readerState.packet->pkt, readerState.pktlen, readerState.pktlen)) {
+            if (deadPcap && !bpf_filter(bpf.bf_insns, readerState.packet->pkt, readerState.pktlen, readerState.pktlen)) {
                 arkime_packet_free(readerState.packet);
             } else {
                 arkime_packet_batch(&batch, readerState.packet);

--- a/capture/reader-tzsp.c
+++ b/capture/reader-tzsp.c
@@ -111,8 +111,7 @@ LOCAL void *tzsp_thread(gpointer UNUSED(uw))
 
         packets++;
 
-        if (config.bpf && bpf_filter(bpfp.bf_insns, BSB_WORK_PTR(bsb), BSB_REMAINING(bsb), BSB_REMAINING(bsb))) {
-            // Not dropped
+        if (config.bpf && !bpf_filter(bpfp.bf_insns, BSB_WORK_PTR(bsb), BSB_REMAINING(bsb), BSB_REMAINING(bsb))) {
             continue;
         }
 


### PR DESCRIPTION
## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
