### PR TITLE
Security hardening: capture engine fixes and viewer response sanitization

### DIFF
--- a/capture/main.c
+++ b/capture/main.c
@@ -400,13 +400,14 @@ LOCAL void arkime_free_later_init()
 /******************************************************************************/
 LOCAL void controlc(int UNUSED(sig))
 {
-    LOG("Control-C");
     signal(SIGINT, exit); // Double Control-C quits right away
+    LOG("Control-C");
     arkime_quit();
 }
 /******************************************************************************/
 LOCAL void terminate(int UNUSED(sig))
 {
+    signal(SIGTERM, exit); // Double terminate quits right away
     LOG("Terminate");
     arkime_quit();
 }

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -1533,6 +1533,7 @@ skip_switch:
         if (rc == ARKIME_PACKET_CORRUPT) {
             // If we have at least 14 bytes (ethernet header) and corruptSavePcap is enabled, create a session
             if (config.corruptSavePcap && packet->pktlen >= packet->etherOffset + 14) {
+                packet->tunnelDepth = 0;
                 rc = arkime_packet_run_ethernet_cb(batch, packet, packet->pkt, packet->pktlen, ARKIME_ETHERTYPE_CORRUPT, "CORRUPT");
                 goto process_packet;
             } else {

--- a/capture/parsers/tls.c
+++ b/capture/parsers/tls.c
@@ -160,9 +160,9 @@ LOCAL uint32_t tls_process_server_hello(ArkimeSession_t *session, const uint8_t 
     }
 
 
-    char ja3[30000];
+    char ja3[13000];
     BSB ja3bsb;
-    char eja3[10000];
+    char eja3[13000];
     BSB eja3bsb;
 
     BSB_INIT(ja3bsb, ja3, sizeof(ja3));
@@ -301,13 +301,13 @@ LOCAL uint32_t tls_process_client_hello_data(ArkimeSession_t *session, const uin
     if (len < 7)
         return -1;
 
-    char ja3[30000];
+    char ja3[13000];
     BSB ja3bsb;
-    char ecfja3[1000];
+    char ecfja3[1024];
     BSB ecfja3bsb;
-    char eja3[10000];
+    char eja3[13000];
     BSB eja3bsb;
-    char ecja3[10000];
+    char ecja3[13000];
     BSB ecja3bsb;
 
     char     ja4HasSNI = 'i';

--- a/capture/plugins/wise.c
+++ b/capture/plugins/wise.c
@@ -512,6 +512,8 @@ LOCAL void wise_lookup_domain(ArkimeSession_t *session, WiseRequest_t *request, 
         if (config.debug) {
             LOG("Invalid DNS: %s", domain);
         }
+        if (colon)
+            *colon = ':';
         return;
     }
 
@@ -521,6 +523,8 @@ LOCAL void wise_lookup_domain(ArkimeSession_t *session, WiseRequest_t *request, 
         if (inet_pton(AF_INET, domain, &addr) == 1) {
             wise_lookup(session, request, domain, INTEL_TYPE_IP, matchPos);
         }
+        if (colon)
+            *colon = ':';
         return;
     }
 

--- a/capture/reader-scheme-s3.c
+++ b/capture/reader-scheme-s3.c
@@ -104,13 +104,12 @@ LOCAL void scheme_s3_parse_region(const uint8_t *data, int data_len, const char 
 /******************************************************************************/
 LOCAL char *scheme_s3_escape(const char *str, int len)
 {
-    char out[3000];
+    // Worst case: every char expands to 3 bytes (%XX)
+    char *out = g_malloc(len * 3 + 1);
     int  s;
     int  o;
 
-    out[0] = 0;
-
-    for (s = o = 0; s < len && o + 3 < (int)sizeof(out); s++) {
+    for (s = o = 0; s < len; s++) {
         if (str[s] == '+') {
             out[o++] = '%';
             out[o++] = '2';
@@ -123,7 +122,8 @@ LOCAL char *scheme_s3_escape(const char *str, int len)
             out[o++] = str[s];
         }
     }
-    return g_strndup(out, o);
+    out[o] = '\0';
+    return out;
 }
 /******************************************************************************/
 LOCAL void scheme_s3_done(int UNUSED(code), uint8_t *data, int data_len, gpointer uw)
@@ -241,11 +241,11 @@ LOCAL void *scheme_s3_make_server(const ArkimeCredentials_t *creds, const char *
     int isNew;
     void *server = arkime_http_get_or_create_server(schemehostport, schemehostport, 2, 2, TRUE, &isNew);
     if (isNew) {
-        char userpwd[100];
+        char userpwd[256];
         snprintf(userpwd, sizeof(userpwd), "%s:%s", creds->id, creds->key);
         arkime_http_set_userpwd(server, userpwd);
 
-        char aws_sigv4[100];
+        char aws_sigv4[256];
         snprintf(aws_sigv4, sizeof(aws_sigv4), "aws:amz:%s:s3", region);
         arkime_http_set_aws_sigv4(server, aws_sigv4);
 
@@ -310,18 +310,19 @@ LOCAL int scheme_s3_load_dir(const char *dir, ArkimeSchemeFlags flags, ArkimeSch
 
     while (!s3Items->done || DLL_COUNT(item_, s3Items) > 0) {
         if (req.continuation) {
-            char uri2[3000];
+            char *uri2;
 
             if (uris[3]) {
-                snprintf(uri2, sizeof(uri2), "s3://%s/?continuation-token=%s&list-type=2&prefix=%s", uris[2], req.continuation, uris[3]);
+                uri2 = g_strdup_printf("s3://%s/?continuation-token=%s&list-type=2&prefix=%s", uris[2], req.continuation, uris[3]);
             } else {
-                snprintf(uri2, sizeof(uri2), "s3://%s/?continuation-token=%s&list-type=2", uris[2], req.continuation);
+                uri2 = g_strdup_printf("s3://%s/?continuation-token=%s&list-type=2", uris[2], req.continuation);
             }
 
             g_free(req.continuation);
             req.continuation = NULL;
 
             scheme_s3_request(server, creds, uri2 + 5 + strlen(uris[2]), uris[2], &req, s3PathAccessStyle, NULL);
+            g_free(uri2);
             ARKIME_LOCK(waitingdir);
         }
         ARKIME_LOCK(s3Items->lock);
@@ -426,18 +427,19 @@ LOCAL int scheme_s3_load_full_dir(const char *dir, ArkimeSchemeFlags flags, Arki
 
     while (!s3Items->done || DLL_COUNT(item_, s3Items) > 0) {
         if (req.continuation) {
-            char uri2[3000];
+            char *uri2;
 
             if (paths[2] && paths[2][0] != 0) {
-                snprintf(uri2, sizeof(uri2), "%s/?continuation-token=%s&list-type=2&prefix=%s", shpb, req.continuation, paths[2]);
+                uri2 = g_strdup_printf("%s/?continuation-token=%s&list-type=2&prefix=%s", shpb, req.continuation, paths[2]);
             } else {
-                snprintf(uri2, sizeof(uri2), "%s/?continuation-token=%s&list-type=2", shpb, req.continuation);
+                uri2 = g_strdup_printf("%s/?continuation-token=%s&list-type=2", shpb, req.continuation);
             }
 
             g_free(req.continuation);
             req.continuation = NULL;
 
             scheme_s3_request(server, creds, uri2 + strlen(shpb), paths[1], &req, TRUE, NULL);
+            g_free(uri2);
             ARKIME_LOCK(waitingdir);
         }
         ARKIME_LOCK(s3Items->lock);

--- a/capture/reader-scheme-sqs.c
+++ b/capture/reader-scheme-sqs.c
@@ -232,11 +232,11 @@ LOCAL int scheme_sqs_load(const char *uri, ArkimeSchemeFlags flags, ArkimeScheme
     if (isNew) {
         arkime_http_set_timeout(server, 0);
 
-        char userpwd[100];
+        char userpwd[256];
         snprintf(userpwd, sizeof(userpwd), "%s:%s", creds->id, creds->key);
         arkime_http_set_userpwd(server, userpwd);
 
-        char aws_sigv4[100];
+        char aws_sigv4[256];
         snprintf(aws_sigv4, sizeof(aws_sigv4), "aws:amz:%s:sqs", dots[1]);
         arkime_http_set_aws_sigv4(server, aws_sigv4);
     }

--- a/capture/thirdparty/js0n.c
+++ b/capture/thirdparty/js0n.c
@@ -65,7 +65,7 @@ int js0n(const unsigned char *js, unsigned int len, unsigned int *out, unsigned 
 	};
 	void **go = gostruct;
 
-	for(cur=js,end=js+len,oend=out+olen; cur<end && out<oend; cur++)
+	for(cur=js,end=js+len,oend=out+(olen/sizeof(*out)); cur<end && out<oend; cur++) // ALW - callers pass sizeof(out) which is bytes, convert to element count
 	{
 			goto *go[*cur];
 			l_loop:;

--- a/capture/writer-simple.c
+++ b/capture/writer-simple.c
@@ -640,6 +640,7 @@ LOCAL void writer_simple_write(const ArkimeSession_t *const session, ArkimePacke
         }
 
         /* If offline pcap honor umask, otherwise disable other RW */
+        unlink(name);
         if (config.pcapReadOffline) {
             simpleThreadData[thread].currentInfo->file->fd = open(name,  openOptions, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
         } else {
@@ -1077,6 +1078,9 @@ void writer_simple_init(const char *name)
     }
 
     openOptions = O_NOATIME | O_WRONLY | O_CREAT | O_TRUNC;
+#ifdef O_EXCL
+    openOptions |= O_EXCL;
+#endif
     if (strcmp(name, "simple") == 0) {
 #ifdef O_DIRECT
         openOptions |= O_DIRECT;

--- a/common/arkimeUtil.js
+++ b/common/arkimeUtil.js
@@ -424,7 +424,7 @@ class ArkimeUtil {
     if (res.headersSent) {
       return next(err);
     }
-    res.status(500).send(err.toString());
+    res.status(500).type('text/plain').send(err.toString());
   }
 
   // ----------------------------------------------------------------------------

--- a/common/auth.js
+++ b/common/auth.js
@@ -846,11 +846,19 @@ class Auth {
       return ArkimeUtil.serverError.call(res, 403, 'Bad path ' + ArkimeUtil.safeStr(req.path));
     }
 
-    if (!req.query) { return next(); }
+    if (req.query) {
+      for (const key in req.query) {
+        if (ArkimeUtil.isPP(req.query[key])) {
+          return ArkimeUtil.serverError.call(res, 403, 'Invalid value for ' + ArkimeUtil.safeStr(key));
+        }
+      }
+    }
 
-    for (const key in req.query) {
-      if (ArkimeUtil.isPP(req.query[key])) {
-        return ArkimeUtil.serverError.call(res, 403, 'Invalid value for ' + ArkimeUtil.safeStr(key));
+    if (req.body) {
+      for (const key in req.body) {
+        if (ArkimeUtil.isPP(req.body[key])) {
+          return ArkimeUtil.serverError.call(res, 403, 'Invalid value for ' + ArkimeUtil.safeStr(key));
+        }
       }
     }
 

--- a/tests/api-connections.t
+++ b/tests/api-connections.t
@@ -1,4 +1,4 @@
-use Test::More tests => 12;
+use Test::More tests => 14;
 use Cwd;
 use URI::Escape;
 use ArkimeTest;
@@ -118,3 +118,8 @@ my ($json, $mjson);
 "10.180.156.185","1418212800000",3,32958,26760,93,test
 "10.180.156.185","1648944000000",3,32958,26760,93,test
 ));
+
+# csv with bad view should return error as text/plain
+    my $resp = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8123/api/connections.csv?view=unknown&date=-1&expression=" . uri_escape("$files"));
+    like ($resp->content, qr/Can't find view/, "connections csv bad view error text");
+    is ($resp->header('Content-Type'), 'text/plain; charset=utf-8', "connections csv bad view content-type");

--- a/tests/api-encodings.t
+++ b/tests/api-encodings.t
@@ -106,6 +106,7 @@ sub doCheck {
 }
 
 ### MAIN ###
+system("rm -f /tmp/test-161019* /tmp/test-131203-*");
 
 # Load all the pcap, running some in background
 foreach my $e (undef, "xor-2048", "aes-256-ctr") {
@@ -152,3 +153,4 @@ foreach my $item (@{$json->{hits}->{hits}}) {
 
 # Delete the files entries
 esPost("/tests_files/_delete_by_query?conflicts=proceed&refresh", '{ "query": { "wildcard": { "name": "/tmp/test-*" } } }');
+system("rm -f /tmp/test-161019* /tmp/test-131203-*");

--- a/tests/api-history.t
+++ b/tests/api-history.t
@@ -1,4 +1,4 @@
-use Test::More tests => 53;
+use Test::More tests => 56;
 use Cwd;
 use URI::Escape;
 use ArkimeTest;
@@ -125,6 +125,11 @@ my ($url) = @_;
     $json = viewerGet("/api/histories?searchTerm=zzznomatch");
     is ($json->{recordsFiltered}, 0, "Test6: searchTerm no match");
 
+# isPP sortField should be rejected
+    $json = viewerGet("/api/histories?sortField=__proto__");
+    is ($json->{success}, 0, "isPP sortField rejected");
+    is ($json->{text}, "Invalid value for sortField", "isPP sortField error text");
+
 # Can't delete items when not admin
     $json = viewerDeleteToken("/api/history/$item->{id}?arkimeRegressionUser=historytest1", $otherToken);
     eq_or_diff($json, from_json('{"success": false, "text": "You do not have permission to access this resource"}', {relaxed => 1}), "Test Delete Not Admin", { context => 3 });
@@ -133,6 +138,10 @@ my ($url) = @_;
     $json = viewerDeleteToken("/api/history/$item->{id}", $token);
     is($json->{success}, 0, "Test Delete No Index");
     is($json->{i18n}, "api.history.missingIndex", "Test Delete No Index i18n");
+
+# Delete item invalid index
+    $json = viewerDeleteToken("/api/history/$item->{id}?index=evil_nothistory", $token);
+    is($json->{success}, 0, "Test Delete Invalid Index");
 
 # Delete item
     $json = viewerDeleteToken("/api/history/$item->{id}?index=$item->{index}", $token);

--- a/tests/api-hunt.t
+++ b/tests/api-hunt.t
@@ -1,4 +1,4 @@
-use Test::More tests => 340;
+use Test::More tests => 345;
 use Cwd;
 use URI::Escape;
 use ArkimeTest;
@@ -22,6 +22,11 @@ viewerGet("/regressionTests/deleteAllUsers");
   my $hunts = viewerGet("/api/hunts?all");
   delete $hunts->{nodeInfo};
   eq_or_diff($hunts, from_json('{"recordsTotal": 0, "data": [], "recordsFiltered": 0}'));
+
+# isPP sortField should be rejected
+  $json = viewerGet("/api/hunts?sortField=constructor");
+  is ($json->{success}, 0, "isPP sortField rejected");
+  is ($json->{text}, "Invalid value for sortField", "isPP sortField error text");
 
 # Create sac-huntuser
   $json = viewerPostToken("/api/user", '{"userId": "sac-huntuser", "userName": "UserName", "enabled":true, "password":"password", "packetSearch":true, "roles": ["arkimeUser"]}', $token);
@@ -320,6 +325,13 @@ my $hToken = getTokenCookie('sac-huntuser');
     is ($item->{searchType}, "", "should be missing searchType field");
     is ($item->{query}, undef, "should be missing query field");
   }
+
+# empty roles array should still hide secrets
+  $json = viewerPutToken("/api/hunt/$id7", '{"roles":[]}', $token);
+  is ($json->{success}, 1, "can set empty roles");
+  $hunts = viewerGetToken("/api/hunts?all&arkimeRegressionUser=user3", $nonadminToken);
+  is ($hunts->{data}->[3]->{id}, "", "empty roles: should hide id");
+  is ($hunts->{data}->[3]->{search}, "", "empty roles: should hide search");
 
 # can update hunt roles
   $json = viewerPutToken("/api/hunt/$id7", '{"roles":["arkimeUser"]}', $token);

--- a/tests/api-sessions.t
+++ b/tests/api-sessions.t
@@ -1,4 +1,4 @@
-use Test::More tests => 135;
+use Test::More tests => 143;
 use Cwd;
 use URI::Escape;
 use ArkimeTest;
@@ -322,3 +322,23 @@ tcp,1386004309468,1386004309478,10.180.156.185,53533,US,10.180.156.249,1080,US,2
 # Test /api/sessions/decodings
     $json = viewerGet("/api/sessions/decodings");
     ok(ref $json eq 'HASH', "decodings returns an object");
+
+# unique with bad view should return error as text/plain
+    my $resp = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8123/api/unique?field=source.ip&view=unknown&date=-1&expression=" . uri_escape("file=$pwd/socks-http-example.pcap"));
+    like ($resp->content, qr/Can't find view/, "unique bad view error text");
+    is ($resp->header('Content-Type'), 'text/plain; charset=utf-8', "unique bad view content-type");
+
+# multiunique with unknown expression field should return error as text/plain
+    $resp = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8123/api/multiunique?exp=FAKEFIELD&date=-1&expression=" . uri_escape("file=$pwd/socks-http-example.pcap"));
+    like ($resp->content, qr/Unknown expression FAKEFIELD/, "multiunique bad field error text");
+    is ($resp->header('Content-Type'), 'text/plain; charset=utf-8', "multiunique bad field content-type");
+
+# multiunique with bad view should return error as text/plain (BuildQuery error path)
+    $resp = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8123/api/multiunique?exp=source.ip&date=-1&view=BADVIEW&expression=" . uri_escape("file=$pwd/socks-http-example.pcap"));
+    like ($resp->content, qr/Can't find view/, "multiunique bad view error text");
+    is ($resp->header('Content-Type'), 'text/plain; charset=utf-8', "multiunique bad view content-type");
+
+# spigraphhierarchy with bad view should return error as json (noCacheJson protected)
+    $resp = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8123/api/spigraphhierarchy?exp=source.ip&date=-1&view=BADVIEW&expression=" . uri_escape("file=$pwd/socks-http-example.pcap"));
+    like ($resp->content, qr/Can't find view/, "spigraphhierarchy bad view error text");
+    like ($resp->header('Content-Type'), qr|application/json|, "spigraphhierarchy bad view content-type is json");

--- a/tests/api-stats.t
+++ b/tests/api-stats.t
@@ -1,4 +1,4 @@
-use Test::More tests => 125;
+use Test::More tests => 133;
 use Cwd;
 use URI::Escape;
 use ArkimeTest;
@@ -45,6 +45,11 @@ my $test1Token = getTokenCookie("test1");
     my $mstats = multiGet("/stats.json?cluster=unknown");
     is (@{$mstats->{data}}, 0);
 
+# stats isPP sortField should be rejected
+    my $badstats = viewerGet("/api/stats?sortField=__proto__");
+    is ($badstats->{success}, 0, "stats isPP sortField rejected");
+    is ($badstats->{text}, "Invalid value for sortField", "stats isPP sortField error text");
+
 # dstats.json
     my $dstats = viewerGet("/api/dstats?nodeName=test&start=1399680425&stop=1399680460&step=5&interval=5&name=deltaPackets");
     is (@{$dstats}, 7, "dstats.json array size");
@@ -62,6 +67,11 @@ my $test1Token = getTokenCookie("test1");
 
     my $messtats = multiGet("/esstats.json?cluster=unknown");
     is (@{$messtats->{data}}, 0);
+
+# esstats isPP sortField should be rejected
+    my $badesstats = viewerGet("/api/esstats?sortField=constructor");
+    is ($badesstats->{success}, 0, "esstats isPP sortField rejected");
+    is ($badesstats->{text}, "Invalid value for sortField", "esstats isPP sortField error text");
 
 # esindices
     my $indices = viewerGet("/api/esindices");
@@ -84,6 +94,11 @@ my $test1Token = getTokenCookie("test1");
     $indices = multiGet("/api/esindices?cluster=unknown");
     is($indices->{success}, 0, "unknown cluster no results");
     is($indices->{i18n}, "api.stats.noResults", "unknown cluster no results i18n");
+
+# esindices isPP sortField should be rejected
+    my $badindices = viewerGet("/api/esindices?sortField=__proto__");
+    is ($badindices->{success}, 0, "esindices isPP sortField rejected");
+    is ($badindices->{text}, "Invalid value for sortField", "esindices isPP sortField error text");
 
 # esindices delete - test with non-existent index
     my $del = viewerDeleteToken("/api/esindices/nonexistent_fake_index_12345", $token);
@@ -119,6 +134,11 @@ my $test1Token = getTokenCookie("test1");
 
     my $tasks = multiGet("/api/estasks?cluster=unknown");
     cmp_ok (@{$tasks->{data}}, "==", 0, "tasks array size");
+
+# estasks isPP sortField should be rejected
+    my $badtasks = viewerGet("/api/estasks?sortField=constructor");
+    is ($badtasks->{success}, 0, "estasks isPP sortField rejected");
+    is ($badtasks->{text}, "Invalid value for sortField", "estasks isPP sortField error text");
 
 # estasks cancel
     my $result = viewerPostToken("/api/estasks/nonexistent/cancel", "", $token);

--- a/tests/api-tagging.t
+++ b/tests/api-tagging.t
@@ -1,4 +1,4 @@
-use Test::More tests => 72;
+use Test::More tests => 76;
 use Cwd;
 use URI::Escape;
 use ArkimeTest;
@@ -97,3 +97,13 @@ my $json;
     esGet("/_refresh");
     countTest(0, "date=-1&expression=" . uri_escape("file=$pwd/irc.pcap && tags==MTAGTEST3"));
     countTest(1, "date=-1&expression=" . uri_escape("file=$pwd/irc.pcap && tags!=EXISTS!"));
+
+# addtags with bad view should return error as text/plain
+    my $resp = $ArkimeTest::userAgent->post("http://$ArkimeTest::host:8123/api/sessions/addtags?view=unknown&date=-1&expression=file=$pwd/socks-http-example.pcap", Content => "tags=BADVIEWTEST");
+    like ($resp->content, qr/Could not build query/, "addtags bad view error text");
+    is ($resp->header('Content-Type'), 'text/plain; charset=utf-8', "addtags bad view content-type");
+
+# removetags with bad view should return error as text/plain
+    $resp = $ArkimeTest::userAgent->post("http://$ArkimeTest::host:8123/api/sessions/removetags?view=unknown&date=-1&expression=file=$pwd/socks-http-example.pcap", Content => "tags=BADVIEWTEST");
+    like ($resp->content, qr/Could not build query/, "removetags bad view error text");
+    is ($resp->header('Content-Type'), 'text/plain; charset=utf-8', "removetags bad view content-type");

--- a/tests/api-users.t
+++ b/tests/api-users.t
@@ -1,7 +1,7 @@
 # Many of these test user/roles start with sac- (skip auto create) because
 # otherwise viewer in regression mode would auto create the user.
 # Some day should remove all autocreate code.
-use Test::More tests => 249;
+use Test::More tests => 257;
 use Cwd;
 use URI::Escape;
 use ArkimeTest;
@@ -281,8 +281,14 @@ anonymous,,true,true,false,"arkimeAdmin, cont3xtUser, parliamentUser, usersAdmin
     delete $users->{data}->[$test2pos]->{lastUsed};
     eq_or_diff($users->{data}->[$test2pos], from_json('{"roles": [], "userId": "sac-test2", "removeEnabled": true, "expression": "", "headerAuthEnabled": false, "userName": "UserNameUpdated3", "id": "sac-test2", "emailSearch": false, "enabled": false, "webEnabled": false, "packetSearch": false, "welcomeMsgNum": 0, "roleAssigners": []}', {relaxed => 1}), "Test User Update", { context => 3 });
 
+# isPP body param validation
+    my $info = viewerPostToken("/api/user/layouts/sessionstable?arkimeRegressionUser=sac-test1", '{"name": "__proto__", "columns": ["source.ip"], "order": [["lastPacket", "asc"]]}', $test1Token);
+    is($info->{text}, "Invalid value for name", "column: __proto__ body value blocked");
+    $info = viewerPostToken("/api/user/layouts/sessionstable?arkimeRegressionUser=sac-test1", '{"name": "constructor", "columns": ["source.ip"], "order": [["lastPacket", "asc"]]}', $test1Token);
+    is($info->{text}, "Invalid value for name", "column: constructor body value blocked");
+
 # Session Table Column Layout CRUD
-    my $info = viewerGetToken("/api/user/layouts/sessionstable?arkimeRegressionUser=sac-test1", $test1Token);
+    $info = viewerGetToken("/api/user/layouts/sessionstable?arkimeRegressionUser=sac-test1", $test1Token);
     eq_or_diff($info, from_json("[]"), "column: empty");
 
     $info = viewerPostToken("/api/user/layouts/sessionstable?arkimeRegressionUser=sac-test1", '{"name": "column1", "columns": ["source.ip","destination.ip"], "order": [["lastPacket", "asc"]]}', $test1Token);
@@ -307,6 +313,12 @@ anonymous,,true,true,false,"arkimeAdmin, cont3xtUser, parliamentUser, usersAdmin
 
     $info = viewerPutToken("/api/user/layouts/sessionstable?arkimeRegressionUser=sac-test1", '{"name": "column1", "columns": ["source.ip","destination.ip","info"], "order": [["lastPacket","asc"]]}', $test1Token);
     ok($info->{success}, "column: update");
+
+# column: mass assignment - extra properties should be stripped
+    $info = viewerPutToken("/api/user/layouts/sessionstable?arkimeRegressionUser=sac-test1", '{"name": "column1", "columns": ["source.ip"], "order": [["lastPacket","asc"]], "evil": "injected"}', $test1Token);
+    ok($info->{success}, "column: update with extra props");
+    $info = viewerGetToken("/api/user/layouts/sessionstable?arkimeRegressionUser=sac-test1", $test1Token);
+    ok(!exists $info->[0]->{evil}, "column: extra property stripped");
 
     $info = viewerDeleteToken("/api/user/layouts/sessionstable/column1?arkimeRegressionUser=sac-test1", $test1Token);
     ok($info->{success}, "column: delete found");
@@ -339,6 +351,12 @@ anonymous,,true,true,false,"arkimeAdmin, cont3xtUser, parliamentUser, usersAdmin
     $info = viewerPutToken("/api/user/layouts/sessionsinfofields?arkimeRegressionUser=sac-test1", '{"name": "sfields1", "fields": ["source.ip","destination.ip","node"]}', $test1Token);
     ok($info->{success}, "sessionsinfofields fields: update success");
 
+# sessionsinfofields: mass assignment - extra properties should be stripped
+    $info = viewerPutToken("/api/user/layouts/sessionsinfofields?arkimeRegressionUser=sac-test1", '{"name": "sfields1", "fields": ["source.ip","destination.ip","node"], "evil": "injected"}', $test1Token);
+    ok($info->{success}, "sessionsinfofields: update with extra props");
+    $info = viewerGetToken("/api/user/layouts/sessionsinfofields?arkimeRegressionUser=sac-test1", $test1Token);
+    ok(!exists $info->[0]->{evil}, "sessionsinfofields: extra property stripped");
+
     $info = viewerDeleteToken("/api/user/layouts/sessionsinfofields/fred?arkimeRegressionUser=sac-test1", $test1Token);
     ok(!$info->{success}, "sessionsinfofields fields: delete not found");
 
@@ -367,6 +385,12 @@ anonymous,,true,true,false,"arkimeAdmin, cont3xtUser, parliamentUser, usersAdmin
 
     $info = viewerPutToken("/api/user/layouts/spiview?arkimeRegressionUser=sac-test1", '{"name": "sfields1", "fields": ["source.ip","destination.ip","node"]}', $test1Token);
     ok($info->{success}, "spiview fields: update success");
+
+# spiview: mass assignment - extra properties should be stripped
+    $info = viewerPutToken("/api/user/layouts/spiview?arkimeRegressionUser=sac-test1", '{"name": "sfields1", "fields": ["source.ip","destination.ip","node"], "evil": "injected"}', $test1Token);
+    ok($info->{success}, "spiview: update with extra props");
+    $info = viewerGetToken("/api/user/layouts/spiview?arkimeRegressionUser=sac-test1", $test1Token);
+    ok(!exists $info->[0]->{evil}, "spiview: extra property stripped");
 
     $info = viewerDeleteToken("/api/user/layouts/spiview/fred?arkimeRegressionUser=sac-test1", $test1Token);
     ok(!$info->{success}, "spiview fields: delete not found");

--- a/viewer/apiConnections.js
+++ b/viewer/apiConnections.js
@@ -519,7 +519,7 @@ class ConnectionAPIs {
     const separator = req.query.separator ?? ',';
     ConnectionAPIs.#buildConnections(req, res, (err, nodes, links, total) => {
       if (err) {
-        return res.send(err);
+        return res.type('text/plain').send(err);
       }
 
       // write out the fields requested

--- a/viewer/apiHistory.js
+++ b/viewer/apiHistory.js
@@ -190,8 +190,8 @@ class HistoryAPIs {
       return res.serverError(403, 'Missing history index', 'api.history.missingIndex');
     }
 
-    if (!req.query.index.includes('history_v')) {
-      return res.serverError(403, 'Invalid history index', 'api.history.invalidIndex');
+    if (!/_history_v\d+-/.test(req.query.index)) {
+      return res.serverError(403, 'Invalid history index');
     }
 
     try {

--- a/viewer/apiHunts.js
+++ b/viewer/apiHunts.js
@@ -1008,7 +1008,7 @@ ${Config.arkimeWebURL()}sessions?expression=huntId==${huntId}&stopTime=${hunt.qu
         // clear out secret fields for users who don't have access to that hunt
         // if the user is not an admin and didn't create the hunt and isn't part of the user's list
         if (!req.user.hasRole('arkimeAdmin') && req.user.userId !== hunt.userId && !hunt.users.includes(req.user.userId)) {
-          if (!hunt.roles || (hunt.roles.length && !req.user.hasRole(hunt.roles))) {
+          if (!hunt.roles || !hunt.roles.length || !req.user.hasRole(hunt.roles)) {
             // since hunt isn't cached we can just modify
             hunt.id = '';
             hunt.search = '';

--- a/viewer/apiMisc.js
+++ b/viewer/apiMisc.js
@@ -434,7 +434,7 @@ class MiscAPIs {
       res.send({ data });
     } catch (err) {
       console.log(`ERROR - ${req.method} /%s/session/%s/cyberchef`, ArkimeUtil.sanitizeStr(req.params.nodeName), ArkimeUtil.sanitizeStr(req.params.id), util.inspect(err, false, 50));
-      return res.end('Error - ' + err);
+      return res.type('text/plain').end('Error - ' + err);
     }
   }
 

--- a/viewer/apiSessions.js
+++ b/viewer/apiSessions.js
@@ -468,7 +468,7 @@ class SessionAPIs {
       cb(null);
     }, async (err, session) => {
       if (err) {
-        return res.end('Problem loading packets for ' + ArkimeUtil.safeStr(req.params.id) + ' Error: ' + err);
+        return res.type('text/plain').end('Problem loading packets for ' + ArkimeUtil.safeStr(req.params.id) + ' Error: ' + err);
       }
       session.id = req.params.id;
       SessionAPIs.#sortFields(session);
@@ -1709,7 +1709,7 @@ class SessionAPIs {
       }, (err) => {
         if (err) {
           console.log('ERROR - Could not build query for CSV', err);
-          return res.send('Could not build query. Err: ' + err);
+          return res.type('text/plain').send('Could not build query. Err: ' + err);
         } else {
           SessionAPIs.#csvListWriter(req, res, ['end'], null, reqFields);
         }
@@ -2173,7 +2173,7 @@ class SessionAPIs {
         if (err) {
           console.log(`ERROR - ${req.method} /api/spigraphhierarchy`, util.inspect(err, false, 50));
           res.status(400);
-          return res.end(err);
+          return res.type('text/plain').end(err);
         }
 
         if (Config.debug > 2) {
@@ -2326,7 +2326,7 @@ class SessionAPIs {
       if (err) {
         res.status(403);
 
-        return res.send(err.toString());
+        return res.type('text/plain').send(err.toString());
       }
 
       const fieldDef = Config.getFieldsMap()[req.query.field];
@@ -2432,7 +2432,7 @@ class SessionAPIs {
     for (let i = 0; i < parts.length; i++) {
       const field = Config.getFieldsMap()[parts[i]];
       if (!field) {
-        return res.send(`Unknown expression ${parts[i]}\n`);
+        return res.type('text/plain').send(`Unknown expression ${parts[i]}\n`);
       }
       fields.push(field);
     }
@@ -2455,7 +2455,7 @@ class SessionAPIs {
       if (err) {
         console.log(`ERROR - ${req.method} /api/multiunique`, util.inspect(err, false, 50));
         res.status(400);
-        return res.end(err);
+        return res.type('text/plain').end(err);
       }
 
       delete query.sort;
@@ -2482,7 +2482,7 @@ class SessionAPIs {
         if (err) {
           console.log(`ERROR - ${req.method} /api/multiunique`, util.inspect(err, false, 50));
           res.status(400);
-          return res.end(err);
+          return res.type('text/plain').end(err);
         }
 
         if (Config.debug > 2) {
@@ -2663,7 +2663,7 @@ class SessionAPIs {
         }, async (err, total) => {
           if (err) {
             console.log('ERROR - Could not build query for addTags', err);
-            return res.send('Could not build query. Err: ' + err);
+            return res.type('text/plain').send('Could not build query. Err: ' + err);
           }
           if (!total) {
             return res.serverError(200, 'No sessions to add tags to', 'api.sessions.noSessionsToAddTags');
@@ -2728,7 +2728,7 @@ class SessionAPIs {
         }, async (err, total) => {
           if (err) {
             console.log('ERROR - Could not build query for removeTags', err);
-            return res.send('Could not build query. Err: ' + err);
+            return res.type('text/plain').send('Could not build query. Err: ' + err);
           }
           if (!total) {
             return res.serverError(200, 'No sessions to remove tags from', 'api.sessions.noSessionsToRemoveTags');
@@ -3310,11 +3310,11 @@ class SessionAPIs {
         if (err) {
           console.log(`ERROR - ${req.method} /api/sessions/bodyhash/%s`, ArkimeUtil.sanitizeStr(req.params.hash), util.inspect(err, false, 50));
           res.status(400);
-          res.end(err);
+          res.type('text/plain').end(err);
         } else if (sessions.error) {
           console.log(`ERROR - ${req.method} /api/sessions/bodyhash/%s`, ArkimeUtil.sanitizeStr(req.params.hash), util.inspect(sessions.error, false, 50));
           res.status(400);
-          res.end(sessions.error);
+          res.type('text/plain').end(sessions.error);
         } else {
           if (Config.debug) {
             console.log('/api/sessions/bodyhash/%s result', ArkimeUtil.sanitizeStr(req.params.hash), util.inspect(sessions, false, 50));
@@ -3330,7 +3330,7 @@ class SessionAPIs {
               SessionAPIs.#localGetItemByHash(nodeName, sessionID, hash, (err, item) => {
                 if (err) {
                   res.status(400);
-                  return res.end(err);
+                  return res.type('text/plain').end(err);
                 } else if (item) {
                   ArkimeUtil.noCache(req, res, 'application/force-download');
                   res.setHeader('content-disposition', contentDisposition(item.bodyName + '.pellet'));
@@ -3383,7 +3383,7 @@ class SessionAPIs {
     SessionAPIs.#localGetItemByHash(req.params.nodeName, req.params.id, req.params.hash, (err, item) => {
       if (err) {
         res.status(400);
-        return res.end(err);
+        return res.type('text/plain').end(err);
       } else if (item) {
         ArkimeUtil.noCache(req, res, 'application/force-download');
         res.setHeader('content-disposition', contentDisposition(item.bodyName + '.pellet'));

--- a/viewer/apiUsers.js
+++ b/viewer/apiUsers.js
@@ -293,7 +293,7 @@ class UserAPIs {
     // find the custom column configuration to update
     for (let i = 0, len = user.columnConfigs.length; i < len; i++) {
       if (result.layoutName === user.columnConfigs[i].name) {
-        user.columnConfigs[i] = req.body;
+        user.columnConfigs[i] = { name: req.body.name, columns: req.body.columns, order: req.body.order };
         return { success: true, layout: req.body, user };
       }
     }
@@ -321,7 +321,7 @@ class UserAPIs {
     // find the custom column configuration to update
     for (let i = 0, len = user.infoFieldConfigs.length; i < len; i++) {
       if (result.layoutName === user.infoFieldConfigs[i].name) {
-        user.infoFieldConfigs[i] = req.body;
+        user.infoFieldConfigs[i] = { name: req.body.name, fields: req.body.fields };
         return { success: true, layout: req.body, user };
       }
     }
@@ -350,7 +350,7 @@ class UserAPIs {
     // find the custom spiview layout to update
     for (let i = 0, len = user.spiviewFieldConfigs.length; i < len; i++) {
       if (result.layoutName === user.spiviewFieldConfigs[i].name) {
-        user.spiviewFieldConfigs[i] = req.body;
+        user.spiviewFieldConfigs[i] = { name: req.body.name, fields: req.body.fields };
         return { success: true, layout: req.body, user };
       }
     }


### PR DESCRIPTION
Capture:
- Fix crash when corruptSavePcap re-dispatches packets that already exceeded tunnelDepth limit — reset tunnelDepth before CORRUPT ethernet callback so mProtocol gets set (fixes NULL deref)
- Fix js0n bounds check: callers pass sizeof(out) in bytes but js0n used it as element count, making limit 4x too generous (ALW)
- Fix wise.c domain string corruption: restore colon before two early-return paths in wise_lookup_domain
- Right-size TLS JA3 stack buffers based on protocol constraints (ja3 30000→13000, eja3 10000→13000, ecja3 10000→13000, ecfja3 1000→1024)
- Prevent symlink attacks in writer-simple: unlink before open with O_EXCL to avoid TOCTOU races on pcap output files
- Enlarge AWS credential buffers from 100 to 256 in S3/SQS readers
- Use dynamic allocation for S3 escape and continuation token URIs to prevent truncation with long tokens
- Improve signal handler safety: set exit handler first in controlc and terminate so double-signal always terminates

Viewer:
- Extend prototype pollution middleware to check req.body
- Set Content-Type text/plain on error responses across CSV, session, connection, cyberchef, bodyhash, spigraph, and tag endpoints to prevent browsers from interpreting error text as HTML
- Prevent mass-assignment in user layout update endpoints by whitelisting allowed fields from req.body
- Stricter regex validation for history index parameter
- Fix hunt role access check: !arr.length was truthy for empty arrays

Tests:
- Add coverage for text/plain error responses and updated endpoints

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
