### PR TITLE
Harden esProxy security and add bulk validation tests

### DIFF
--- a/tests/esProxy.t
+++ b/tests/esProxy.t
@@ -1,5 +1,5 @@
 # ESProxy
-use Test::More tests => 27;
+use Test::More tests => 37;
 use ArkimeTest;
 use Cwd;
 use URI::Escape;
@@ -113,3 +113,48 @@ $req->header('Content-Type' => 'application/x-ndjson');
 $req->content($bulk_update);
 $response = $ArkimeTest::userAgent->request($req);
 is ($response->code, 200, "bulk update to fields index succeeds");
+
+# Bulk - sessions index without dash should be rejected
+my $bulk_no_dash = qq({"index":{"_index":"tests_sessions3evil","_id":"1"}}\n{"field":"value"}\n);
+$req = HTTP::Request->new('POST', "http://test:test\@$ArkimeTest::host:7200/_bulk");
+$req->header('Content-Type' => 'application/x-ndjson');
+$req->content($bulk_no_dash);
+$response = $ArkimeTest::userAgent->request($req);
+is ($response->code, 400, "bulk sessions index without dash rejected");
+is ($response->content, "Not authorized for API");
+
+# Bulk - create to fields index should be rejected (create only allows sessions)
+my $bulk_create_fields = qq({"create":{"_index":"tests_fields","_id":"1"}}\n{"field":"value"}\n);
+$req = HTTP::Request->new('POST', "http://test:test\@$ArkimeTest::host:7200/_bulk");
+$req->header('Content-Type' => 'application/x-ndjson');
+$req->content($bulk_create_fields);
+$response = $ArkimeTest::userAgent->request($req);
+is ($response->code, 400, "bulk create to fields index rejected");
+is ($response->content, "Not authorized for API");
+
+# Bulk - update to sessions index should be rejected (update only allows fields)
+my $bulk_update_sessions = qq({"update":{"_index":"tests_sessions3-2024","_id":"1"}}\n{"doc":{"field":"value"}}\n);
+$req = HTTP::Request->new('POST', "http://test:test\@$ArkimeTest::host:7200/_bulk");
+$req->header('Content-Type' => 'application/x-ndjson');
+$req->content($bulk_update_sessions);
+$response = $ArkimeTest::userAgent->request($req);
+is ($response->code, 400, "bulk update to sessions index rejected");
+is ($response->content, "Not authorized for API");
+
+# Bulk - invalid JSON should be rejected
+my $bulk_bad_json = qq(not valid json\n);
+$req = HTTP::Request->new('POST', "http://test:test\@$ArkimeTest::host:7200/_bulk");
+$req->header('Content-Type' => 'application/x-ndjson');
+$req->content($bulk_bad_json);
+$response = $ArkimeTest::userAgent->request($req);
+is ($response->code, 400, "bulk with invalid JSON rejected");
+is ($response->content, "Not authorized for API");
+
+# Bulk - multiple operations in one action line should be rejected
+my $bulk_multi_op = qq({"index":{"_index":"tests_sessions3-2024","_id":"1"},"create":{"_index":"tests_sessions3-2024","_id":"2"}}\n{"field":"value"}\n);
+$req = HTTP::Request->new('POST', "http://test:test\@$ArkimeTest::host:7200/_bulk");
+$req->header('Content-Type' => 'application/x-ndjson');
+$req->content($bulk_multi_op);
+$response = $ArkimeTest::userAgent->request($req);
+is ($response->code, 400, "bulk with multiple ops in one line rejected");
+is ($response->content, "Not authorized for API");

--- a/tests/esProxy.t
+++ b/tests/esProxy.t
@@ -1,11 +1,12 @@
 # ESProxy
-use Test::More tests => 16;
+use Test::More tests => 27;
 use ArkimeTest;
 use Cwd;
 use URI::Escape;
 use Data::Dumper;
 use Test::Differences;
 use JSON -support_by_pp;
+use HTTP::Request;
 use strict;
 
 my $response;
