### PR TITLE
Security audit fixes for common/ JS modules

### DIFF
--- a/common/arkimeCache.js
+++ b/common/arkimeCache.js
@@ -20,7 +20,7 @@ class ArkimeCache {
   constructor (options) {
     this.cacheSize = parseInt(options.cacheSize ?? 100000);
     this.cacheTimeout = ArkimeUtil.parseTimeStr(options.cacheTimeout ?? 24 * 60 * 60);
-    this.#lru = new LRUCache({ max: this.cacheSize });
+    this.#lru = new LRUCache({ max: this.cacheSize, ttl: this.cacheTimeout * 1000 });
   }
 
   // ----------------------------------------------------------------------------
@@ -179,11 +179,20 @@ class ArkimeLMDBCache extends ArkimeCache {
 
   // ----------------------------------------------------------------------------
   async get (key) {
-    return this.store.get(key);
+    if (super.has(key)) {
+      return super.get(key);
+    }
+
+    const result = this.store.get(key);
+    if (result !== undefined) {
+      super.set(key, result);
+    }
+    return result;
   }
 
   // ----------------------------------------------------------------------------
   set (key, result) {
+    super.set(key, result);
     this.store.put(key, result);
   }
 }

--- a/common/arkimeConfig.js
+++ b/common/arkimeConfig.js
@@ -47,7 +47,7 @@ class ArkimeConfig {
 
     if (options.defaultSections === undefined) {
       console.trace('defaultSections option must be set');
-      process.exit();
+      process.exit(1);
     } else if (Array.isArray(options.defaultSections)) {
       ArkimeConfig.#defaultSections = options.defaultSections;
     } else {
@@ -224,7 +224,7 @@ class ArkimeConfig {
     if (value === undefined) {
       if (d === ArkimeConfig.exit) {
         console.log(`ERROR - ${sectionKey} not found in sections: ${sections}`);
-        process.exit();
+        process.exit(1);
       }
       if (d === ArkimeConfig.throw) {
         throw new Error(`${sectionKey} not found in sections: ${sections}`);
@@ -353,7 +353,7 @@ class ArkimeConfig {
    * Get the full config for a section
    *
    * @param {string} section - The section of the config file to return
-   * @returns {object} - A list of all the sections in the config file
+   * @returns {object} - The config object for the given section
    */
   static getSection (section) {
     return ArkimeConfig.#config[section];
@@ -513,7 +513,7 @@ class ConfigRedisSentinel {
     const redisParts = uri.split('/');
     redisParts[1] = 'stoperror';
     if (redisParts.length !== 6 || redisParts.some(p => p === '')) {
-      throw new Error(`Invalid redis-sentinel url - ${redisParts[0]}//[sentinelPassword:redisPassword@]sentinelHost[:sentinelPort][,sentinelPortN:sentinelPortN]/redisName/redisDbNum`);
+      throw new Error(`Invalid redis-sentinel url - ${redisParts[0]}//[sentinelPassword:redisPassword@]sentinelHost[:sentinelPort][,sentinelPortN:sentinelPortN]/redisName/redisDbNum/key`);
     }
     ConfigRedisSentinel.#redisKey = redisParts[5];
     ConfigRedisSentinel.#redis = ArkimeUtil.createRedisClient(uri, 'config');

--- a/common/arkimeUtil.js
+++ b/common/arkimeUtil.js
@@ -173,8 +173,8 @@ class ArkimeUtil {
   // ----------------------------------------------------------------------------
   /**
    * Create a redis client from the provided url
-   * @params {string} url - The redis url to connect to.
-   * @params {string} section - The section this redis client is being created for
+   * @param {string} url - The redis url to connect to.
+   * @param {string} section - The section this redis client is being created for
    */
   static createRedisClient (url, section) {
     url = ArkimeUtil.sanitizeStr(url);
@@ -206,10 +206,10 @@ class ArkimeUtil {
         options.sentinels.push({ host: hostport[0], port: hostport[1] || 26379 });
       }
 
-      if (match[3] !== '') {
+      if (match[3]) {
         options.sentinelPassword = match[3];
       }
-      if (match[4] !== '') {
+      if (match[4]) {
         options.password = match[4];
       }
 
@@ -234,7 +234,7 @@ class ArkimeUtil {
       }
 
       const options = { db: parseInt(match[5]) };
-      if (match[3] !== '') {
+      if (match[3]) {
         options.password = match[3];
       }
 
@@ -290,8 +290,8 @@ class ArkimeUtil {
   // ----------------------------------------------------------------------------
   /**
    * Create a memcached client from the provided url
-   * @params {string} url - The memcached url to connect to.
-   * @params {string} section - The section this memcached client is being created for
+   * @param {string} url - The memcached url to connect to.
+   * @param {string} section - The section this memcached client is being created for
    */
   static createMemcachedClient (url, section) {
     url = ArkimeUtil.sanitizeStr(url);
@@ -310,8 +310,8 @@ class ArkimeUtil {
   // ----------------------------------------------------------------------------
   /**
    * Create a LMDB store from the provided url
-   * @params {string} url - The LMDB url to connect to.
-   * @params {string} section - The section this LMDB client is being created for
+   * @param {string} url - The LMDB url to connect to.
+   * @param {string} section - The section this LMDB client is being created for
    */
   static createLMDBStore (url, section) {
     // eslint-disable-next-line no-shadow
@@ -512,7 +512,7 @@ class ArkimeUtil {
 
   // ----------------------------------------------------------------------------
   /**
-   * Callback when of the cert files change
+   * Callback when one of the cert files changes
    */
   static #fsWait;
   static #httpsServer;

--- a/common/auth.js
+++ b/common/auth.js
@@ -1,5 +1,5 @@
 /******************************************************************************/
-/* auth.js  -- common Auth apis
+/* auth.js  -- common Auth APIs
  *
  * Copyright Yahoo Inc.
  *
@@ -209,8 +209,8 @@ class Auth {
 
     function check (field, str) {
       if (!ArkimeUtil.isString(Auth.#authConfig[field])) {
-        console.log(`ERROR - ${str} missing from config file`);
-        process.exit();
+        console.log(`ERROR - ${str ?? field} missing from config file`);
+        process.exit(1);
       }
     }
 
@@ -312,10 +312,13 @@ class Auth {
           res.sendFile(path.join(__dirname, '../assets/Arkime_Logo_Mark_FullGradient.png'));
         });
 
+        let formHtmlTemplate;
         Auth.#authRouter.get('/auth', (req, res) => {
           // User is not authenticated, show the login form
-          let html = fs.readFileSync(path.join(__dirname, '/vueapp/formAuth.html'), 'utf-8');
-          html = html.toString().replace(/@@BASEHREF@@/g, Auth.#basePath)
+          if (!formHtmlTemplate) {
+            formHtmlTemplate = fs.readFileSync(path.join(__dirname, '/vueapp/formAuth.html'), 'utf-8');
+          }
+          const html = formHtmlTemplate.replace(/@@BASEHREF@@/g, Auth.#basePath)
             .replace(/@@MESSAGE@@/g, ArkimeConfig.get('loginMessage', ''))
             .replace(/@@OGURL@@/g, req.session.ogurl ?? Auth.#basePath);
           return res.send(html);
@@ -382,7 +385,7 @@ class Auth {
       logoutUrl = logoutUrl.replace('ARKIME_ID_TOKEN', req.session.id_token);
     }
     if (ArkimeConfig.debug > 0) {
-      console.log('Set logoutUrl to', req.user.userId, '=>', Auth.#logoutUrl);
+      console.log('Set logoutUrl to', req.user.userId, '=>', logoutUrl);
     }
     return logoutUrl;
   }
@@ -953,6 +956,9 @@ class Auth {
           }
           return res.redirect(Auth.#basePath);
         } else if (req._parsedUrl.pathname === '/auth/logout/callback') {
+          if (ArkimeConfig.debug > 0) {
+            console.log('AUTH - logout callback from', req.user?.userId, req.ip);
+          }
         }
         return next();
       }
@@ -1255,7 +1261,7 @@ class ESStore extends expressSession.Store {
       });
     } catch (err) {
       // If already exists ignore error
-      if (err.meta.body?.error?.type !== 'resource_already_exists_exception') {
+      if (err.meta?.body?.error?.type !== 'resource_already_exists_exception') {
         console.log(err);
         process.exit(1);
       }

--- a/common/locales.js
+++ b/common/locales.js
@@ -6,12 +6,18 @@ SPDX-License-Identifier: Apache-2.0
 const fs = require('fs');
 const path = require('path');
 
+let cachedLocales = null;
+
 /**
  * Handler for loading and serving locale files
  * @param {Object} req - Express request object
  * @param {Object} res - Express response object
  */
 function getLocales(req, res) {
+  if (cachedLocales !== null) {
+    return res.json(cachedLocales);
+  }
+
   const localesPath = path.join(__dirname, 'vueapp/locales');
 
   try {
@@ -37,7 +43,11 @@ function getLocales(req, res) {
       }
     }
 
-    res.json({ success: true, locales });
+    const result = { success: true, locales };
+    if (process.env.NODE_ENV !== 'development') {
+      cachedLocales = result;
+    }
+    res.json(result);
   } catch (error) {
     console.error('Error reading locales directory:', error);
     res.status(500).json({ success: false, error: 'Failed to read locales' });

--- a/common/notifier.js
+++ b/common/notifier.js
@@ -610,7 +610,7 @@ class NotifierLMDBImplementation {
 
   async deleteAllNotifiers () {
     for (const { key } of this.store.getRange({})) {
-      this.store.remove(key);
+      await this.store.remove(key);
     }
   }
 }

--- a/common/user.js
+++ b/common/user.js
@@ -129,7 +129,7 @@ class User {
       for (const [role, func] of Object.entries(userRoleMappings)) {
         if (!systemRolesMapping[role] && !role.startsWith('role:')) {
           console.log(`ERROR - user-role-mappings ${role} must start with role: or be a system role`);
-          process.exit();
+          process.exit(1);
         }
         try {
           User.#dynamicRolesFuncs.set(role, ArkimeUtil.safeExpression(func, 'vals'));
@@ -258,7 +258,7 @@ class User {
 
   static async #makeRegressionUser (userId) {
     if (!Auth.regressionTests) {
-      process.exit();
+      process.exit(1);
     }
 
     // Skip Auto Create - SAC users. This means when in regression mode we don't
@@ -304,7 +304,7 @@ class User {
       let user;
       if (err || !data) {
         if (Auth.regressionTests) {
-          user = await User.#makeRegressionUser(userId, cb);
+          user = await User.#makeRegressionUser(userId);
           if (!user) {
             console.log(`Not making regression user ${userId}`);
             return cb(undefined, undefined);
@@ -394,8 +394,7 @@ class User {
 
     try {
       const users = await User.searchUsers({});
-      let usersList = [];
-      usersList = users.users.map((user) => {
+      const usersList = users.users.map((user) => {
         return user.userId;
       });
 
@@ -657,12 +656,9 @@ class User {
           if (value === undefined) {
             value = '';
           } else if (Array.isArray(value)) {
-            value = '"' + value.join(', ') + '"';
-          } else if (typeof (value) === 'string' && value.includes(',')) {
-            if (value.includes('"')) {
-              value = value.replace(/"/g, '""');
-            }
-            value = '"' + value + '"';
+            value = '"' + value.join(', ').replace(/"/g, '""') + '"';
+          } else if (typeof (value) === 'string' && (value.includes(',') || value.includes('"') || value.includes('\n') || value.includes('\r'))) {
+            value = '"' + value.replace(/"/g, '""') + '"';
           }
           values.push(value);
         }
@@ -1918,8 +1914,8 @@ class UserESImplementation {
   }
 
   async flush (cluster) {
-    this.client.indices.flush({ index: this.prefix + 'users', cluster });
-    this.client.indices.refresh({ index: this.prefix + 'users', cluster });
+    await this.client.indices.flush({ index: this.prefix + 'users', cluster });
+    await this.client.indices.refresh({ index: this.prefix + 'users', cluster });
   }
 
   // search against user index, promise only
@@ -2008,7 +2004,7 @@ class UserESImplementation {
       id: userId,
       refresh: true
     });
-    User.deleteCache(userId); // Delete again after db says its done refreshing
+    User.deleteCache(userId); // Delete again after db says it's done refreshing
   }
 
   // Set user, callback only
@@ -2023,7 +2019,7 @@ class UserESImplementation {
       timeout: '10m',
       op_type: createOnly ? 'create' : 'index'
     }, (err) => {
-      User.deleteCache(userId); // Delete again after db says its done refreshing
+      User.deleteCache(userId); // Delete again after db says it's done refreshing
       cb(err);
     });
   }
@@ -2096,7 +2092,6 @@ class UserLMDBImplementation {
   async searchUsers (query) {
     let hits = [];
     this.store.getRange({})
-      .filter(({ key, value }) => key !== '_moloch_shared')
       .forEach(({ key, value }) => {
         value = cleanSearchUser(value);
         value.id = key;
@@ -2124,25 +2119,13 @@ class UserLMDBImplementation {
   }
 
   async numberOfUsers () {
-    return await new Promise((resolve, reject) => {
-      try {
-        let count = 0;
-        for (const key of this.store.getKeys({})) {
-          if (key !== '_moloch_shared') {
-            count++;
-          }
-        }
-        resolve(count);
-      } catch (err) {
-        reject(err);
-      }
-    });
+    return this.store.getCount({});
   }
 
   // Delete user, promise only
   async deleteUser (userId) {
     await this.store.remove(userId);
-    User.deleteCache(userId); // Delete again after db says its done refreshing
+    User.deleteCache(userId); // Delete again after db says it's done refreshing
   }
 
   // Set user, callback only
@@ -2256,7 +2239,7 @@ class UserRedisImplementation {
   // Delete user, promise only
   async deleteUser (userId) {
     await this.client.del(this.prefix + userId);
-    User.deleteCache(userId); // Delete again after db says its done refreshing
+    User.deleteCache(userId); // Delete again after db says it's done refreshing
   }
 
   // Set user, callback only


### PR DESCRIPTION
auth.js:
- Add str fallback and exit(1) in check()
- Fix incomplete optional chain on err.meta?.body
- Cache form HTML template on first use instead of reading every request
- Fix logoutUrl debug log showing template URL
- Add debug log for logout callback
- Fix 'apis' spelling to 'APIs'

user.js:
- Add exit code 1 to process.exit() calls
- Fix CSV quoting per RFC 4180 (handle quotes and newlines)
- Remove dead cb arg from #makeRegressionUser
- Add await to flush() ES operations
- Remove LMDB _moloch_shared exclusions
- Fix 'its done' spelling to "it's done"
- Change unnecessary let to const
- Use store.getCount({}) for LMDB numberOfUsers

arkimeUtil.js:
- Fix redis sentinel/cluster password check using truthiness instead of !== ''
- Fix comment spelling: 'when of the cert' to 'when one of the cert'
- Fix JSDoc @params to @param (6 occurrences)

arkimeConfig.js:
- Add exit code 1 to process.exit() calls
- Fix redis-sentinel error message missing /key
- Fix getSection() JSDoc copy-paste error

arkimeCache.js:
- Add TTL to LRU cache so cacheTimeout is honored
- Add LRU local tier to LMDB cache (was allocated but unused)

locales.js:
- Cache locale data outside development mode

notifier.js:
- Add missing await on LMDB deleteAllNotifiers remove()

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
