### PR TITLE
fix bugs found in viewer/common/parliament/cont3xt scan

### DIFF
--- a/common/notifier.notifme.js
+++ b/common/notifier.notifme.js
@@ -122,7 +122,8 @@ exports.sendSlackAlert = function (config, message, links, cb) {
   }
 
   SlackNotifier.send(slackMsgObj)
-    .then((response) => { if (cb) { cb(response); } });
+    .then((response) => { if (cb) { cb(response); } })
+    .catch((err) => { if (cb) { cb({ errors: { slack: err.message || String(err) } }); } });
 };
 
 // Twilio
@@ -157,7 +158,9 @@ exports.sendTwilioAlert = function (config, message, links, cb) {
       to: config.toNumber,
       text: message
     }
-  }).then((response) => { if (cb) { cb(response); } });
+  })
+    .then((response) => { if (cb) { cb(response); } })
+    .catch((err) => { if (cb) { cb({ errors: { twilio: err.message || String(err) } }); } });
 };
 
 // Email
@@ -202,5 +205,7 @@ exports.sendEmailAlert = function (config, message, links, cb) {
       from: config.from,
       subject: config.subject || 'Parliament Alert'
     }
-  }).then((response) => { if (cb) { cb(response); } });
+  })
+    .then((response) => { if (cb) { cb(response); } })
+    .catch((err) => { if (cb) { cb({ errors: { email: err.message || String(err) } }); } });
 };

