### PR TITLE
Security: input type validation and mass assignment fixes

### DIFF
--- a/common/auth.js
+++ b/common/auth.js
@@ -293,7 +293,7 @@ class Auth {
         name: 'ARKIME-SID',
         secret: Auth.passwordSecret + Auth.#serverSecret,
         resave: false,
-        saveUninitialized: true,
+        saveUninitialized: false,
         cookie: { path: Auth.#basePath, secure: Auth.#authConfig.cookieSecure, sameSite: Auth.#authConfig.cookieSameSite ?? 'Lax', maxAge: 24 * 60 * 60 * 1000, httpOnly: true },
         store: new ESStore({ })
       }));

--- a/common/notifier.js
+++ b/common/notifier.js
@@ -193,6 +193,14 @@ class Notifier {
       }
     }
 
+    if (notifier.roles !== undefined && !ArkimeUtil.isStringArray(notifier.roles)) {
+      return 'Roles field must be an array of strings';
+    }
+
+    if (notifier.users !== undefined && !ArkimeUtil.isString(notifier.users, 0)) {
+      return 'Users field must be a string';
+    }
+
     return;
   }
 
@@ -340,22 +348,30 @@ class Notifier {
     }
 
     // add user and created date
-    req.body.user = req.user.userId;
-    req.body.created = Math.floor(Date.now() / 1000);
+    const doc = {
+      name: req.body.name,
+      type: req.body.type,
+      fields: req.body.fields,
+      on: !!req.body.on,
+      alerts: req.body.alerts ?? Notifier.#defaultAlerts,
+      roles: req.body.roles,
+      user: req.user.userId,
+      created: Math.floor(Date.now() / 1000)
+    };
 
     // comma/newline separated value -> array of values
     let users = ArkimeUtil.commaOrNewlineStringToArray(req.body.users || '');
     users = await User.validateUserIds(users);