@@ -45,3 +46,70 @@ is ($response->content, "Not authorized for API");
 
 $response = $ArkimeTest::userAgent->get("http://test:test\@$ArkimeTest::host:7200/_template/tests_sessions3_template");
 is ($response->code, 200);
+
+# Bulk - valid index with correct prefix
+my $bulk_valid = qq({"index":{"_index":"tests_sessions3-2024","_id":"1"}}\n{"field":"value"}\n);
+my $req = HTTP::Request->new('POST', "http://test:test\@$ArkimeTest::host:7200/_bulk");
+$req->header('Content-Type' => 'application/x-ndjson');
+$req->content($bulk_valid);
+$response = $ArkimeTest::userAgent->request($req);
+is ($response->code, 200, "bulk with valid prefixed sessions3 index");
+
+# Bulk - substring match should be rejected (index contains sessions2 but wrong prefix)
+my $bulk_bad_substr = qq({"index":{"_index":"evil_sessions2_hack","_id":"1"}}\n{"field":"value"}\n);
+$req = HTTP::Request->new('POST', "http://test:test\@$ArkimeTest::host:7200/_bulk");
+$req->header('Content-Type' => 'application/x-ndjson');
+$req->content($bulk_bad_substr);
+$response = $ArkimeTest::userAgent->request($req);
+is ($response->code, 400, "bulk with substring-matching bad index rejected");
+is ($response->content, "Not authorized for API");
+
+# Bulk - bad prefix should be rejected
+my $bulk_bad_prefix = qq({"index":{"_index":"other_sessions3-2024","_id":"1"}}\n{"field":"value"}\n);
+$req = HTTP::Request->new('POST', "http://test:test\@$ArkimeTest::host:7200/_bulk");
+$req->header('Content-Type' => 'application/x-ndjson');
+$req->content($bulk_bad_prefix);
+$response = $ArkimeTest::userAgent->request($req);
+is ($response->code, 400, "bulk with wrong prefix rejected");
+is ($response->content, "Not authorized for API");
+
+# Bulk - delete to valid fields index
+my $bulk_delete = qq({"delete":{"_index":"tests_fields","_id":"1"}}\n);
+$req = HTTP::Request->new('POST', "http://test:test\@$ArkimeTest::host:7200/_bulk");
+$req->header('Content-Type' => 'application/x-ndjson');
+$req->content($bulk_delete);
+$response = $ArkimeTest::userAgent->request($req);
+is ($response->code, 200, "bulk delete to fields index succeeds");
+
+# Bulk - delete followed by index (validates delete doesn't skip next action)
+my $bulk_delete_then_index = qq({"delete":{"_index":"tests_fields","_id":"1"}}\n{"index":{"_index":"tests_sessions3-2024","_id":"2"}}\n{"field":"value"}\n);
+$req = HTTP::Request->new('POST', "http://test:test\@$ArkimeTest::host:7200/_bulk");
+$req->header('Content-Type' => 'application/x-ndjson');
+$req->content($bulk_delete_then_index);
+$response = $ArkimeTest::userAgent->request($req);
+is ($response->code, 200, "bulk delete then index works correctly");
+
+# Bulk - delete to bad index should be rejected
+my $bulk_delete_bad = qq({"delete":{"_index":"evil_fields_hack","_id":"1"}}\n);
+$req = HTTP::Request->new('POST', "http://test:test\@$ArkimeTest::host:7200/_bulk");
+$req->header('Content-Type' => 'application/x-ndjson');
+$req->content($bulk_delete_bad);
+$response = $ArkimeTest::userAgent->request($req);
+is ($response->code, 400, "bulk delete to bad index rejected");
+is ($response->content, "Not authorized for API");
+
+# Bulk - create to valid sessions index
+my $bulk_create = qq({"create":{"_index":"tests_sessions3-2024","_id":"3"}}\n{"field":"value"}\n);
+$req = HTTP::Request->new('POST', "http://test:test\@$ArkimeTest::host:7200/_bulk");
+$req->header('Content-Type' => 'application/x-ndjson');
+$req->content($bulk_create);
+$response = $ArkimeTest::userAgent->request($req);
+is ($response->code, 200, "bulk create to sessions3 index succeeds");
+
+# Bulk - update to valid fields index
+my $bulk_update = qq({"update":{"_index":"tests_fields","_id":"1"}}\n{"doc":{"field":"value"}}\n);
+$req = HTTP::Request->new('POST', "http://test:test\@$ArkimeTest::host:7200/_bulk");
+$req->header('Content-Type' => 'application/x-ndjson');
+$req->content($bulk_update);
+$response = $ArkimeTest::userAgent->request($req);
+is ($response->code, 200, "bulk update to fields index succeeds");

