### PR TITLE
Exclude silent clusters from ES Issues count, add hide issues query param

### DIFF
--- a/parliament/vueapp/src/components/Navbar.vue
+++ b/parliament/vueapp/src/components/Navbar.vue
@@ -209,7 +209,7 @@ export default {
         if (group.clusters) {
           for (const cluster of group.clusters) {
             const clusterStats = this.stats[cluster.id];
-            if (clusterStats && (clusterStats.status === 'yellow' || clusterStats.status === 'red' || clusterStats.healthError)) {
+            if (clusterStats && cluster.type !== 'noAlerts' && (clusterStats.status === 'yellow' || clusterStats.status === 'red' || clusterStats.healthError)) {
               clusters.push({ groupId: group.id, clusterId: cluster.id, cluster });
             }
           }

--- a/parliament/vueapp/src/components/Parliament.vue
+++ b/parliament/vueapp/src/components/Parliament.vue
@@ -857,7 +857,7 @@ export default {
       // create/edit/rearrange groups/clusters (or not)
       editMode: false,
       // hide all issues toggle
-      hideAllIssues: false,
+      hideAllIssues: this.$route.query.hideIssues === 'true',
       // highlighted cluster for ES status navigation
       highlightedClusterId: null
     };
@@ -1008,6 +1008,12 @@ export default {
     },
     toggleHideAllIssues () {
       this.hideAllIssues = !this.hideAllIssues;
+      this.$router.replace({
+        query: {
+          ...this.$route.query,
+          hideIssues: this.hideAllIssues ? 'true' : undefined
+        }
+      });
     },
     scrollToCluster (clusterId) {
       // Find the cluster element and scroll to it


### PR DESCRIPTION
- Exclude clusters with type 'noAlerts' from the navbar ES Issues button count
- Add ?hideIssues=true URL query param to suppress issue indicators on the main page

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