-    req.body.users = users.validUsers;
+    doc.users = users.validUsers;
 
     try {
-      const id = await Notifier.createNotifier(req.body);
+      const id = await Notifier.createNotifier(doc);
 
-      req.body.id = id;
-      req.body.users = req.body.users.join(',');
+      doc.id = id;
+      doc.users = doc.users.join(',');
       return res.json({
         success: true,
-        notifier: req.body,
+        notifier: doc,
         text: 'Created notifier!',
         invalidUsers: users.invalidUsers
       });

--- a/tests/api-hunt.t
+++ b/tests/api-hunt.t
@@ -1,4 +1,4 @@
-use Test::More tests => 345;
+use Test::More tests => 349;
 use Cwd;
 use URI::Escape;
 use ArkimeTest;
@@ -115,6 +115,16 @@ my $hToken = getTokenCookie('sac-huntuser');
   $json = viewerPostToken("/api/hunt?arkimeRegressionUser=anonymous", '{"totalSessions":1,"name":"test hunt 18","size":"50","search":"test search text","searchType":"ascii","type":"raw","src":true,"dst":true,"query":{"startTime":18000,"stopTime":1536872891}, "users": [false]}', $token);
   is($json->{success}, 0, "users array not string");
   is($json->{i18n}, "api.hunts.usersMustBeString", "users array not string i18n");
+
+# Bad description (object)
+  $json = viewerPostToken("/api/hunt?arkimeRegressionUser=anonymous", '{"totalSessions":1,"name":"test hunt desc1","size":"50","search":"test search text","searchType":"ascii","type":"raw","src":true,"dst":true,"query":{"startTime":18000,"stopTime":1536872891},"description":{"evil":"object"}}', $token);
+  is($json->{success}, 0, "create hunt with object description fails");
+  is($json->{text}, "Description must be a string", "create hunt object description error message");
+
+# Bad description (array)
+  $json = viewerPostToken("/api/hunt?arkimeRegressionUser=anonymous", '{"totalSessions":1,"name":"test hunt desc2","size":"50","search":"test search text","searchType":"ascii","type":"raw","src":true,"dst":true,"query":{"startTime":18000,"stopTime":1536872891},"description":["arr"]}', $token);
+  is($json->{success}, 0, "create hunt with array description fails");
+  is($json->{text}, "Description must be a string", "create hunt array description error message");
 
 # Make sure no hunts
   my $hunts = viewerGet("/api/hunts?all");

--- a/tests/api-multies.t
+++ b/tests/api-multies.t
@@ -1,4 +1,4 @@
-use Test::More tests => 37;
+use Test::More tests => 43;
 use Cwd;
 use URI::Escape;
 use ArkimeTest;
@@ -106,3 +106,21 @@ my $json;
     $json = mesPost("/MULTIPREFIX_sessions3-141015/_search?preference=primary_first&ignore_unavailable=true&rest_total_hits_as_int=true", '{"from": 100, "size":20000}');
     is (scalar @{$json->{hits}->{hits}}, 0);
     cmp_ok($json->{hits}->{total}, '>=', 6, "sessions count is at least 6");
+
+# invalid JSON body - simpleGather1Cluster
+    my $response = $ArkimeTest::userAgent->post("http://$ArkimeTest::host:8200/_tasks/_cancel?cluster=test", Content => "NOT_JSON");
+    is($response->code, 400, "invalid JSON body returns 400 for simpleGather1Cluster");
+    my $body = from_json($response->content);
+    is($body->{error}, "Invalid JSON body", "invalid JSON body error message for simpleGather1Cluster");
+
+# invalid JSON body - _update route
+    $response = $ArkimeTest::userAgent->post("http://$ArkimeTest::host:8200/MULTIPREFIX_stats/_update/foobar", Content => "NOT_JSON");
+    is($response->code, 400, "invalid JSON body returns 400 for _update");
+    $body = from_json($response->content);
+    is($body->{error}, "Invalid JSON body", "invalid JSON body error message for _update");
+
+# invalid JSON body - _search route
+    $response = $ArkimeTest::userAgent->post("http://$ArkimeTest::host:8200/MULTIPREFIX_stats/_search", Content => "NOT_JSON");
+    is($response->code, 400, "invalid JSON body returns 400 for _search");
+    $body = from_json($response->content);
+    is($body->{error}, "Invalid JSON body", "invalid JSON body error message for _search");

--- a/tests/api-notifiers.t
+++ b/tests/api-notifiers.t
@@ -1,4 +1,4 @@
-use Test::More tests => 77;
+use Test::More tests => 94;
 use Cwd;
 use URI::Escape;
 use ArkimeTest;
@@ -82,9 +82,53 @@ viewerGet("/regressionTests/deleteAllNotifiers");
   is($json->{notifier}->{user}, "anonymous", "user field set");
   ok(exists $json->{notifier}->{created}, "created field was set");
 
-# update notifier requires admin access
+# mass assignment - extra fields should not be stored
+  $json = viewerPostToken("/api/notifier", '{"name":"testevil","type":"slack","fields":[{"name":"slackWebhookUrl","value":"evilurl"}],"evil":"injected"}', $token);
+  ok($json->{success}, "notifier with extra field creates ok");
+  my $evilId = $json->{notifier}->{id};
+  ok(!exists $json->{notifier}->{evil}, "extra field not in create response");
+  $notifiers = viewerGetToken("/api/notifiers", $token);
+  my ($evilNotifier) = grep { $_->{id} eq $evilId } @{$notifiers};
+  ok(!exists $evilNotifier->{evil}, "extra field not stored in notifier");
+  viewerDeleteToken("/api/notifier/$evilId", $token);
+
+# roles validation - create with non-array roles should fail
+  $json = viewerPostToken("/api/notifier", '{"name":"badroles","type":"slack","fields":[{"name":"slackWebhookUrl","value":"test"}],"roles":"notanarray"}', $token);
+  ok(!$json->{success}, "create notifier with string roles fails");
+  is($json->{text}, "Roles field must be an array of strings", "create string roles error message");
+
+# roles validation - create with array of non-strings should fail
+  $json = viewerPostToken("/api/notifier", '{"name":"badroles2","type":"slack","fields":[{"name":"slackWebhookUrl","value":"test"}],"roles":[123,456]}', $token);
+  ok(!$json->{success}, "create notifier with non-string array roles fails");
+  is($json->{text}, "Roles field must be an array of strings", "create non-string array roles error message");
+
+# roles validation - update with non-array roles should fail
+  $json = viewerPutToken("/api/notifier/$id1", '{"name":"slack1","type":"slack","fields":[{"name":"slackWebhookUrl","value":"test"}],"roles":{"bad":"object"}}', $token);
+  ok(!$json->{success}, "update notifier with object roles fails");
+  is($json->{text}, "Roles field must be an array of strings", "update object roles error message");
+
   $json = viewerPutToken("/api/notifier/$id1?arkimeRegressionUser=sac-notadmin", '{}', $notAdminToken);
   is($json->{text}, "You do not have permission to access this resource", "update notifier requires admin");
+
+# users validation - create with array users should fail
+  $json = viewerPostToken("/api/notifier", '{"name":"badusers","type":"slack","fields":[{"name":"slackWebhookUrl","value":"test"}],"users":["arr"]}', $token);
+  ok(!$json->{success}, "create notifier with array users fails");
+  is($json->{text}, "Users field must be a string", "create array users error message");
+
+# users validation - create with object users should fail
+  $json = viewerPostToken("/api/notifier", '{"name":"badusers2","type":"slack","fields":[{"name":"slackWebhookUrl","value":"test"}],"users":{"bad":"obj"}}', $token);
+  ok(!$json->{success}, "create notifier with object users fails");
+  is($json->{text}, "Users field must be a string", "create object users error message");
+
+# users validation - update with array users should fail
+  $json = viewerPutToken("/api/notifier/$id1", '{"name":"slack1","type":"slack","fields":[{"name":"slackWebhookUrl","value":"test"}],"users":["arr"]}', $token);
+  ok(!$json->{success}, "update notifier with array users fails");
+  is($json->{text}, "Users field must be a string", "update array users error message");
+
+# users validation - update with object users should fail
+  $json = viewerPutToken("/api/notifier/$id1", '{"name":"slack1","type":"slack","fields":[{"name":"slackWebhookUrl","value":"test"}],"users":{"bad":"obj"}}', $token);
+  ok(!$json->{success}, "update notifier with object users fails");
+  is($json->{text}, "Users field must be a string", "update object users error message");
 
 # update notifier needs valid id
   $json = viewerPutToken("/api/notifier/badid", '{"name":"hi","fields":[{"name":"slackWebhookUrl","value":"test"}],"type":"slack"}', $token);

--- a/tests/api-sessions.t
+++ b/tests/api-sessions.t
@@ -8,6 +8,7 @@ use Data::Dumper;
 use strict;
 
 my $pwd = "*/pcap";
+my $token = getTokenCookie();
 
 sub testMulti {
     my ($json, $mjson, $url) = @_;
@@ -287,15 +288,15 @@ tcp,1386004309468,1386004309478,10.180.156.185,53533,US,10.180.156.249,1080,US,2
     is($json->{i18n}, "api.sessions.missingIds", "send sessions missing ids i18n");
 
 # Test errors for /api/sessions/send
-    $json = viewerPost("/api/sessions/send", '');
+    $json = viewerPostToken("/api/sessions/send", '', $token);
     is($json->{success}, 0, "send all missing cluster");
     is($json->{i18n}, "api.sessions.missingCluster", "send all missing cluster i18n");
 
-    $json = viewerPost("/api/sessions/send", "cluster=unknown");
+    $json = viewerPostToken("/api/sessions/send", "wrongparam=unknown", $token);
     is($json->{success}, 0, "send all cluster param missing cluster");
     is($json->{i18n}, "api.sessions.missingCluster", "send all cluster param missing cluster i18n");
 
-    $json = viewerPost("/api/sessions/send", "remoteCluster=unknown");
+    $json = viewerPostToken("/api/sessions/send", "remoteCluster=unknown", $token);
     is($json->{success}, 0, "send all unknown cluster");
     is($json->{i18n}, "api.sessions.unknownCluster", "send all unknown cluster i18n");
 

--- a/tests/api-shareables.t
+++ b/tests/api-shareables.t
@@ -1,4 +1,4 @@
-use Test::More tests => 110;
+use Test::More tests => 121;
 use ArkimeTest;
 use JSON;
 use Test::Differences;
@@ -341,6 +341,41 @@ $info = viewerPutToken("/api/shareable/${idOwn}?arkimeRegressionUser=sac-test1",
 ok($info->{success}, "creator can still edit");
 $info = viewerDeleteToken("/api/shareable/${idOwn}?arkimeRegressionUser=sac-test1", $token);
 ok($info->{success}, "creator can delete");
+
+# --- data field type validation tests ---
+
+# create shareable with string data should fail
+$info = viewerPostToken("/api/shareable?arkimeRegressionUser=sac-test1", '{"name":"bad_data1","type":"test","data":"not-an-object"}', $token);
+ok(!$info->{success}, "create shareable with string data fails");
+is($info->{text}, "Data must be an object", "create string data error message");
+
+# create shareable with array data should fail
+$info = viewerPostToken("/api/shareable?arkimeRegressionUser=sac-test1", '{"name":"bad_data2","type":"test","data":["bad"]}', $token);
+ok(!$info->{success}, "create shareable with array data fails");
+is($info->{text}, "Data must be an object", "create array data error message");
+
+# create shareable with valid object data should succeed
+$info = viewerPostToken("/api/shareable?arkimeRegressionUser=sac-test1", '{"name":"good_data","type":"test","data":{"key":"value"}}', $token);
+ok($info->{success}, "create shareable with object data succeeds");
+my $idData = $info->{id};
+
+# update shareable with number data should fail
+$info = viewerPutToken("/api/shareable/${idData}?arkimeRegressionUser=sac-test1", '{"name":"good_data","data":123}', $token);
+ok(!$info->{success}, "update shareable with number data fails");
+is($info->{text}, "Data must be an object", "update number data error message");
+
+# update shareable with non-string name should fail
+$info = viewerPutToken("/api/shareable/${idData}?arkimeRegressionUser=sac-test1", '{"name":123}', $token);
+ok(!$info->{success}, "update shareable with number name fails");
+is($info->{text}, "Name must be a string", "update number name error message");
+
+# update shareable with object name should fail
+$info = viewerPutToken("/api/shareable/${idData}?arkimeRegressionUser=sac-test1", '{"name":{"bad":"object"}}', $token);
+ok(!$info->{success}, "update shareable with object name fails");
+is($info->{text}, "Name must be a string", "update object name error message");
+
+# cleanup data test shareable
+viewerDeleteToken("/api/shareable/${idData}?arkimeRegressionUser=sac-test1", $token);
 
 # cleanup pagination and validation shareables
 viewerDeleteToken("/api/shareable/${idPA}?arkimeRegressionUser=sac-test1", $token);

--- a/tests/api-shortcuts.t
+++ b/tests/api-shortcuts.t
@@ -1,4 +1,4 @@
-use Test::More tests => 121;
+use Test::More tests => 125;
 use Cwd;
 use URI::Escape;
 use ArkimeTest;
@@ -300,6 +300,21 @@ for (my $i=0; $i < scalar(@{$testsCluster}); $i++) { # indexes are different
 }
 
 eq_or_diff($testsCluster, $tests2Cluster, "cluster sync failed", { context => 2 });
+
+# --- Description type validation tests ---
+
+# create shortcut with object description should fail
+$json = viewerPostToken("/api/shortcut", '{"name":"bad_desc_create","type":"ip","value":"1.2.3.4","description":{"evil":"object"}}', $token);
+ok(!$json->{success}, "create shortcut with object description fails");
+is($json->{text}, "Description must be a string", "create object description error message");
+
+# update shortcut with object description should fail
+my $goodShortcut = viewerPostToken("/api/shortcut", '{"name":"good_desc_test","type":"ip","value":"1.2.3.4","description":"valid"}', $token);
+my $goodId = $goodShortcut->{shortcut}->{id};
+$json = viewerPutToken("/api/shortcut/$goodId", '{"name":"good_desc_test","type":"ip","value":"1.2.3.4","description":["array","desc"]}', $token);
+ok(!$json->{success}, "update shortcut with array description fails");
+is($json->{text}, "Description must be a string", "update array description error message");
+viewerDeleteToken("/api/shortcut/$goodId", $token);
 
 # --- Extra field sanitization tests ---
 

--- a/tests/api-users.t
+++ b/tests/api-users.t
@@ -1,7 +1,7 @@
 # Many of these test user/roles start with sac- (skip auto create) because
 # otherwise viewer in regression mode would auto create the user.
 # Some day should remove all autocreate code.
-use Test::More tests => 257;
+use Test::More tests => 260;
 use Cwd;
 use URI::Escape;
 use ArkimeTest;
@@ -166,6 +166,16 @@ anonymous,,true,true,false,"arkimeAdmin, cont3xtUser, parliamentUser, usersAdmin
     $json = viewerGetToken("/api/user/settings?arkimeRegressionUser=sac-test1", $test1Token);
     ok(!exists $json->{__proto__}, "no prototype pollution");
     eq_or_diff($json->{logo}, "testlogo.png");
+
+# update user settings - object values should be silently skipped
+    $json = viewerPostToken("/api/user/settings?arkimeRegressionUser=sac-test1", '{"logo":{"bad":"object"}}', $test1Token);
+    is($json->{success}, 1, "update user settings with object value succeeds");
+    $json = viewerGetToken("/api/user/settings?arkimeRegressionUser=sac-test1", $test1Token);
+    ok(!defined $json->{logo} || ref($json->{logo}) eq '', "logo object was not stored");
+
+# restore logo to string value
+    $json = viewerPostToken("/api/user/settings?arkimeRegressionUser=sac-test1", '{"logo":"testlogo.png"}', $test1Token);
+    is($json->{success}, 1, "restore logo setting");
 
 # user css - no theme returns 404
     my $cssResponse = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8123/api/user.css?arkimeRegressionUser=sac-test1");

--- a/tests/api-views.t
+++ b/tests/api-views.t
@@ -1,4 +1,4 @@
-use Test::More tests => 76;
+use Test::More tests => 93;
 use ArkimeTest;
 use JSON;
 use Test::Differences;
@@ -248,6 +248,56 @@ is($info->{data}->[0]->{name}, "gamma", "pagination offset returns gamma");
 # non-admin all=true should not show other users' views
 $info = viewerGet("/api/views?arkimeRegressionUser=sac-test2&all=true");
 is($info->{recordsTotal}, 0, "non-admin all=true doesn't show other users views");
+
+# --- sessionsColConfig type validation tests ---
+
+# create view with string sessionsColConfig should fail
+$info = viewerPostToken("/api/view?arkimeRegressionUser=sac-test1", '{"name":"bad_col_view","expression":"ip.src==1.2.3.4","sessionsColConfig":"not-an-object"}', $token);
+ok(!$info->{success}, "create view with string sessionsColConfig fails");
+is($info->{text}, "sessionsColConfig must be an object", "create string sessionsColConfig error message");
+
+# create view with array sessionsColConfig should fail
+$info = viewerPostToken("/api/view?arkimeRegressionUser=sac-test1", '{"name":"bad_col_view2","expression":"ip.src==1.2.3.4","sessionsColConfig":["bad"]}', $token);
+ok(!$info->{success}, "create view with array sessionsColConfig fails");
+is($info->{text}, "sessionsColConfig must be an object", "create array sessionsColConfig error message");
+
+# create view with valid object sessionsColConfig should succeed
+$info = viewerPostToken("/api/view?arkimeRegressionUser=sac-test1", '{"name":"good_col_view","expression":"ip.src==1.2.3.4","sessionsColConfig":{"visibleHeaders":["firstPacket"]}}', $token);
+ok($info->{success}, "create view with object sessionsColConfig succeeds");
+my $colViewId = $info->{view}->{id};
+
+# update view with string sessionsColConfig should fail
+$info = viewerPutToken("/api/view/${colViewId}?arkimeRegressionUser=sac-test1", '{"name":"good_col_view","expression":"ip.src==1.2.3.4","sessionsColConfig":123}', $token);
+ok(!$info->{success}, "update view with number sessionsColConfig fails");
+is($info->{text}, "sessionsColConfig must be an object", "update number sessionsColConfig error message");
+
+# create view with array users should fail
+$info = viewerPostToken("/api/view?arkimeRegressionUser=sac-test1", '{"name":"bad_users_view","expression":"ip.src==1.2.3.4","users":["sac-test2"]}', $token);
+ok(!$info->{success}, "create view with array users fails");
+is($info->{text}, "Users field must be a string", "create array users error message");
+
+# create view with object users should fail
+$info = viewerPostToken("/api/view?arkimeRegressionUser=sac-test1", '{"name":"bad_users_view2","expression":"ip.src==1.2.3.4","users":{"bad":"obj"}}', $token);
+ok(!$info->{success}, "create view with object users fails");
+is($info->{text}, "Users field must be a string", "create object users error message");
+
+# update view with array users should fail
+$info = viewerPutToken("/api/view/${colViewId}?arkimeRegressionUser=sac-test1", '{"name":"good_col_view","expression":"ip.src==1.2.3.4","users":["sac-test2"]}', $token);
+ok(!$info->{success}, "update view with array users fails");
+is($info->{text}, "Users field must be a string", "update array users error message");
+
+# update view with non-string user (owner) should fail
+$info = viewerPutToken("/api/view/${colViewId}?arkimeRegressionUser=sac-test1", '{"name":"good_col_view","expression":"ip.src==1.2.3.4","user":123}', $token);
+ok(!$info->{success}, "update view with number user (owner) fails");
+is($info->{text}, "User field must be a string", "update number user error message");
+
+# update view with object user (owner) should fail
+$info = viewerPutToken("/api/view/${colViewId}?arkimeRegressionUser=sac-test1", '{"name":"good_col_view","expression":"ip.src==1.2.3.4","user":{"bad":"obj"}}', $token);
+ok(!$info->{success}, "update view with object user (owner) fails");
+is($info->{text}, "User field must be a string", "update object user error message");
+
+# cleanup sessionsColConfig test view
+viewerDeleteToken("/api/view/${colViewId}?arkimeRegressionUser=sac-test1", $token);
 
 # cleanup sort/search/pagination views
 viewerDeleteToken("/api/view/${idA}?arkimeRegressionUser=sac-test1", $token);

--- a/viewer/apiHunts.js
+++ b/viewer/apiHunts.js
@@ -875,6 +875,10 @@ ${Config.arkimeWebURL()}sessions?expression=huntId==${huntId}&stopTime=${hunt.qu
       return res.serverError(403, 'Users field must be a string', 'api.hunts.usersMustBeString');
     }
 
+    if (req.body.description !== undefined && !ArkimeUtil.isString(req.body.description, 0)) {
+      return res.serverError(403, 'Description must be a string');
+    }
+
     const now = Math.floor(Date.now() / 1000);
 
     req.body.name = req.body.name.replace(/[^-a-zA-Z0-9_: ]/g, '');

--- a/viewer/apiShareables.js
+++ b/viewer/apiShareables.js
@@ -121,6 +121,10 @@ class ShareableAPIs {
       editUsers = validatedEditUsers.validUsers;
     }
 
+    if (req.body.data !== undefined && (typeof req.body.data !== 'object' || Array.isArray(req.body.data) || req.body.data === null)) {
+      return res.serverError(403, 'Data must be an object');
+    }
+
     const doc = {
       name: req.body.name,
       description: req.body.description,
@@ -208,6 +212,10 @@ class ShareableAPIs {
         return res.serverError(403, 'Cannot change shareable type', 'api.shareables.cannotChangeType');
       }
 
+      if (req.body.name !== undefined && !ArkimeUtil.isString(req.body.name)) {
+        return res.serverError(403, 'Name must be a string', 'api.shareables.nameMustBeString');
+      }
+
       if (req.body.description !== undefined && !ArkimeUtil.isString(req.body.description)) {
         return res.serverError(403, 'Description must be a string', 'api.shareables.descriptionMustBeString');
       }
@@ -225,6 +233,10 @@ class ShareableAPIs {
       if (editUsers.length > 0) {
         const validatedEditUsers = await User.validateUserIds(editUsers);
         editUsers = validatedEditUsers.validUsers;
+      }
+
+      if (req.body.data !== undefined && (typeof req.body.data !== 'object' || Array.isArray(req.body.data) || req.body.data === null)) {
+        return res.serverError(403, 'Data must be an object');
       }
 
       const doc = {

--- a/viewer/apiShortcuts.js
+++ b/viewer/apiShortcuts.js
@@ -254,6 +254,10 @@ class ShortcutAPIs {
       return res.serverError(403, 'Users field must be a string', 'api.shortcuts.usersMustBeString');
     }
 
+    if (req.body.description !== undefined && !ArkimeUtil.isString(req.body.description, 0)) {
+      return res.serverError(403, 'Description must be a string');
+    }
+
     req.body.name = req.body.name.replace(/[^-a-zA-Z0-9_]/g, '');
 
     // return nothing if we can't find the user
@@ -361,6 +365,10 @@ class ShortcutAPIs {
 
     if (req.body.users !== undefined && !ArkimeUtil.isString(req.body.users, 0)) {
       return res.serverError(403, 'Users field must be a string', 'api.shortcuts.usersMustBeString');
+    }
+
+    if (req.body.description !== undefined && !ArkimeUtil.isString(req.body.description, 0)) {
+      return res.serverError(403, 'Description must be a string');
     }
 
     const sentShortcut = {

--- a/viewer/apiUsers.js
+++ b/viewer/apiUsers.js
@@ -576,7 +576,11 @@ class UserAPIs {
     req.settingUser.settings = ['ms', 'logo', 'theme', 'timezone', 'spiGraph', 'numPackets', 'infoFields', 'manualQuery', 'detailFormat',
       'connSrcField', 'connDstField', 'sortColumn', 'sortDirection', 'showTimestamps', 'connNodeFields',
       'connLinkFields', 'timelineDataFilters', 'hideTags', 'shiftyEyes'].reduce((obj, key) => {
-      obj[key] = req.body[key];
+      const val = req.body[key];
+      if (val !== undefined && val !== null && typeof val === 'object' && !Array.isArray(val)) {
+        return obj;
+      }
+      obj[key] = val;
       return obj;
     }, {});
 

--- a/viewer/apiViews.js
+++ b/viewer/apiViews.js
@@ -112,6 +112,18 @@ class ViewAPIs {
       return res.serverError(403, 'Missing view expression', 'api.views.missingExpression');
     }
 
+    if (req.body.roles !== undefined && !ArkimeUtil.isStringArray(req.body.roles)) {
+      return res.serverError(403, 'Roles field must be an array of strings');
+    }
+
+    if (req.body.editRoles !== undefined && !ArkimeUtil.isStringArray(req.body.editRoles)) {
+      return res.serverError(403, 'Edit roles field must be an array of strings');
+    }
+
+    if (req.body.users !== undefined && !ArkimeUtil.isString(req.body.users, 0)) {
+      return res.serverError(403, 'Users field must be a string');
+    }
+
     const user = req.settingUser;
 
     // comma/newline separated value -> array of values
@@ -128,6 +140,9 @@ class ViewAPIs {
     };
 
     if (req.body.sessionsColConfig !== undefined) {
+      if (typeof req.body.sessionsColConfig !== 'object' || Array.isArray(req.body.sessionsColConfig) || req.body.sessionsColConfig === null) {
+        return res.serverError(403, 'sessionsColConfig must be an object');
+      }
       doc.sessionsColConfig = req.body.sessionsColConfig;
     }
 
@@ -191,6 +206,22 @@ class ViewAPIs {
       return res.serverError(403, 'Missing view expression', 'api.views.missingExpression');
     }
 
+    if (req.body.roles !== undefined && !ArkimeUtil.isStringArray(req.body.roles)) {
+      return res.serverError(403, 'Roles field must be an array of strings');
+    }
+
+    if (req.body.editRoles !== undefined && !ArkimeUtil.isStringArray(req.body.editRoles)) {
+      return res.serverError(403, 'Edit roles field must be an array of strings');
+    }
+
+    if (req.body.users !== undefined && !ArkimeUtil.isString(req.body.users, 0)) {
+      return res.serverError(403, 'Users field must be a string');
+    }
+
+    if (req.body.user !== undefined && !ArkimeUtil.isString(req.body.user)) {
+      return res.serverError(403, 'User field must be a string');
+    }
+
     try {
       const dbViewSource = await Db.getView(req.params.id);
 
@@ -204,6 +235,9 @@ class ViewAPIs {
       };
 
       if (req.body.sessionsColConfig !== undefined) {
+        if (typeof req.body.sessionsColConfig !== 'object' || Array.isArray(req.body.sessionsColConfig) || req.body.sessionsColConfig === null) {
+          return res.serverError(403, 'sessionsColConfig must be an object');
+        }
         doc.sessionsColConfig = req.body.sessionsColConfig;
       } else if (dbViewSource.sessionsColConfig !== undefined) {
         doc.sessionsColConfig = dbViewSource.sessionsColConfig;

--- a/viewer/multies.js
+++ b/viewer/multies.js
@@ -375,7 +375,12 @@ function simpleGather1Cluster (req, res) {
 
   // Remove cluster from body if there
   if (req._body) {
-    const body = JSON.parse(req.body);
+    let body;
+    try {
+      body = JSON.parse(req.body);
+    } catch (e) {
+      return res.status(400).send({ error: 'Invalid JSON body' });
+    }
     delete body.cluster;
     req.body = JSON.stringify(body);
   }
@@ -1051,7 +1056,7 @@ app.post(['/:index/:type/_search', '/:index/_search'], function (req, res) {
   try {
     search = JSON.parse(req.body);
   } catch (e) {
-    return res.status(400).send('Invalid JSON body');
+    return res.status(400).send({ error: 'Invalid JSON body' });
   }
 
   if (+search.size + (+search.from || 0) > 10000) {
@@ -1147,7 +1152,12 @@ function msearch (req, res) {
 }
 
 app.post(['/:index/:type/:id/_update', '/:index/_update/:id'], async (req, res) => {
-  const body = JSON.parse(req.body);
+  let body;
+  try {
+    body = JSON.parse(req.body);
+  } catch (e) {
+    return res.status(400).send({ error: 'Invalid JSON body' });
+  }
   const cluster = req.query.cluster ?? body.cluster;
   if (cluster && clusters[cluster]) {
     const node = clusters[cluster];

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -1894,6 +1894,7 @@ app.post( // sessions send to node endpoint - used by CronAPIs.#sendSessionsList
 
 app.post( // sessions send endpoint - used by vueapp
   ['/api/sessions/send'],
+  [ArkimeUtil.noCacheJson, checkCookieToken, logAction()],
   SessionAPIs.sendSessions
 );
 


### PR DESCRIPTION
- Validate roles, users, description, data, name field types across views, notifiers, shortcuts, shareables, hunts
- Fix notifier create mass assignment (allowlist known fields)
- Fix user settings to skip plain object values
- Fix view sessionsColConfig/users/user owner type validation
- Fix multies.js JSON.parse try/catch and error format
- Add CSRF middleware to /api/sessions/send
- Set saveUninitialized: false in session config
- Add tests for all fixes across 8 test files

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
