### PR TITLE
Add codec column to ES Indices stats page

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -56,6 +56,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
 ## Viewer
   - #3842 Add internationalized aria-labels
   - #3863 Add per-cluster serverSecret in S2S auth for multicluster pcap retrieval
+  - #3877 Add ESIndices codec column
 
 6.1.1 2026/04/06
 ## BREAKING

--- a/common/vueapp/locales/de.json
+++ b/common/vueapp/locales/de.json
@@ -759,7 +759,8 @@
       "molochtype": "Heiß/Warm",
       "shardsPerNode": "Shards/Knoten",
       "versionCreated": "ES-Version",
-      "docSize": "Festplatte pro Dokument"
+      "docSize": "Festplatte pro Dokument",
+      "codec": "Codec"
     },
     "esNodes": {
       "mainManaging": "Hauptverwaltungsknoten",

--- a/common/vueapp/locales/en.json
+++ b/common/vueapp/locales/en.json
@@ -759,7 +759,8 @@
       "molochtype": "Hot/Warm",
       "shardsPerNode": "Shards/Node",
       "versionCreated": "ES Version",
-      "docSize": "Disk Per Doc"
+      "docSize": "Disk Per Doc",
+      "codec": "Codec"
     },
     "esNodes": {
       "mainManaging": "Main Managing Node",

--- a/common/vueapp/locales/es.json
+++ b/common/vueapp/locales/es.json
@@ -759,7 +759,8 @@
       "molochtype": "Caliente/Tibio",
       "shardsPerNode": "Shards/Nodo",
       "versionCreated": "Versión ES",
-      "docSize": "Disco por documento"
+      "docSize": "Disco por documento",
+      "codec": "Códec"
     },
     "esNodes": {
       "mainManaging": "Nodo principal de gestión",

--- a/common/vueapp/locales/et.json
+++ b/common/vueapp/locales/et.json
@@ -759,7 +759,8 @@
       "molochtype": "Kuum/Soe",
       "shardsPerNode": "Kilde/Sõlm",
       "versionCreated": "ES versioon",
-      "docSize": "Ketas dokumendi kohta"
+      "docSize": "Ketas dokumendi kohta",
+      "codec": "Koodek"
     },
     "esNodes": {
       "mainManaging": "Peamine haldussõlm",

--- a/common/vueapp/locales/fr.json
+++ b/common/vueapp/locales/fr.json
@@ -759,7 +759,8 @@
       "molochtype": "Type Arkime",
       "shardsPerNode": "Shards/Nœud",
       "versionCreated": "Version Créée",
-      "docSize": "Taille Doc"
+      "docSize": "Taille Doc",
+      "codec": "Codec"
     },
     "esNodes": {
       "mainManaging": "Gestion Principale",

--- a/common/vueapp/locales/ja.json
+++ b/common/vueapp/locales/ja.json
@@ -759,7 +759,8 @@
       "molochtype": "Hot/Warm",
       "shardsPerNode": "シャード/ノード",
       "versionCreated": "ES バージョン",
-      "docSize": "1ドキュメントあたりのディスク量"
+      "docSize": "1ドキュメントあたりのディスク量",
+      "codec": "コーデック"
     },
     "esNodes": {
       "mainManaging": "メイン管理ノード",

--- a/common/vueapp/locales/ko.json
+++ b/common/vueapp/locales/ko.json
@@ -759,7 +759,8 @@
       "molochtype": "Hot/Warm",
       "shardsPerNode": "노드당 샤드",
       "versionCreated": "ES 버전",
-      "docSize": "문서당 디스크"
+      "docSize": "문서당 디스크",
+      "codec": "코덱"
     },
     "esNodes": {
       "mainManaging": "주 관리 노드",

--- a/common/vueapp/locales/pt-BR.json
+++ b/common/vueapp/locales/pt-BR.json
@@ -759,7 +759,8 @@
       "molochtype": "Hot/Warm",
       "shardsPerNode": "Shards/Nó",
       "versionCreated": "Versão ES",
-      "docSize": "Disco Por Doc"
+      "docSize": "Disco Por Doc",
+      "codec": "Codec"
     },
     "esNodes": {
       "mainManaging": "Nó Gerenciador Principal",

--- a/common/vueapp/locales/x-pl.json
+++ b/common/vueapp/locales/x-pl.json
@@ -760,7 +760,8 @@
       "molochtype": "OtHay/ArmWay",
       "shardsPerNode": "Ardsshay/OdeNay",
       "versionCreated": "ESway Ersionvay",
-      "docSize": "OcDay Izesay"
+      "docSize": "OcDay Izesay",
+      "codec": "Odeccay"
     },
     "esNodes": {
       "mainManaging": "Ainmay AnagingMay Odenay",

--- a/common/vueapp/locales/zh.json
+++ b/common/vueapp/locales/zh.json
@@ -759,7 +759,8 @@
       "molochtype": "Arkime类型",
       "shardsPerNode": "每节点分片数",
       "versionCreated": "创建版本",
-      "docSize": "文档大小"
+      "docSize": "文档大小",
+      "codec": "编解码器"
     },
     "esNodes": {
       "mainManaging": "主管理",

--- a/viewer/apiStats.js
+++ b/viewer/apiStats.js
@@ -574,6 +574,8 @@ class StatsAPIs {
           index.shardsPerNode = indicesSettings[index.index].settings['index.routing.allocation.total_shards_per_node'];
         }
 
+        index.codec = indicesSettings[index.index].settings['index.codec'] || 'default';
+
         index.creationDate = parseInt(indicesSettings[index.index].settings['index.creation_date']);
         index.versionCreated = parseInt(indicesSettings[index.index].settings['index.version.created']);
         index.docSize = index['docs.count'] === '0' ? 0 : Math.ceil(parseInt(index['store.size']) / parseInt(index['docs.count']));
@@ -581,7 +583,7 @@ class StatsAPIs {
 
       // sorting
       const sortField = req.query.sortField || 'index';
-      if (sortField === 'index' || sortField === 'status' || sortField === 'health') {
+      if (sortField === 'index' || sortField === 'status' || sortField === 'health' || sortField === 'codec') {
         if (req.query.desc === 'true') {
           findices = findices.sort((a, b) => { return b[sortField].localeCompare(a[sortField]); });
         } else {

--- a/viewer/vueapp/src/components/stats/EsIndices.vue
+++ b/viewer/vueapp/src/components/stats/EsIndices.vue
@@ -165,6 +165,7 @@ export default {
         intl({ id: 'molochtype', sort: 'molochtype', doStats: false, width: 100 }),
         intl({ id: 'shardsPerNode', sort: 'shardsPerNode', doStats: false, width: 100 }),
         intl({ id: 'versionCreated', sort: 'versionCreated', doStats: false, width: 100 }),
+        intl({ id: 'codec', sort: 'codec', doStats: false, width: 100 }),
         intl({ id: 'docSize', sort: 'docSize', doStats: true, width: 100, dataFunction: (item) => { return roundCommaString(item.docSize); } })
       ];
     },


### PR DESCRIPTION
Extract index.codec from index settings and display it as a sortable column. Defaults to 'default' when not explicitly set.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