--- a/cont3xt/audit.js
+++ b/cont3xt/audit.js
@@ -73,7 +73,7 @@ class Audit {
       const msg = Audit.verifyAudit(audit);
 
       if (msg) {
-        reject(msg);
+        return reject(msg);
       }
 
       Db.putAudit(null, audit).then((results) => {

--- a/cont3xt/overview.js
+++ b/cont3xt/overview.js
@@ -78,7 +78,10 @@ class Overview {
   }
 
   // Verify the given overview, returns error { msg: string } on failure, { custom } otherwise
-  static verifyOverviewCustomField (custom) {
+  static verifyOverviewCustomField (custom, depth = 0) {
+    if (depth > 20) {
+      return { msg: 'Custom field nested too deep' };
+    }
     // non-empty strings are always valid (they're applied as both label and field)
     if (ArkimeUtil.isString(custom)) { return { custom }; }
 
@@ -142,7 +145,7 @@ class Overview {
 
     if (custom.fields != null) {
       for (let i = 0; i < custom.fields.length; i++) {
-        const { custom: customSubField, msg } = this.verifyOverviewCustomField(custom.fields[i]);
+        const { custom: customSubField, msg } = this.verifyOverviewCustomField(custom.fields[i], depth + 1);
         if (msg) { return { msg }; }
 
         custom.fields[i] = customSubField;

--- a/tests/cont3xt.t
+++ b/tests/cont3xt.t
@@ -1,5 +1,5 @@
 # Test cont3xt.js
-use Test::More tests => 217;
+use Test::More tests => 218;
 use Test::Differences;
 use Data::Dumper;
 use ArkimeTest;
@@ -599,6 +599,25 @@ $json = cont3xtPutToken("/api/overview", to_json({
     }]
 }), $token);
 eq_or_diff($json, from_json('{"success": false, "text": "editRoles must be an array of strings"}'));
+
+# deeply nested custom field should be rejected to prevent stack overflow DoS
+my $deep = { field => "leaf", type => "string" };
+for (my $i = 0; $i < 100; $i++) {
+  $deep = { type => "table", fields => [$deep] };
+}
+$json = cont3xtPutToken("/api/overview", to_json({
+    name => "DeepOverview",
+    title => "Deep",
+    iType => "domain",
+    viewRoles => ["cont3xtUser"],
+    editRoles => ["superAdmin"],
+    fields => [{
+        type => "custom",
+        from => "Foo",
+        custom => $deep
+    }]
+}), $token);
+eq_or_diff($json, from_json('{"success": false, "text": "Custom field nested too deep"}'));
 
 # update overview requires token
 $json = cont3xtPut('/api/overview', to_json({

--- a/viewer/addUser.js
+++ b/viewer/addUser.js
@@ -187,6 +187,9 @@ function mainWithPassword (password) {
     case '--timeLimit':
       if (i + 1 >= process.argv.length) { help('Missing value for --timeLimit'); }
       nuser.timeLimit = parseInt(process.argv[i + 1], 10);
+      if (!Number.isFinite(nuser.timeLimit) || nuser.timeLimit < 0) {
+        help(`--timeLimit must be a non-negative integer, got '${process.argv[i + 1]}'`);
+      }
       i++;
       break;
 

--- a/viewer/apiCrons.js
+++ b/viewer/apiCrons.js
@@ -744,6 +744,7 @@ class CronAPIs {
             (!cq.lastNotified || (Math.floor(Date.now() / 1000) - cq.lastNotified >= 600))) {
             const newMatchCount = cq.lastNotifiedCount ? (doc.doc.count - cq.lastNotifiedCount) : doc.doc.count;
             doc.doc.lastNotifiedCount = doc.doc.count;
+            doc.doc.lastNotified = Math.floor(Date.now() / 1000);
 
             let urlPath = 'sessions?expression=';
             const tags = cq.tags.split(',');
@@ -768,6 +769,18 @@ ${Config.arkimeWebURL()}${urlPath}${cq.description ? '\n' + cq.description : ''}
               for (const notifierId of notifiers) {
                 Notifier.issueAlert(notifierId, message, () => {});
               }
+            }
+
+            // persist the notification state so the 10-minute throttle works
+            try {
+              await Db.update('queries', qid, {
+                doc: {
+                  lastNotified: doc.doc.lastNotified,
+                  lastNotifiedCount: doc.doc.lastNotifiedCount
+                }
+              }, { refresh: true });
+            } catch (err) {
+              console.log('ERROR CRON - updating lastNotified', err);
             }
           }
         }

--- a/viewer/apiHunts.js
+++ b/viewer/apiHunts.js
@@ -1373,19 +1373,24 @@ ${Config.arkimeWebURL()}sessions?expression=huntId==${huntId}&stopTime=${hunt.qu
       const options = HuntAPIs.#buildHuntOptions(huntId, hunt);
 
       HuntAPIs.#sessionHunt(sessionId, options, async (err, matched) => {
-        if (Config.debug > 1) {
-          console.log('HUNT - result', huntId, sessionId, err, matched);
-        }
-        if (err) {
-          if (!res.headersSent) { res.send({ matched: false, error: err }); }
-          return;
-        }
+        try {
+          if (Config.debug > 1) {
+            console.log('HUNT - result', huntId, sessionId, err, matched);
+          }
+          if (err) {
+            if (!res.headersSent) { res.send({ matched: false, error: err }); }
+            return;
+          }
 
-        if (matched) {
-          await HuntAPIs.#updateSessionWithHunt(session, sessionId, hunt, huntId);
-        }
+          if (matched) {
+            await HuntAPIs.#updateSessionWithHunt(session, sessionId, hunt, huntId);
+          }
 
-        if (!res.headersSent) { res.send({ matched }); }
+          if (!res.headersSent) { res.send({ matched }); }
+        } catch (cbErr) {
+          console.log(`ERROR - remoteHunt callback %s/%s`, ArkimeUtil.sanitizeStr(huntId), ArkimeUtil.sanitizeStr(sessionId), util.inspect(cbErr, false, 50));
+          if (!res.headersSent) { res.send({ matched: false, error: cbErr.message || 'callback error' }); }
+        }
       });
     }).catch((err) => {
       console.log(`ERROR - ${req.method} /api/hunt/%s/%s/remote/%s`, ArkimeUtil.sanitizeStr(req.params.nodeName), ArkimeUtil.sanitizeStr(req.params.huntId), ArkimeUtil.sanitizeStr(req.params.sessionId), util.inspect(err, false, 50));

--- a/viewer/apiSessions.js
+++ b/viewer/apiSessions.js
@@ -337,8 +337,8 @@ class SessionAPIs {
         res.send(data);
       });
     } else { // return SPI data and packets
-      res.send('HOW DID I GET HERE?');
-      console.trace('HOW DID I GET HERE');
+      console.trace('Unexpected code path in localSessionDetail');
+      return res.serverError(500, 'Internal error: unexpected code path');
     }
   }
 
@@ -1886,6 +1886,9 @@ class SessionAPIs {
         });
         sessions.aggregations.fileand = { doc_count_error_upper_bound: 0, sum_other_doc_count: sodc, buckets: nresults };
         return sendResult();
+      }).catch((err) => {
+        console.log(`ERROR - ${req.method} /api/spiview`, util.inspect(err, false, 50));
+        return res.serverError(500, 'Error retrieving spiview data');
       });
     });
   }