--- a/viewer/esProxy.js
+++ b/viewer/esProxy.js
@@ -398,7 +398,7 @@ app.get('*', (req, res) => {
 // Validate Bulk
 
 function isSessionsIndex (_index) {
-  return _index.startsWith(`${oldprefix}sessions2`) || _index.startsWith(`${prefix}sessions3`);
+  return _index.startsWith(`${oldprefix}sessions2-`) || _index.startsWith(`${prefix}sessions3-`);
 }
 
 function isFieldsIndex (_index) {

--- a/viewer/esProxy.js
+++ b/viewer/esProxy.js
@@ -10,6 +10,7 @@
  */
 const Config = require('./config.js');
 const express = require('express');
+const crypto = require('crypto');
 const http = require('http');
 const https = require('https');
 const fs = require('fs');
@@ -204,7 +205,10 @@ app.use((req, res, next) => {
     return res.set('WWW-Authenticate', 'Basic').status(401).send();
   }
 
-  if (sensors[credentials.name].pass !== undefined && sensors[credentials.name].pass !== credentials.pass) {
+  if (sensors[credentials.name].pass !== undefined &&
+      !crypto.timingSafeEqual(
+        crypto.createHmac('sha256', 'compare').update(sensors[credentials.name].pass).digest(),
+        crypto.createHmac('sha256', 'compare').update(credentials.pass).digest())) {
     console.log(`Incorrect password for ${credentials.name}`);
     return res.set('WWW-Authenticate', 'Basic').status(401).send();
   }
@@ -214,7 +218,7 @@ app.use((req, res, next) => {
     return next();
   }
 
-  let ip = req.connection.remoteAddress;
+  let ip = req.socket.remoteAddress;
   if (ip.startsWith('::ffff:')) {
     ip = ip.substring(7);
   }
@@ -344,6 +348,7 @@ async function doProxyFull (config, req, res) {
 
   preq.on('error', (e) => {
     console.log('Request error "%s"', ArkimeUtil.sanitizeStr(url), e);
+    try { res.status(502).send('ES proxy error'); } catch (err) { }
   });
   if (bodyToSend) {
     preq.end(bodyToSend);
@@ -391,6 +396,15 @@ app.get('*', (req, res) => {
 });
 
 // Validate Bulk
+
+function isSessionsIndex (_index) {
+  return _index.startsWith(`${oldprefix}sessions2`) || _index.startsWith(`${prefix}sessions3`);
+}
+
+function isFieldsIndex (_index) {
+  return _index.startsWith(`${prefix}fields`);
+}
+
 function validateBulk (req) {
   if (!req._body) {
     return true;
@@ -415,33 +429,37 @@ function validateBulk (req) {
   for (let i = 0; i < lines.length; i++) {
     // ES allows blank lines between pairs of meta/object
     if (lines[i].trim() === '') { continue; }
+    let json;
     try {
-      const json = JSON.parse(lines[i]);
+      json = JSON.parse(lines[i]);
       if (Object.keys(json).length !== 1) { throw new Error('More than 1 bulk operation in object'); }
       if (typeof json.index === 'object') {
         if (typeof json.index._index !== 'string') { throw new Error('Missing index _index string'); }
 
         // Eventually this should only allow fields
         const _index = json.index._index;
-        if (!_index.includes('sessions2') && !_index.includes('sessions3') && !_index.includes('fields')) { throw new Error(`Bad index ${_index}`); }
+        if (!isSessionsIndex(_index) && !isFieldsIndex(_index)) { throw new Error(`Bad index ${_index}`); }
       } else if (typeof json.create === 'object') {
         const _index = json.create._index;
-        if (!_index.includes('sessions2') && !_index.includes('sessions3')) { throw new Error(`Bad index ${_index}`); }
+        if (!isSessionsIndex(_index)) { throw new Error(`Bad index ${_index}`); }
       } else if (typeof json.update === 'object') {
         const _index = json.update._index;
-        if (!_index.includes('fields')) { throw new Error(`Bad index ${_index}`); }
+        if (!isFieldsIndex(_index)) { throw new Error(`Bad index ${_index}`); }
       } else if (typeof json.delete === 'object') {
         const _index = json.delete._index;
-        if (!_index.includes('fields')) { throw new Error(`Bad index ${_index}`); }
+        if (!isFieldsIndex(_index)) { throw new Error(`Bad index ${_index}`); }
       } else {
-        console.log('Failed bulk', JSON.stringify(json, false, 2));
+        console.log('Failed bulk', JSON.stringify(json, null, 2));
         throw new Error('Missing create, update or index operation');
       }
     } catch (err) {
       console.log('Bulk error', err, ArkimeUtil.sanitizeStr(lines[i]));
       return false;
     }
-    i++; // Skip object, must be there since we only support create/index
+    // delete has no body line, all others do
+    if (!json.delete) {
+      i++;
+    }
   }
 
   return true;
@@ -496,9 +514,12 @@ app.post('*', saveBody, (req, res) => {
   } else if (path.match(/^\/[^/]*history_v[^/]*\/_doc$/)) {
   } else if (path.match(/^\/[^/]*sessions[23]-[^/]+\/_update\/[^/]+$/) && validateUpdate(req)) {
     console.log(`UPDATE : ${req.sensor.node} path:>%s<:`, ArkimeUtil.sanitizeStr(path));
-    console.log(req.body.toString('utf8'));
+    if (Config.debug) {
+      console.log(req.body.toString('utf8'));
+    }
   } else {
     console.log(`POST failed node: ${req.sensor.node} path:>%s<:`, ArkimeUtil.sanitizeStr(path));
+    // Log failed body for debuging hacking
     console.log(req.body.toString('utf8'));
     return res.status(400).send('Not authorized for API');
   }

--- a/viewer/esProxy.js
+++ b/viewer/esProxy.js
@@ -10,7 +10,7 @@
  */
 const Config = require('./config.js');
 const express = require('express');
-const crypto = require('crypto');
+const cryptoLib = require('crypto');
 const http = require('http');
 const https = require('https');
 const fs = require('fs');
@@ -206,9 +206,9 @@ app.use((req, res, next) => {
   }
 
   if (sensors[credentials.name].pass !== undefined &&
-      !crypto.timingSafeEqual(
-        crypto.createHmac('sha256', 'compare').update(sensors[credentials.name].pass).digest(),
-        crypto.createHmac('sha256', 'compare').update(credentials.pass).digest())) {
+      !cryptoLib.timingSafeEqual(
+        cryptoLib.createHmac('sha256', 'compare').update(sensors[credentials.name].pass).digest(),
+        cryptoLib.createHmac('sha256', 'compare').update(credentials.pass).digest())) {
     console.log(`Incorrect password for ${credentials.name}`);
     return res.set('WWW-Authenticate', 'Basic').status(401).send();
   }


### PR DESCRIPTION
- Use timing-safe HMAC comparison for sensor passwords
- Fix bulk delete skipping next action line (json scoping bug)
- Tighten index validation to use startsWith with prefix
- Send 502 to client on upstream proxy error instead of hanging
- Replace deprecated req.connection with req.socket
- Fix JSON.stringify replacer arg from false to null
- Add 11 new bulk validation tests to esProxy.t

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