--- a/viewer/apiShortcuts.js
+++ b/viewer/apiShortcuts.js
@@ -481,7 +481,9 @@ class ShortcutAPIs {
    * @returns {boolean} success - Always true.
    */
   static syncShortcuts (req, res) {
-    Db.updateLocalShortcuts();
+    Db.updateLocalShortcuts().catch((err) => {
+      console.log(`ERROR - ${req.method} /api/syncshortcuts`, util.inspect(err, false, 50));
+    });
     return res.json({ success: true });
   }
 }

--- a/viewer/apiStats.js
+++ b/viewer/apiStats.js
@@ -635,11 +635,9 @@ class StatsAPIs {
    * @returns {boolean} success - Always true, the optimizeIndex function might block. Check the logs for errors.
    */
   static optimizeESIndex (req, res) {
-    try {
-      Db.optimizeIndex([req.params.index], { cluster: req.query.cluster });
-    } catch (err) {
+    Db.optimizeIndex([req.params.index], { cluster: req.query.cluster }).catch((err) => {
       console.log(`ERROR - ${req.method} /api/esindices/%s/optimize`, ArkimeUtil.sanitizeStr(req.params.index), util.inspect(err, false, 50));
-    }
+    });
 
     // always return successfully right away, optimizeIndex might block
     return res.json({ success: true });
@@ -682,11 +680,9 @@ class StatsAPIs {
       return res.serverError(401, 'Not supported in multies', 'api.stats.notSupportedInMulties');
     }
 
-    try {
-      Db.openIndex([req.params.index], { cluster: req.query.cluster });
-    } catch (err) {
+    Db.openIndex([req.params.index], { cluster: req.query.cluster }).catch((err) => {
       console.log(`ERROR - ${req.method} /api/esindices/%s/open`, ArkimeUtil.sanitizeStr(req.params.index), util.inspect(err, false, 50));
-    }
+    });
 
     // always return successfully right away, openIndex might block
     return res.json({ success: true });
@@ -739,7 +735,7 @@ class StatsAPIs {
         cluster: req.query.cluster
       };
 
-      // wait for no more reloacting shards
+      // wait for no more relocating shards
       const shrinkCheckInterval = setInterval(() => {
         Db.healthCache(req.query.cluster).then(async (result) => {
           if (result.relocating_shards === 0) {
@@ -756,6 +752,8 @@ class StatsAPIs {
               console.log(`ERROR - ${req.method} /api/esindices/%s/shrink`, ArkimeUtil.sanitizeStr(req.params.index), util.inspect(err, false, 50));
             }
           }
+        }).catch((err) => {
+          console.log(`ERROR - ${req.method} /api/esindices/%s/shrink healthCache`, ArkimeUtil.sanitizeStr(req.params.index), util.inspect(err, false, 50));
         });
       }, 10000);
 
@@ -1131,7 +1129,8 @@ class StatsAPIs {
     }
 
     if (req.body.key.startsWith('arkime.ilm')) {
-      Promise.all([Db.getILMPolicy(req.query.cluster)]).then(([ilm]) => {
+      try {
+        const [ilm] = await Promise.all([Db.getILMPolicy(req.query.cluster)]);
         const silm = ilm[`${prefix}molochsessions`];
         const hilm = ilm[`${prefix}molochhistory`];
 
@@ -1159,17 +1158,20 @@ class StatsAPIs {
           return res.serverError(500, 'Unknown field', 'api.stats.unknownField');
         }
         if (req.body.key.startsWith('arkime.ilm.history')) {
-          Db.setILMPolicy(`${prefix}molochhistory`, hilm, req.query.cluster);
+          await Db.setILMPolicy(`${prefix}molochhistory`, hilm, req.query.cluster);
         } else {
-          Db.setILMPolicy(`${prefix}molochsessions`, silm, req.query.cluster);
+          await Db.setILMPolicy(`${prefix}molochsessions`, silm, req.query.cluster);
         }
         return res.json({ success: true, text: 'Set', i18n: 'api.stats.set' });
-      });
-      return;
+      } catch (err) {
+        console.log(`ERROR - ${req.method} /api/esadmin/set (ilm)`, util.inspect(err, false, 50));
+        return res.serverError(500, 'Set failed', 'api.stats.setFailed');
+      }
     }
 
     if (req.body.key.startsWith('arkime.sessions')) {
-      Promise.all([Db.getTemplate('sessions3_template', req.query.cluster)]).then(([{ body: template }]) => {
+      try {
+        const [{ body: template }] = await Promise.all([Db.getTemplate('sessions3_template', req.query.cluster)]);
         switch (req.body.key) {
         case 'arkime.sessions.shards':
           template[`${prefix}sessions3_template`].settings['index.number_of_shards'] = req.body.value;
@@ -1187,10 +1189,12 @@ class StatsAPIs {
         default:
           return res.serverError(500, 'Unknown field', 'api.stats.unknownField');
         }
-        Db.putTemplate('sessions3_template', template[`${prefix}sessions3_template`], req.query.cluster);
+        await Db.putTemplate('sessions3_template', template[`${prefix}sessions3_template`], req.query.cluster);
         return res.json({ success: true, text: 'Successfully set settings', i18n: 'api.stats.settingsSet' });
-      });
-      return;
+      } catch (err) {
+        console.log(`ERROR - ${req.method} /api/esadmin/set (sessions)`, util.inspect(err, false, 50));
+        return res.serverError(500, 'Set failed', 'api.stats.setFailed');
+      }
     }
 
     const clusterQuery = { body: { persistent: {} }, cluster: req.query.cluster };
@@ -1237,8 +1241,12 @@ class StatsAPIs {
    * @returns {string} text - The success message to (optionally) display to the user.
    */
   static flushES (req, res) {
-    Db.refresh('*', req.query.cluster);
-    Db.flush('*', req.query.cluster);
+    Db.refresh('*', req.query.cluster).catch((err) => {
+      console.log(`ERROR - ${req.method} /api/esadmin/flush (refresh)`, util.inspect(err, false, 50));
+    });
+    Db.flush('*', req.query.cluster).catch((err) => {
+      console.log(`ERROR - ${req.method} /api/esadmin/flush (flush)`, util.inspect(err, false, 50));
+    });
     return res.json({ success: true, text: 'Flushed', i18n: 'api.stats.flushed' });
   }
 
@@ -1255,6 +1263,8 @@ class StatsAPIs {
     Db.setIndexSettings('*', {
       body: { 'index.blocks.read_only_allow_delete': null },
       cluster: req.query.cluster
+    }).catch((err) => {
+      console.log(`ERROR - ${req.method} /api/esadmin/unflood`, util.inspect(err, false, 50));
     });
     return res.json({ success: true, text: 'Unflooded', i18n: 'api.stats.unflooded' });
   }

--- a/viewer/db.js
+++ b/viewer/db.js
@@ -868,6 +868,7 @@ Db.searchSessionsIterator = async function* (index, query, options) {
       if (hit.fields?.packetPos !== undefined) {
         await fixPacketPos(hit.fields);
       }
+      await fixFileIds(hit.fields);
     }
     yield chunk;
   }

--- a/viewer/decode.js
+++ b/viewer/decode.js
@@ -612,7 +612,7 @@ class ItemHTTPStream extends ItemTransform {
       if (this.contentLength[item.client] === 0) {
         this.msgEnd(item);
       } else {
-        this.states[item.client] = ItemHTTPStream.STATES.res_body;
+        this.states[item.client] = ItemHTTPStream.STATES.req_body;
       }
       break;
 

--- a/viewer/decryptPcap.js
+++ b/viewer/decryptPcap.js
@@ -22,19 +22,19 @@ async function main () {
     const data = await Db.search('files', query);
     if (data.hits.hits.length === 0) {
       console.error('No matches');
-      process.exit();
+      process.exit(1);
     }
     const info = data.hits.hits[0]._source;
     if (!info.encoding || info.encoding === 'normal') {
       console.error('Not encrypted');
-      process.exit();
+      process.exit(1);
     }
 
     // Get the kek
     const kek = Config.sectionGet('keks', info.kekId, undefined);
     if (kek === undefined) {
       console.error("ERROR - Couldn't find kek", info.kekId, 'in keks section');
-      process.exit();
+      process.exit(1);
     }
 
     // Decrypt the dek
@@ -75,16 +75,17 @@ async function main () {
       });
     } else {
       console.log('Unknown encoding', info.encoding);
+      process.exit(1);
     }
   } catch (err) {
     console.error('ES Error', err);
-    process.exit();
+    process.exit(1);
   }
 }
 
 if (process.argv.length < 3) {
   console.log('Missing full path filename');
-  process.exit();
+  process.exit(1);
 }
 
 async function premain () {

--- a/viewer/multies.js
+++ b/viewer/multies.js
@@ -167,6 +167,12 @@ function getActiveNodes (clusterin) {
 
 function makeRequest (url, options, cb) {
   let result = '';
+  let called = false;
+  const done = (err, res) => {
+    if (called) { return; }
+    called = true;
+    if (cb) { cb(err, res); }
+  };
 
   const preq = options.arkime_client.request(url, options, (pres) => {
     pres.on('data', (chunk) => {
@@ -182,14 +188,16 @@ function makeRequest (url, options, cb) {
           result = JSON.parse(result);
         } catch (e) {
           console.log('ERROR - could not parse response from ES', e);
-          if (cb) { return cb(e, {}); }
+          return done(e, {});
         }
       } else {
         result = {};
       }
-      if (cb) {
-        cb(null, result);
-      }
+      done(null, result);
+    });
+    pres.on('error', (e) => {
+      console.log('Response error', e);
+      done(e, {});
     });
   });
   preq.setHeader('content-type', 'application/json');
@@ -204,6 +212,7 @@ function makeRequest (url, options, cb) {
   }
   preq.on('error', (e) => {
     console.log('Request error', e);
+    done(e, {});
   });
   preq.end();
 }
@@ -843,7 +852,7 @@ function fixQuery (node, body, doneCb) {
 
   let outstanding = 0;
   let finished = 0;
-  const err = null;
+  let outerErr = null;
 
   function convert (qParent, obj) {
     for (const item in obj) {
@@ -875,10 +884,10 @@ function fixQuery (node, body, doneCb) {
           obj.bool.should.push({ bool: { filter: [{ term: { node: file._source.node } }, { term: { fileId: file._source.num } }] } });
         }
         if (obj.bool.should.length === 0) {
-          err = 'No matching files found';
+          outerErr = 'No matching files found';
         }
         if (finished && outstanding === 0) {
-          doneCb(err, body);
+          doneCb(outerErr, body);
         }
       });
     } else if (typeof obj[item] === 'object') {
@@ -888,7 +897,7 @@ function fixQuery (node, body, doneCb) {
 
   convert(null, body);
   if (outstanding === 0) {
-    return doneCb(err, body);
+    return doneCb(outerErr, body);
   }
 
   finished = 1;

--- a/viewer/pcap.js
+++ b/viewer/pcap.js
@@ -627,13 +627,17 @@ class Pcap {
         next = data[offset];
         offset++;
       }
-      while (next !== 0) {
+      while (next !== 0 && offset < data.length) {
         const extlen = data[offset];
         offset++;
+        if (extlen === 0) { break; }
         offset += extlen * 4 - 2;
+        if (offset < 0 || offset >= data.length) { break; }
         next = data[offset];
         offset++;
       }
+
+      if (offset >= data.length) { return; }
 
       if ((data[offset] & 0xf0) === 0x60) {
         this.ip6(data.slice(offset), obj, pos + offset);
@@ -691,10 +695,12 @@ class Pcap {
     if (obj.gre.flags_version & 0x4000) {
       while (true) {
         bpos += 3;
+        if (bpos + 2 > buffer.length) { break; }
         const len = buffer.readUInt16BE(bpos);
         bpos++;
         if (len === 0) { break; }
         bpos += len;
+        if (bpos > buffer.length) { break; }
       }
     }
 
@@ -988,7 +994,9 @@ class Pcap {
           return this.ip6(buffer.slice(offset + 4), obj, pos + offset + 4);
         }
       } else {
-        offset += (len + 3) & 0xfffc;
+        const advance = (len + 3) & 0xfffc;
+        if (advance === 0) { break; }
+        offset += advance;
       }
     }
 

--- a/viewer/schemes.js
+++ b/viewer/schemes.js
@@ -22,7 +22,7 @@ const httpAgent = new http.Agent({ family: 4 });
 // --------------------------------------------------------------------------
 async function getBlockHTTP (info, pos) {
   async function getBlockHttpInternal () {
-    const result = await axios.get(info.name, { responseType: 'arraybuffer', httpAgent, headers: { range: `bytes=${blockStart}-${blockStart + blockSize}` } });
+    const result = await axios.get(info.name, { responseType: 'arraybuffer', httpAgent, headers: { range: `bytes=${blockStart}-${blockStart + blockSize - 1}` } });
     return result.data;
   }
 
@@ -34,6 +34,7 @@ async function getBlockHTTP (info, pos) {
   if (!block) {
     block = getBlockHttpInternal();
     blocklru.set(key, block);
+    block.catch(() => { blocklru.delete(key); });
   }
   block = await block;
   return block.slice(pos - blockStart);
@@ -108,11 +109,12 @@ async function getBlockS3 (info, pos) {
     const params = {
       Bucket: parts[2],
       Key: parts[3],
-      Range: `bytes=${blockStart}-${blockStart + blockSize}`
+      Range: `bytes=${blockStart}-${blockStart + blockSize - 1}`
     };
 
     block = getBlockS3Internal(info, params);
     blocklru.set(key, block);
+    block.catch(() => { blocklru.delete(key); });
   }
 
   block = await block;
@@ -129,18 +131,15 @@ async function getBlockS3HTTP (info, pos) {
   const key = `${info.name}:${blockStart}`;
   let block = blocklru.get(key);
   if (!block) {
-    try {
-      const params = {
-        Bucket: info.extra.bucket,
-        Key: info.extra.path.replace(/^\//, ''),
-        Range: `bytes=${blockStart}-${blockStart + blockSize}`
-      };
+    const params = {
+      Bucket: info.extra.bucket,
+      Key: info.extra.path.replace(/^\//, ''),
+      Range: `bytes=${blockStart}-${blockStart + blockSize - 1}`
+    };
 
-      block = getBlockS3Internal(info, params);
-      blocklru.set(key, block);
-    } catch (err) {
-      console.error(err);
-    }
+    block = getBlockS3Internal(info, params);
+    blocklru.set(key, block);
+    block.catch(() => { blocklru.delete(key); });
   }
 
   // Return a new buffer starting at pos


### PR DESCRIPTION
- viewer, common: various fixes from bug scan
- cont3xt/audit.js: add missing return before reject() to prevent double-settling the Promise (Db.putAudit still ran after reject)
- cont3xt/overview.js: cap verifyOverviewCustomField recursion depth at 20 to prevent stack-overflow DoS from deeply nested fields
- tests/cont3xt.t: add regression test for deep custom-field nesting

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
